### PR TITLE
docs: spec the accepts/placement feature and schedule it across M2-M4

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -79,6 +79,7 @@ progest-core のモジュール:
 - `core::meta` — .meta I/O、原子書込、pending queue
 - `core::identity` — UUID 発行、fingerprint、複製検出
 - `core::rules` — 規則 DSL パーサ、評価、違反検出、継承解決
+- `core::accepts` — `.dirmeta.toml` の `[accepts]` パース、エイリアス解決、effective 計算、placement 違反検出、インポート先ランキング
 - `core::index` — SQLite+FTS5 schema、upsert、query
 - `core::search` — DSL パーサ、クエリプラン、実行
 - `core::watch` — notify ラッパー、三段構え制御
@@ -87,6 +88,7 @@ progest-core のモジュール:
 - `core::template` — テンプレート入出力
 - `core::ai` — BYOK クライアント、keychain 連携
 - `core::rename` — preview、apply、undo history
+- `core::import` — インポート実体（copy/move）、原子トランザクション、accepts と rename preview の一体適用
 - `core::doctor` — 整合性診断
 
 ---
@@ -148,9 +150,17 @@ project-root/
 ├── .gitignore               # init 時自動生成 / 追記
 ├── .gitattributes           # init 時自動生成 / 追記
 └── assets/
-    ├── .dirmeta.toml        # ディレクトリ自体のメタ
+    ├── .dirmeta.toml        # ディレクトリ自体のメタ + [accepts] セクション
     ├── foo.psd
     └── foo.psd.meta
