### PR TITLE
feat(app): theme toggle (system/light/dark) + semantic badge tokens

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Progest</title>
+    <script>
+      // Resolve the persisted theme before React hydrates so the user
+      // never sees a light-mode flash on a dark-mode reload. Mirrors the
+      // logic in @/lib/theme-context exactly — keep them in sync.
+      (function () {
+        try {
+          var t = localStorage.getItem("progest:theme") || "system";
+          var dark =
+            t === "dark" ||
+            (t === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (dark) document.documentElement.classList.add("dark");
+        } catch (e) {
+          // Storage / matchMedia unavailable — fall back to light.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^1.11.0",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,17 +5,27 @@ import { CommandPalette } from "@/components/command-palette";
 import { TreeView } from "@/components/tree-view";
 import { FlatView } from "@/components/flat-view";
 import { ResultDetailDialog } from "@/components/result-detail-dialog";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { ProjectProvider, useProject } from "@/lib/project-context";
+import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
 
 import "./App.css";
 
 export function App() {
   return (
-    <ProjectProvider>
-      <Shell />
-    </ProjectProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      storageKey="progest:theme"
+      disableTransitionOnChange
+    >
+      <ProjectProvider>
+        <Shell />
+      </ProjectProvider>
+    </ThemeProvider>
   );
 }
 
@@ -93,9 +103,8 @@ function TopBar() {
         <FolderOpen />
         {project ? project.name : "Open project…"}
       </Button>
-      <span className="ml-auto text-xs text-muted-foreground">
-        ⌘K to search
-      </span>
+      <span className="ml-auto text-xs text-muted-foreground">⌘K to search</span>
+      <ThemeToggle />
     </header>
   );
 }
@@ -103,7 +112,10 @@ function TopBar() {
 function Welcome() {
   const { recent, openPicker, pickRecent, error } = useProject();
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-6 p-6">
+    <div className="relative flex h-screen flex-col items-center justify-center gap-6 p-6">
+      <div className="absolute top-3 right-3">
+        <ThemeToggle />
+      </div>
       <div className="text-center">
         <h1 className="text-2xl font-semibold tracking-tight">Progest</h1>
         <p className="text-xs text-muted-foreground">

--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -319,7 +319,7 @@ function PaletteStatus(props: {
   }
   if (response?.warnings.length) {
     lines.push(
-      <span key="warn" className="text-amber-600 dark:text-amber-300">
+      <span key="warn" className="text-warning">
         {response.warnings.length} warning{response.warnings.length === 1 ? "" : "s"}:{" "}
         {response.warnings.join("; ")}
       </span>,

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -146,7 +146,7 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
           </span>
         ) : null}
         {response?.warnings && response.warnings.length > 0 ? (
-          <span className="text-amber-600 dark:text-amber-300">
+          <span className="text-warning">
             {response.warnings.length} warning
             {response.warnings.length === 1 ? "" : "s"}: {response.warnings.join("; ")}
           </span>
@@ -378,7 +378,7 @@ function SaveAsDialog(props: {
               </span>
             ) : null}
             {idValid && conflictId ? (
-              <span className="text-amber-600 dark:text-amber-300">
+              <span className="text-warning">
                 will replace existing view {id}
               </span>
             ) : null}

--- a/app/src/components/theme-toggle.tsx
+++ b/app/src/components/theme-toggle.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Icon button that cycles `system → light → dark → system`. Lives in
+ * the TopBar (and the Welcome screen header) so it's available with or
+ * without an attached project.
+ *
+ * Backed by `next-themes` per the shadcn `customization.md §Dark Mode`
+ * recommendation. The `attribute="class"` + `storageKey="progest:theme"`
+ * provider props are wired in `App.tsx`; the inline boot script in
+ * `index.html` reads the same key to prevent FOUC on hard reload.
+ */
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  // next-themes hydrates `theme` lazily — render a stable placeholder
+  // until the provider has read storage to avoid an SSR-style mismatch
+  // (Tauri runs as a static SPA so the first paint sees `undefined`).
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  const current: "system" | "light" | "dark" =
+    !mounted || !theme ? "system" : (theme as "system" | "light" | "dark");
+  const Icon = current === "system" ? Monitor : current === "light" ? Sun : Moon;
+  const next: typeof current =
+    current === "system" ? "light" : current === "light" ? "dark" : "system";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={() => setTheme(next)}
+      title={`Theme: ${current} (click to switch to ${next})`}
+      aria-label={`Theme ${current}, switch to ${next}`}
+    >
+      <Icon />
+    </Button>
+  );
+}

--- a/app/src/components/violation-badges.tsx
+++ b/app/src/components/violation-badges.tsx
@@ -6,6 +6,11 @@ import type { RichViolationCounts } from "@/lib/ipc";
  * Full violation badges with category icon + count. Designed for
  * inline rows where horizontal space is plentiful (palette results,
  * flat list).
+ *
+ * Colors come from semantic tokens defined in `index.css`
+ * (`--badge-naming` / `--badge-placement` / `--badge-sequence`) so
+ * dark mode swaps one variable instead of every utility — see
+ * `customization.md §Dark Mode` in the shadcn skill for the rule.
  */
 export function ViolationBadges({ counts }: { counts: RichViolationCounts }) {
   const total = counts.naming + counts.placement + counts.sequence;
@@ -13,17 +18,17 @@ export function ViolationBadges({ counts }: { counts: RichViolationCounts }) {
   return (
     <span className="ml-auto flex items-center gap-1 text-[0.625rem] tracking-wide">
       {counts.naming > 0 ? (
-        <span className="rounded bg-amber-500/15 px-1 py-0.5 text-amber-600 dark:text-amber-300">
+        <span className="rounded bg-badge-naming/15 px-1 py-0.5 text-badge-naming">
           <Triangle className="inline size-2.5" /> {counts.naming}
         </span>
       ) : null}
       {counts.placement > 0 ? (
-        <span className="rounded bg-sky-500/15 px-1 py-0.5 text-sky-600 dark:text-sky-300">
+        <span className="rounded bg-badge-placement/15 px-1 py-0.5 text-badge-placement">
           <Hash className="inline size-2.5" /> {counts.placement}
         </span>
       ) : null}
       {counts.sequence > 0 ? (
-        <span className="rounded bg-violet-500/15 px-1 py-0.5 text-violet-600 dark:text-violet-300">
+        <span className="rounded bg-badge-sequence/15 px-1 py-0.5 text-badge-sequence">
           ≡ {counts.sequence}
         </span>
       ) : null}
@@ -40,9 +45,15 @@ export function ViolationDots({ counts }: { counts: RichViolationCounts }) {
   if (total === 0) return null;
   return (
     <span className="ml-1 flex items-center gap-0.5">
-      {counts.naming > 0 ? <span className="size-1.5 rounded-full bg-amber-500" /> : null}
-      {counts.placement > 0 ? <span className="size-1.5 rounded-full bg-sky-500" /> : null}
-      {counts.sequence > 0 ? <span className="size-1.5 rounded-full bg-violet-500" /> : null}
+      {counts.naming > 0 ? (
+        <span className="size-1.5 rounded-full bg-badge-naming" />
+      ) : null}
+      {counts.placement > 0 ? (
+        <span className="size-1.5 rounded-full bg-badge-placement" />
+      ) : null}
+      {counts.sequence > 0 ? (
+        <span className="size-1.5 rounded-full bg-badge-sequence" />
+      ) : null}
     </span>
   );
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -39,6 +39,10 @@
     --color-card: var(--card);
     --color-foreground: var(--foreground);
     --color-background: var(--background);
+    --color-badge-naming: var(--badge-naming);
+    --color-badge-placement: var(--badge-placement);
+    --color-badge-sequence: var(--badge-sequence);
+    --color-warning: var(--warning);
     --radius-sm: calc(var(--radius) * 0.6);
     --radius-md: calc(var(--radius) * 0.8);
     --radius-lg: var(--radius);
@@ -81,6 +85,13 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+    /* Violation category badges (M3_HANDOFF §3.6 placeholder palette).
+       naming = amber, placement = sky, sequence = violet. Define here
+       (not via dark: utilities) so light/dark mode is one token swap. */
+    --badge-naming: oklch(0.62 0.16 75);
+    --badge-placement: oklch(0.6 0.16 235);
+    --badge-sequence: oklch(0.55 0.2 295);
+    --warning: oklch(0.62 0.16 75);
 }
 
 .dark {
@@ -115,6 +126,10 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+    --badge-naming: oklch(0.78 0.13 75);
+    --badge-placement: oklch(0.78 0.13 235);
+    --badge-sequence: oklch(0.72 0.18 295);
+    --warning: oklch(0.78 0.13 75);
 }
 
 @layer base {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.5)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2436,6 +2439,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -5222,6 +5231,11 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
## Summary
TopBar / Welcome icon button that cycles **system → light → dark**, persisted in localStorage. Backed by `next-themes` per the shadcn `customization.md §Dark Mode` recommendation. Same pass also moves every `text-amber-600 dark:text-amber-300`-style override out of our (non-shadcn-registry) components and into semantic tokens — `shadcn` skill `rules/styling.md` flags manual `dark:` overrides as anti-pattern.

- **Theme provider** — `next-themes` `<ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="progest:theme" disableTransitionOnChange>` wraps the app. FOUC is prevented by an inline boot script in `index.html` that resolves the same key before React hydrates.
- **`<ThemeToggle />`** — `Button variant="ghost" size="icon-sm"` with Sun / Moon / Monitor (lucide-react) cycling system → light → dark → system. Renders a stable Monitor placeholder until `next-themes` has hydrated, dodging the SSR-style mismatch guard. Mounted in TopBar (always-on shell) and Welcome (absolute top-right).
- **Semantic badge tokens** — `--badge-naming` (amber), `--badge-placement` (sky), `--badge-sequence` (violet), and `--warning` (amber) defined in `:root` + `.dark` in `index.css`, exposed to Tailwind via `@theme inline` (`--color-badge-naming` etc). `<ViolationBadges>` / `<ViolationDots>` and the warning chips in `<CommandPalette>` / `<FlatView>` now use `text-badge-* / bg-badge-*/15` and `text-warning` instead of dark-variant pairs.

## Verified against the shadcn skill (`shadcn/ui@shadcn`)
- `customization.md §Dark Mode` → use `next-themes` with `attribute="class"` ✅
- `rules/styling.md` → no manual `dark:` color overrides outside the shadcn registry components ✅ (`grep` confirms zero `dark:` in `app/src/` excluding `components/ui/`)
- `rules/styling.md` → built-in Button variants ✅ (`variant="ghost"` `size="icon-sm"`)
- Semantic tokens for status colors ✅

## Out of scope
- `app/src/components/ui/*` (shadcn-registry components) keep their `dark:bg-input/30` etc. — those are framework-baseline and regenerated by the CLI, not author-owned.

## Test plan
- [x] `mise run check` green (rustfmt + clippy `-D warnings` + tsc)
- [x] `pnpm --filter @progest/app build` green (313 KB / 97 KB gzip)
- [x] `grep -rn 'dark:' app/src | grep -v 'components/ui/'` returns nothing actionable
- [ ] `tauri dev` smoke — toggle button cycles through three states, dark mode visually flips backgrounds + foregrounds + violation badges, OS auto-dark mode flips when in `system`, hard reload preserves selection without flash. **Not yet executed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)