### PR TITLE
feat(app,tauri): empty FlatView query lists all files; hide .meta / .dirmeta.toml

### DIFF
--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, List as ListIcon, Save, Trash2, FileIcon } from "lucide-rea
 
 import {
   IpcError,
+  filesListAll,
   searchExecute,
   viewDelete,
   viewList,
@@ -48,27 +49,59 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     void refreshViews();
   }, [refreshViews]);
 
-  // Debounced search whenever query changes.
+  // Debounced search whenever query changes. Empty query falls
+  // through to `files_list_all` so the panel always shows *something*
+  // — name-sorted full project — instead of an empty placeholder.
   React.useEffect(() => {
     const trimmed = query.trim();
+    let cancelled = false;
     if (trimmed.length === 0) {
-      setResponse(null);
-      setLoading(false);
-      return;
+      setLoading(true);
+      filesListAll()
+        .then((hits) => {
+          if (cancelled) return;
+          setResponse({
+            query: "",
+            hits,
+            warnings: [],
+            parse_error: null,
+          });
+          setError(null);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          if (e instanceof IpcError && e.isNoProject) {
+            setResponse(null);
+          } else {
+            setError(e instanceof IpcError ? e.raw : String(e));
+            setResponse(null);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
     }
     setLoading(true);
     const handle = setTimeout(async () => {
       try {
+        if (cancelled) return;
         setResponse(await searchExecute(trimmed));
         setError(null);
       } catch (e) {
+        if (cancelled) return;
         setError(e instanceof IpcError ? e.raw : String(e));
         setResponse(null);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }, DEBOUNCE_MS);
-    return () => clearTimeout(handle);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
   }, [query]);
 
   const onSelectView = (id: string) => {
@@ -165,8 +198,6 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
           ) : (
             <HitGrid hits={response.hits} onPick={props.onPickHit} />
           )
-        ) : query.trim().length === 0 ? (
-          <Empty>Type a query or pick a saved view.</Empty>
         ) : null}
       </div>
       <SaveAsDialog

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -196,3 +196,11 @@ export async function filesListDir(path: string): Promise<DirEntry[]> {
     throw toIpcError(e);
   }
 }
+
+export async function filesListAll(): Promise<RichSearchHit[]> {
+  try {
+    return await invoke<RichSearchHit[]>("files_list_all");
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}

--- a/crates/progest-core/src/fs/ignore.rs
+++ b/crates/progest-core/src/fs/ignore.rs
@@ -39,6 +39,12 @@ pub const DEFAULT_PATTERNS: &[&str] = &[
     "*.psd~",
     ".autosave/",
     ".progest/",
+    // Project-level metadata sidecars. `<asset>.meta` is filtered at
+    // the reconciler layer (see `is_sidecar` in `core::reconcile`)
+    // because it's per-asset and pairs with the indexed file; the
+    // directory-scoped `.dirmeta.toml` has no asset to pair with so we
+    // drop it at scan time instead.
+    ".dirmeta.toml",
 ];
 
 /// Location of the user-editable ignore file, relative to the project root.

--- a/crates/progest-tauri/src/commands.rs
+++ b/crates/progest-tauri/src/commands.rs
@@ -32,8 +32,8 @@ use progest_core::search::views::{
     save as save_views_doc, upsert as upsert_view,
 };
 use progest_core::search::{
-    CustomFieldKind, CustomFields, RichCustomField, RichSearchHit, RichViolationCounts, execute,
-    parse, plan, project_hits, validate_with_catalog,
+    CustomFieldKind, CustomFields, RichCustomField, RichSearchHit, RichViolationCounts, SearchHit,
+    execute, parse, plan, project_hits, validate_with_catalog,
 };
 use serde::Serialize;
 use tauri::State;
@@ -187,7 +187,10 @@ pub fn search_execute(query: String, state: State<'_, AppState>) -> Result<Searc
         .index
         .with_connection(|conn| execute(conn, &planned))
         .map_err(|e| format!("execute search: {e}"))?;
-    let rich = project_hits(&ctx.index, &hits).map_err(|e| format!("project search hits: {e}"))?;
+    let mut rich =
+        project_hits(&ctx.index, &hits).map_err(|e| format!("project search hits: {e}"))?;
+    // See `is_plumbing_path` — same stale-index defense as files_list_all.
+    rich.retain(|h| !is_plumbing_path(&h.path));
 
     let warnings: Vec<String> = validated.warnings.iter().map(ToString::to_string).collect();
 
@@ -319,6 +322,69 @@ pub struct FileEntryWire {
     pub custom_fields: Vec<RichCustomField>,
 }
 
+/// Return every indexed file as a [`RichSearchHit`], sorted
+/// case-insensitively by basename. Backs the `FlatView` empty-query
+/// state ("show me everything").
+///
+/// `.meta` sidecars never appear in the index (reconciler skips them
+/// via `is_sidecar`), so we don't need an extra suffix filter here —
+/// the tree view's filter handles the FS surface separately.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn files_list_all(state: State<'_, AppState>) -> Result<Vec<RichSearchHit>, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+    // Run an ad-hoc SELECT against the files table — there's no
+    // planner shortcut for "match all" today, and writing one for one
+    // caller isn't worth the surface. The closure boxes rusqlite
+    // errors into String at the boundary so this crate doesn't have
+    // to take a direct rusqlite dep.
+    let hits: Vec<SearchHit> = ctx.index.with_connection(|conn| {
+        let mut stmt = conn
+            .prepare(
+                "SELECT file_id, path \
+                 FROM files \
+                 ORDER BY LOWER(COALESCE(name, path)) ASC, path ASC, file_id ASC",
+            )
+            .map_err(|e| format!("prepare: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(SearchHit {
+                    file_id: row.get::<_, String>(0)?,
+                    path: row.get::<_, String>(1)?,
+                })
+            })
+            .map_err(|e| format!("query: {e}"))?;
+        let mut out: Vec<SearchHit> = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| format!("row: {e}"))?);
+        }
+        Ok::<Vec<SearchHit>, String>(out)
+    })?;
+
+    let mut rich = project_hits(&ctx.index, &hits).map_err(|e| format!("project files: {e}"))?;
+    // Defense in depth: even after the scanner-level ignore now drops
+    // `.dirmeta.toml`, an index that hasn't been re-scanned since this
+    // build still contains stale sidecar rows. Drop them here so the
+    // UI never surfaces project plumbing.
+    rich.retain(|h| !is_plumbing_path(&h.path));
+    Ok(rich)
+}
+
+/// True for paths whose basename is project plumbing (`.meta` /
+/// `.meta.tmp` sidecar, or `.dirmeta.toml` directory metadata) that
+/// should never reach the user-visible result lists. The scanner now
+/// filters these too — the IPC layer keeps the check as a safety net
+/// for indexes carried over from older builds.
+fn is_plumbing_path(path: &str) -> bool {
+    let basename = std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    is_sidecar_filename(basename) || basename == ".dirmeta.toml"
+}
+
 /// List the immediate children of `path` (project-relative; "" or "."
 /// = root). Directories come first, then files; each list is sorted
 /// case-insensitively for stable UI ordering. Hidden files (`.foo`)
