### PR TITLE
fix(app): refresh FlatView + TreeView on project change

### DIFF
--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -13,6 +13,7 @@ import {
   type View,
   type ViewDisplay,
 } from "@/lib/ipc";
+import { useProject } from "@/lib/project-context";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -28,6 +29,7 @@ import { ViolationBadges } from "@/components/violation-badges";
 const DEBOUNCE_MS = 200;
 
 export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
+  const { project } = useProject();
   const [query, setQuery] = React.useState("");
   const [display, setDisplay] = React.useState<ViewDisplay>("list");
   const [response, setResponse] = React.useState<SearchResponse | null>(null);
@@ -45,9 +47,19 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     }
   }, []);
 
+  // Reset all per-project state when the attached project changes.
+  // Without this, switching projects via the picker / recent list
+  // would leave the old query, response, saved-views list, and
+  // active-view selection in place — the panel would look stale
+  // until the user typed something.
   React.useEffect(() => {
+    setQuery("");
+    setResponse(null);
+    setError(null);
+    setActiveViewId(null);
+    setDisplay("list");
     void refreshViews();
-  }, [refreshViews]);
+  }, [project?.root, refreshViews]);
 
   // Debounced search whenever query changes. Empty query falls
   // through to `files_list_all` so the panel always shows *something*
@@ -102,7 +114,11 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
       cancelled = true;
       clearTimeout(handle);
     };
-  }, [query]);
+    // `project?.root` is in the deps so a project switch retriggers
+    // the empty-query files_list_all (or the saved view's loaded
+    // query) against the new index even when the query string itself
+    // is identical between projects.
+  }, [query, project?.root]);
 
   const onSelectView = (id: string) => {
     if (id === "") {

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ChevronRight, ChevronDown, Folder, FolderOpen, FileIcon } from "lucide-react";
 
 import { filesListDir, IpcError, type DirEntry, type FileEntry } from "@/lib/ipc";
+import { useProject } from "@/lib/project-context";
 
 import { ViolationDots } from "@/components/violation-badges";
 
@@ -14,6 +15,7 @@ type DirState = {
 };
 
 export function TreeView(props: { onPickFile?: (entry: DirEntry) => void }) {
+  const { project } = useProject();
   // path "" = root; cache keeps loaded children + error per path so
   // collapsing/re-expanding doesn't re-fetch.
   const [cache, setCache] = React.useState<Record<string, DirState>>({});
@@ -39,10 +41,15 @@ export function TreeView(props: { onPickFile?: (entry: DirEntry) => void }) {
     [],
   );
 
-  // Load root immediately so the tree isn't empty on first mount.
+  // Reset cache + expanded set when the attached project changes,
+  // then refetch the new root. Without this, the tree would keep
+  // showing the old project's directory snapshot until the user
+  // collapsed and re-expanded each branch.
   React.useEffect(() => {
+    setCache({});
+    setExpanded(new Set([""]));
     void fetchDir("");
-  }, [fetchDir]);
+  }, [project?.root, fetchDir]);
 
   const toggle = React.useCallback(
     async (path: string) => {


### PR DESCRIPTION
## Summary
`<FlatView>` and `<TreeView>` were holding their internal state across project switches, so reopening a different project via the TopBar picker / Welcome screen / recent-projects list left both panels showing the previous project's data until the user manually typed a new query or collapsed-and-re-expanded each tree branch.

Both components now subscribe to `useProject()` and reset on `project?.root` change:

- **FlatView**: clear query / response / error / active saved view / display preference; re-fetch saved-views via `viewList()`. The search effect's dependency array gains `project?.root` so an identical-looking empty query still re-runs `files_list_all` against the new index.
- **TreeView**: clear the dir cache, reset `expanded` back to the root-only set, and re-fetch the new root via `files_list_dir("")`.

## Test plan
- [x] `mise run check` green
- [x] `pnpm --filter @progest/app build` green
- [ ] `tauri dev` smoke — open project A, run a query, open project B via the TopBar picker; confirm FlatView refreshes (query cleared, file list switches) and TreeView refreshes (root re-fetched, all branches collapsed). Same with the recent-projects list. **Not yet executed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)