### PR TITLE
ci: ensure rustfmt and clippy survive mise cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           workspaces: ". -> target"
 
+      # jdx/mise-action caches ~/.local/share/mise but not ~/.rustup, so on
+      # cache hits mise skips the rustup install and never re-adds components.
+      # Make rustfmt/clippy idempotent here regardless of cache state.
+      - name: Ensure rust components
+        run: rustup component add rustfmt clippy
+
       - name: Run mise check
         run: mise run check
 


### PR DESCRIPTION
## Summary

- On cache hits, `jdx/mise-action` restores `~/.local/share/mise` but not `~/.rustup`, and `mise install` then short-circuits because it thinks rust 1.95.0 is already present. The resulting toolchain has no `rustfmt`, which breaks `cargo fmt --check`.
- PR #1 is the first post-fix run that actually hit the cache and surfaced this, while the previous CI fix on `main` passed only because it was a cache miss that forced a full rustup install.
- Add an idempotent `rustup component add rustfmt clippy` step after the mise-action/rust-cache steps in the `Lint & typecheck` job. Leave the components listed on the `mise.toml` rust spec so fresh local installs still pick them up in one go.

## Test plan

- [x] `mise run check` green locally.
- [ ] Fresh CI run on this PR: `Lint & typecheck` passes.
- [ ] Retry of PR #1 after this merges: `Lint & typecheck` passes.