+```
+
+`.dirmeta.toml` の `[accepts]` 抜粋:
+```toml
+[accepts]
+inherit = false             # true で親の accepts を union
+exts = [".psd", ".tif", ":image"]
+mode = "warn"               # strict | warn (default) | hint | off
 ```
 
 SQLite schema（主要テーブル）:
@@ -200,12 +210,15 @@ CREATE VIRTUAL TABLE fts_files USING fts5(
 CREATE TABLE violations (
   file_id TEXT NOT NULL,
   rule_id TEXT NOT NULL,
+  category TEXT NOT NULL,     -- naming | placement
   reason TEXT,
   severity TEXT,
-  suggested_names TEXT,       -- JSON
+  suggested_names TEXT,       -- JSON (naming)
+  suggested_destinations TEXT,-- JSON (placement)
   detected_at TEXT,
   PRIMARY KEY (file_id, rule_id)
 );
+CREATE INDEX idx_violations_category ON violations(category);
 
 CREATE TABLE history (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -254,43 +267,51 @@ CREATE INDEX idx_history_applied_at ON history(applied_at);
 
 完了条件: `progest init && progest scan` で 1万ファイル程度の fixture が 5秒以内にインデックス化、孤児 .meta を doctor が検出。
 
-### M2 — 命名規則エンジン（1ヶ月）
-**目的**: ルールで lint と rename ができる。
+### M2 — 命名規則エンジン + 配置規則（1ヶ月）
+**目的**: ルールで lint と rename ができる。配置違反（placement）も同じ lint パイプラインで扱える。
 
 - `core::rules` — DSL パーサ、2層規則、継承解決、勝利 rule_id トレース
 - テンプレート構文（`{prefix}_{seq:03d}` 等）
 - 制約規則（charset、casing、forbidden_chars 等）
 - 違反検出、修正提案生成
-- `core::history` — 操作ログ（rename / tag / meta_edit）、inverse 生成、undo/redo
+- `core::accepts` — `.dirmeta.toml` の `[accepts]` パース、`schema.toml` のエイリアス解決、effective 計算（opt-in 継承）、placement 違反検出、インポート先ランキング算出
+- 組み込みエイリアス（`:image`, `:video`, `:audio`, `:raw`, `:3d`, `:project`, `:text`）の構成拡張子を確定し `docs/` に記載
+- `core::history` — 操作ログ（rename / tag / meta_edit / import）、inverse 生成、undo/redo
 - `core::rename` — preview、apply（原子トランザクション）、history 連携
-- CLI: `lint`, `rename --preview|--apply`, `undo`, `redo`
-- ゴールデンテスト（規則評価結果を YAML に固定）
+- CLI: `lint`（placement カテゴリ統合）, `rename --preview|--apply`, `undo`, `redo`
+- ゴールデンテスト（naming / placement 評価結果を YAML に固定）
 
-完了条件: fixture プロジェクトに対して lint が期待通り違反検出、rename preview と apply が動く、undo で戻せる。
+完了条件: fixture プロジェクトに対して lint が naming / placement 両方の違反を期待通り検出、rename preview と apply が動く、undo で戻せる。
 
 ### M3 — 検索とビュー（1ヶ月）
-**目的**: クエリ駆動でファイルを操作できる UI。
+**目的**: クエリ駆動でファイルを操作できる UI。配置違反の可視化とディレクトリ単位の accepts 編集 UI も同時に提供する。
 
 - `core::search` — DSL パーサ（key:value + 自由テキスト + ブール）、クエリプラン
 - FTS5 + trigram の設定、日本語検索の基本動作
 - コマンドパレット UI（shadcn Command + Dialog）
 - ツリービュー、フラットビュー、保存済みビュー
+- ディレクトリインスペクターパネル（accepts 編集フォーム: chip input + inherit チェックボックス + mode セレクタ）
+- flat view / ツリー上の placement 違反バッジ（naming とは別色）
+- `is:misplaced` クエリサポート
 - views.toml の I/O
 - CLI: `search`, `tag add|remove|list`
 - カスタムフィールドのクエリ対応
 
-完了条件: UI で `tag:foo type:psd is:violation` 相当が 100ms 以下で返る、保存済みビューが永続化される。
+完了条件: UI で `tag:foo type:psd is:violation` / `is:misplaced` 相当が 100ms 以下で返る、保存済みビューが永続化される、ディレクトリインスペクターで accepts を編集して `.dirmeta.toml` に反映される。
 
 ### M4 — サムネ + 外部連携 + AI + テンプレート（1ヶ月）
-**目的**: 価値提案を完成させる。
+**目的**: 価値提案を完成させる。accepts を踏まえた D&D import / CLI import もここで完結する。
 
 - `core::thumbnail` — 生成キュー、LRU キャッシュ
   - 画像（image crate）→ 動画（ffmpeg 子プロセス）→ PSD（psd crate）の順で実装
-- 外部連携: D&D 受入、外部アプリで開く、D&D 出
-- `core::template` — 書出・読込、`progest init --template <path>`
+- `core::import` — インポート実体（copy / move）、原子トランザクション、accepts ランキング + rename preview の一体適用、history への単一エントリ記録
+- 外部連携: D&D 受入（flat view は accepts サジェスト、tree view は mismatch 確認ダイアログ）、外部アプリで開く、D&D 出
+- 複数ファイルの一括 import UI（一覧確認モーダル）
+- CLI: `progest import <files...> [--dest|--auto|--move|--dry-run|--format json|text]`（対話 / 非対話両対応、tty 検出）
+- `core::template` — 書出・読込、`progest init --template <path>`、テンプレートに `.dirmeta.toml`（accepts）を含める
 - `core::ai` — BYOK クライアント、keychain 連携、簡易 UI
 
-完了条件: 画像・動画・PSD のサムネが出る、D&D でファイル追加できる、テンプレートから空プロジェクトが作れる、AI 提案が動く。
+完了条件: 画像・動画・PSD のサムネが出る、D&D でファイル追加（accepts サジェストが動く）、CLI `progest import` が対話・非対話両方で動く、テンプレートから空プロジェクトが作れる（accepts 含む）、AI 提案が動く。
 
 ### M5 — 仕上げ・リリース（0.5ヶ月 + 予備1ヶ月）
 **目的**: 公開可能な品質に整える。

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -38,15 +38,16 @@ Progest は、既存のクリエイティブ案件ディレクトリに後付け
 | サイドカーメタ | `file.ext.meta`（TOML、セクション分離） |
 | ファイル ID | UUID（複製時は新規発行 + `source_file_id` 記録）、blake3 fingerprint |
 | 命名規則エンジン | テンプレートDSL + 制約DSL、継承、4モード、rule_id トレース、rename preview、一括適用、ロールバック |
+| 配置規則 (accepts) | ディレクトリごとの受入拡張子、カテゴリエイリアス、import 先サジェスト、`placement` lint |
 | 連番 | ディレクトリローカル + 名前空間指定 |
 | AI命名支援 | BYOK（OpenAI/Anthropic互換、簡易実装）、OS keychain保存 |
 | FS監視 | startup scan + OS watch + periodic reconcile（三段構え） |
 | 検索 | SQLite + FTS5 + trigram/N-gram、GitHub風 key:value DSL |
 | ビュー | ツリー、フラット、保存済みビュー（.progest/views.toml） |
 | コマンドパレット | GUI |
-| CLI | init/scan/lint/rename/tag/search/doctor/meta merge |
+| CLI | init/scan/lint/rename/tag/search/import/doctor/meta merge |
 | サムネ | 画像（image crate）、動画（ffmpeg）、PSD埋込（psd crate） |
-| 外部連携 | D&D 双方向、外部アプリで開く |
+| 外部連携 | D&D 双方向（accepts ベースのインポート先サジェスト付き）、外部アプリで開く |
 | テンプレート | 単一TOML 書出・読込（ローカルファイルのみ） |
 | i18n | UI 日英両対応（i18next / react-i18next） |
 | ライセンス | Apache License 2.0 |
@@ -108,7 +109,7 @@ project-root/
 
 配置:
 - ファイル: Unity 式隣接型。`foo.psd` の隣に `foo.psd.meta`
-- ディレクトリ: ディレクトリ直下に `.dirmeta.toml`（各ディレクトリ 1つ、スキーマは `.meta` と共通）
+- ディレクトリ: ディレクトリ直下に `.dirmeta.toml`（各ディレクトリ 1つ、`.meta` スキーマに加えて §3.13 の `[accepts]` セクションを許容）
 
 フォーマット: TOML。セクション分離で衝突頻度を下げる。
 
@@ -263,7 +264,7 @@ DSL: GitHub / Linear 風 key:value + 自由テキスト。
 予約キー:
 - `tag:<name>`, `-tag:<name>`
 - `type:<ext>` / `kind:asset|directory|derived`
-- `is:violation|orphan|duplicate`
+- `is:violation|orphan|duplicate|misplaced`
 - `name:<glob>`, `path:<glob>`
 - `scene:<int>` `shot:<int>` `status:<enum>` (カスタムフィールド)
 - `created:<iso>..<iso>`, `updated:<iso>..<iso>`
@@ -301,6 +302,7 @@ progest tag add <tag> <files...>
 progest tag remove <tag> <files...>
 progest tag list <files...>
 progest search <query> [--format json|text]
+progest import <files...> [--dest <path>] [--auto] [--move] [--dry-run] [--format json|text]
 progest export-template --include structure,rules,schema,views --out <path>
 progest meta merge <ours> <theirs> <base> --output <path>   # git merge driver
 ```