@@ -415,6 +481,14 @@ fn build_dir_entry(
     if name.starts_with('.') {
         return Ok(None);
     }
+    // Sidecar metadata files (`foo.psd.meta`) and in-flight atomic
+    // writes (`foo.psd.meta.tmp`) are project plumbing — never user
+    // content. The reconciler already excludes them from the index
+    // via `is_sidecar()`, but the tree view reads the FS directly so
+    // we filter here too.
+    if is_sidecar_filename(&name) {
+        return Ok(None);
+    }
     let entry_rel = if rel.is_empty() {
         name.clone()
     } else {
@@ -466,6 +540,20 @@ fn build_dir_entry(
         kind: DirEntryKind::File,
         file: Some(file_payload),
     }))
+}
+
+/// True for `.meta` sidecars or their `.meta.tmp` atomic-write
+/// staging counterparts. Compared on the basename, never on the
+/// full path (the substring match is unsafe at path level).
+///
+/// Uses `Path::extension` for the canonical case so `foo.psd.META`
+/// gets the same treatment as `foo.psd.meta`; `.meta.tmp` is matched
+/// as a literal suffix because the staging convention is fixed-case.
+fn is_sidecar_filename(name: &str) -> bool {
+    std::path::Path::new(name)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("meta"))
+        || name.ends_with(".meta.tmp")
 }
 
 fn kind_label(kind: progest_core::meta::Kind) -> &'static str {

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -55,6 +55,7 @@ pub fn run() {
             commands::view_save,
             commands::view_delete,
             commands::files_list_dir,
+            commands::files_list_all,
         ])
         .setup(|_app| Ok(()))
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
Two related polish fixes flagged on the M3 #8 surface:

### 1. Empty FlatView query now lists every file, name-sorted
The panel always shows *something* — typing still filters down via `search_execute`, but a blank box no longer parks on a "Type a query" placeholder.
- New IPC `files_list_all() -> Vec<RichSearchHit>`: ad-hoc `SELECT file_id, path FROM files ORDER BY LOWER(COALESCE(name, path)), path, file_id`, then `project_hits` to enrich. The closure boxes rusqlite errors into `String` at the boundary so `progest-tauri` doesn't have to take a direct rusqlite dep.
- `app/src/lib/ipc.ts` adds `filesListAll()` wrapper.
- `<FlatView>` empty-query branch now calls it and renders through the existing list/grid path. Cancellation flag guards against late responses overwriting a newer query.

### 2. Project plumbing no longer surfaces in tree / flat / search
- **Tree view** (`build_dir_entry`): skip basenames matching the new `is_sidecar_filename(name)` helper (case-insensitive `.meta` extension or `.meta.tmp` literal suffix). The existing dotfile rule already handled `.dirmeta.toml`.
- **Scanner** (`fs::ignore::DEFAULT_PATTERNS`): add `.dirmeta.toml` so reconcile stops indexing it on fresh scans. `<asset>.meta` stays handled by `core::reconcile::is_sidecar` as before.
- **IPC defense-in-depth**: `files_list_all` and `search_execute` filter the rich results through a shared `is_plumbing_path` predicate (basename = `.meta` / `.meta.tmp` / `.dirmeta.toml`) so indexes carried over from older builds — which still have stale `.dirmeta.toml` rows — don't leak into the UI before the next reconcile drops them.

## Test plan
- [x] `mise run check` green (rustfmt + clippy `-D warnings` + tsc)
- [x] `cargo test --workspace` green (all suites pass)
- [ ] `tauri dev` smoke against a seeded project — clear the search box and confirm the full project lists name-sorted; create a `.dirmeta.toml` and confirm it doesn't appear in tree/flat/search; type a query and confirm `.meta` companion files don't surface. **Not yet executed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)