@@ -338,6 +340,9 @@ ffmpeg 配布:
 ### 3.11 外部連携（v1）
 
 - Finder/Explorer → Progest の D&D 受入（ファイル取り込み、meta 生成、規則適用）
+  - flat view に落とされた場合は §3.13 の配置規則に従ってインポート先をサジェスト
+  - tree view に落とされた場合は落下先 dir の accepts と突合し、mismatch 時は確認ダイアログ
+  - 複数ファイルは各ファイルの最上位 typed match へ自動振り分け、一覧確認モーダルで確定
 - Progest → 外部アプリ起動（OSデフォルト、拡張子別指定）
 - Progest → 外部への D&D 出（ファイルパス渡し）
 
@@ -347,11 +352,107 @@ ffmpeg 配布:
 - 書出時に含める内容を選択可（構造は必須）:
   - ディレクトリ構造（空ディレクトリ階層、必須）
   - 命名規則（rules.toml）
-  - カスタムスキーマ（schema.toml）
+  - カスタムスキーマ（schema.toml、alias 含む）
   - 保存済みビュー（views.toml）
+  - `.dirmeta.toml`（accepts を含むディレクトリメタ）
 - `progest init --template <path>` で適用
 - テンプレート内にメタデータ（id, version, author, description）記録
 - v1 はローカルパスのみ、git URL は v1.1
+
+### 3.13 配置規則（accepts）
+
+ディレクトリごとに「受け入れる拡張子」を宣言し、import 時のインポート先サジェストと既存ファイルの配置違反 lint を実現する。命名規則（§3.4）とは独立したカテゴリとして扱う。
+
+#### 3.13.1 基本モデル
+
+- 配置: `.dirmeta.toml` の `[accepts]` セクション
+- 未設定: 当該ディレクトリは全拡張子を受け入れる（制約なし）
+- 記述形式: 拡張子文字列 + カテゴリエイリアス混在可
+
+スキーマ例:
+```toml
+[accepts]
+inherit = false              # デフォルト。true で親 dir の accepts と union
+exts = [".psd", ".tif", ":image", ""]   # "" は拡張子なしファイル（README 等）
+```
+
+- 拡張子: 先頭ドット必須、大小文字非感知で比較（TOML には小文字で記録推奨）
+- 複合拡張子（`.tar.gz`, `.blend1`）は文字列末尾の最長一致で評価
+- カテゴリエイリアス: `:image` `:video` 等。定義は `.progest/schema.toml` の `[alias.<name>]` で拡張可能（後述）
+
+#### 3.13.2 継承（opt-in）
+
+命名規則と異なり、デフォルトは非継承。子で `inherit = true` を明示した時のみ、祖先の accepts を再帰的に union する。
+
+```
+effective_accepts(dir) = own_accepts(dir) ∪ (inherit ? effective_accepts(parent) : ∅)
+```
+
+祖先自身の inherit フラグは effective 計算に影響しない（あくまで子の宣言でその鎖を辿るかを決める）。
+
+#### 3.13.3 カテゴリエイリアス
+
+組み込みエイリアス（v1 で必ず提供）:
+- `:image`, `:video`, `:audio`, `:raw`, `:3d`, `:project`, `:text`
+- 正確な構成拡張子は実装時に確定し、`docs/` 配下のリファレンスに明示する
+
+プロジェクト定義エイリアスは `.progest/schema.toml` に記述:
+```toml
+[alias.studio_3d]
+exts = [".fbx", ".usd", ".usda", ".usdc", ".abc"]
+```
+
+- ネスト（alias 内で alias 参照）は v1 ではサポートしない
+- 同名のプロジェクト定義は組み込みを上書きする（診断ログに警告）
+
+#### 3.13.4 インポート先サジェスト
+
+対象ファイルの拡張子（または `""`）と各 dir の effective_accepts を突合し、候補をランキングして提示する。
+
+順位付けルール（上位優先）:
+1. 明示一致: dir 自身の own_accepts に当該拡張子が含まれる
+2. 継承一致: effective_accepts に含まれるが own_accepts には無い
+3. MRU: 最近インポート先に選ばれた dir
+4. パス深さ: 浅いほど優先
+
+UI 構成:
+- 上部: typed match（1〜4 のルールで並ぶ）
+- 折りたたみ: "Other locations"（accepts 未設定 dir、typed match ゼロ時のフォールバックも兼ねる）
+
+#### 3.13.5 発動導線
+
+| 起点 | 挙動 |
+| --- | --- |
+| flat view D&D | typed match が 1 件なら自動配置 + toast（undo 可）、複数なら一覧モーダル |
+| tree view D&D | 落下先の accepts に合致しない場合、確認ダイアログ（推奨候補を併記） |
+| CLI `progest import` | stdin が tty なら対話選択。非 tty 時は `--dest` または `--auto` 必須、どちらも無ければエラー。`--auto` は typed match 1 位を自動選択（2 件以上ある時はエラー）、`--dry-run` で移動せずプレビュー |
+| 複数ファイルの一括 D&D / `progest import <files...>` | 各ファイルを最上位 typed match に自動振り分け、一覧確認モーダルで変更可、Apply で確定 |
+
+import 操作の実体:
+- デフォルトはコピー（元ファイルを残す）
+- `--move` または D&D 時の明示モディファイアで移動に切り替え
+- 失敗時はロールバック（原子トランザクション）
+
+naming rule との連鎖:
+- 配置先 dir に naming rule がある場合、rename preview を同一ダイアログに一体化して提示
+- Apply で「配置 + 名前付け」を単一の history エントリとして記録、undo 可
+
+#### 3.13.6 lint（placement カテゴリ）
+
+accepts に違反する既存ファイルを検出する。命名違反とは別カテゴリ `placement` として扱う。
+
+- 検出対象: ファイルの直接親 dir の effective_accepts に当該拡張子が含まれないもの
+- モード: naming と同じ 4 モード（`strict` / `warn`（default）/ `hint` / `off`）を `.dirmeta.toml` の `[accepts]` 内で指定可
+- 違反レポート必須フィールド: `file_id`, `path`, `category = "placement"`, `expected_exts[]`, `winning_rule_source`（own か inherited か）, `suggested_destinations[]`（ランキング上位 N 件）
+- 検索クエリ: `is:misplaced`
+- UI: 違反バッジを naming と別色で表示
+
+#### 3.13.7 編集 UX
+
+- ツリーで dir を選択 → インスペクターパネルに `accepts` 編集フォーム
+- `exts`: chip input。`:image` 等のエイリアスはオートコンプリート
+- `inherit`: チェックボックス
+- 変更は `.dirmeta.toml` の原子書込（§3.2 と同等）で反映
 
 ---
 


### PR DESCRIPTION
## Summary

- Introduce the `accepts` feature: directory-scoped declaration of which file extensions live in that directory, stored in `.dirmeta.toml` under `[accepts]`. Powers (1) import-destination suggestions and (2) a new `placement` lint category.
- Specify the model in `docs/REQUIREMENTS.md` §3.13 (semantics, aliases, inheritance, UI, CLI, lint) and update the MVP scope table, §3.7 search DSL, §3.9 CLI, and §3.11 external integration to reference it.
- Schedule delivery across milestones in `docs/IMPLEMENTATION_PLAN.md`: parsing/evaluation/lint in M2 (`core::accepts`), inspector panel + placement badge + `is:misplaced` in M3, `progest import` + D&D suggestion + unified place+rename history in M4 (`core::import`). Update the violations table schema with a `category` column and a `suggested_destinations` payload.

## Background decisions

Agreed during grill-me:

- Field name: `accepts` (not `recommended_extensions` or `expected_extensions`).
- Unset directory = accept any extension (no constraint, no suggestion weight).
- Inheritance is opt-in (`inherit = true` unions with ancestors). Default off.
- Extension strings plus category aliases (`:image`, `:video`, ...). Aliases ship built-in and can be extended per project in `.progest/schema.toml`.
- Suggestion ranking: explicit match > inherited match > MRU > path depth.
- UI: typed matches on top, "Other locations" collapsible section for unset directories.
- flat-view D&D: single typed match auto-places with a toast; multiple opens a modal. Tree-view D&D warns on mismatch. CLI `progest import` is interactive by default with `--dest`/`--auto`/`--dry-run`/`--move`/`--format` flags.
- Import defaults to copy; `--move` opts into move.
- After placement, the destination directory's naming rule triggers a unified rename preview in the same dialog.
- Lint surfaces as a separate `placement` category (rule_id + winning source + suggested destinations) queryable via `is:misplaced`.
- Edit UX: directory inspector panel with chip input + inherit checkbox + mode selector.
- Edge cases: extension-less files match an explicit `""`; compound extensions use longest-match; extension comparison is case-insensitive.

## Test plan

This PR is docs-only.

- [x] `mise run check` green locally on every commit (hooked via lefthook pre-push).
- [ ] Reviewer sanity check: §3.13 matches the agreed behavior, cross-references in §2.1 / §3.2 / §3.4 / §3.7 / §3.9 / §3.11 / §3.12 are consistent.
- [ ] Reviewer sanity check: M2/M3/M4 milestone bullets and completion criteria match the spec and stay MVP-sized.