### PR TITLE
feat(app): `>command` mode in the command palette + extensible registry

### DIFF
--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FolderOpen, History, X } from "lucide-react";
+import { ChevronRight, FolderOpen, History, X } from "lucide-react";
 
 import {
   Command,
@@ -22,8 +22,17 @@ import {
   type SearchResponse,
 } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
+import {
+  fuzzyMatch,
+  groupCommands,
+  usePaletteCommands,
+  type PaletteCommand,
+} from "@/lib/palette-commands";
 import { ResultDetailDialog } from "@/components/result-detail-dialog";
 import { ViolationBadges } from "@/components/violation-badges";
+
+/** Prefix that flips the palette into "system commands" mode. */
+const COMMAND_PREFIX = ">";
 
 const SEARCH_DEBOUNCE_MS = 200;
 
@@ -36,6 +45,25 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
   const [history, setHistory] = React.useState<HistoryEntry[]>([]);
   const [error, setError] = React.useState<string | null>(null);
   const [selected, setSelected] = React.useState<RichSearchHit | null>(null);
+
+  const allCommands = usePaletteCommands();
+  const isCommandMode = query.startsWith(COMMAND_PREFIX);
+  const commandQuery = isCommandMode ? query.slice(COMMAND_PREFIX.length).trim() : "";
+  const filteredCommands = React.useMemo(
+    () => allCommands.filter((c) => fuzzyMatch(commandQuery, c)),
+    [allCommands, commandQuery],
+  );
+
+  const onRunCommand = React.useCallback((cmd: PaletteCommand) => {
+    setOpen(false);
+    setQuery("");
+    // Defer to next tick so the dialog close animation isn't competing
+    // with whatever the command does (open another dialog, swap project,
+    // toggle theme).
+    queueMicrotask(() => {
+      void cmd.run();
+    });
+  }, []);
 
   // Cmd+K / Ctrl+K toggle.
   React.useEffect(() => {
@@ -73,10 +101,12 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
     setResponse(null);
   }, [project?.root]);
 
-  // Debounced search.
+  // Debounced search. Skipped when the user is in command mode
+  // (`>`-prefixed) — the query would otherwise hit search_execute as
+  // a literal `>foo` and confuse the parser.
   React.useEffect(() => {
     const trimmed = query.trim();
-    if (!open || trimmed.length === 0) {
+    if (!open || isCommandMode || trimmed.length === 0) {
       setResponse(null);
       setLoading(false);
       return;
@@ -96,7 +126,7 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
       }
     }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [query, open]);
+  }, [query, open, isCommandMode]);
 
   const onPickHit = (hit: RichSearchHit) => {
     setOpen(false);
@@ -130,15 +160,22 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
             value={query}
             onValueChange={setQuery}
             placeholder={
-              project
-                ? "tag:wip type:psd is:violation …  (Cmd+K)"
-                : "Open a project to search"
+              isCommandMode
+                ? "Type a command (Open project, Set theme, …)"
+                : project
+                  ? "tag:wip type:psd is:violation …  (>command for actions)"
+                  : "Open a project to search, or type > for commands"
             }
             autoFocus
-            disabled={project === null}
           />
           <CommandList>
-            {project === null ? (
+            {isCommandMode ? (
+              <CommandsBody
+                commands={filteredCommands}
+                emptyHint={commandQuery}
+                onPick={onRunCommand}
+              />
+            ) : project === null ? (
               <NoProjectBody
                 recent={recent}
                 onOpenPicker={() => {
@@ -254,6 +291,61 @@ function NoProjectBody(props: {
           <code>.progest/</code> to get started.
         </CommandEmpty>
       )}
+    </>
+  );
+}
+
+/**
+ * Render the `>`-prefixed command-mode body. Commands are bucketed
+ * by their `group` field (Project / Recent projects / Theme / …);
+ * cmdk handles arrow-key navigation across groups for free.
+ */
+function CommandsBody(props: {
+  commands: PaletteCommand[];
+  emptyHint: string;
+  onPick: (cmd: PaletteCommand) => void;
+}) {
+  const { commands, emptyHint, onPick } = props;
+  if (commands.length === 0) {
+    return (
+      <CommandEmpty>
+        {emptyHint.length > 0
+          ? `No commands matching "${emptyHint}".`
+          : "No commands available."}
+      </CommandEmpty>
+    );
+  }
+  const groups = groupCommands(commands);
+  return (
+    <>
+      {Array.from(groups.entries()).map(([group, items], idx) => (
+        <React.Fragment key={group || "(default)"}>
+          {idx > 0 ? <CommandSeparator /> : null}
+          <CommandGroup heading={group || undefined}>
+            {items.map((cmd) => (
+              <CommandItem
+                key={cmd.id}
+                value={cmd.id}
+                onSelect={() => onPick(cmd)}
+              >
+                <ChevronRight className="opacity-60" />
+                {/* min-w-0 lets the truncate kick in inside cmdk's
+                    flex row; without it the span ignores width and
+                    pushes the shortcut off-screen / onto a new line. */}
+                <span className="min-w-0 truncate">{cmd.title}</span>
+                {cmd.hint ? (
+                  <CommandShortcut
+                    className="min-w-0 max-w-[55%] truncate"
+                    title={cmd.hint}
+                  >
+                    {cmd.hint}
+                  </CommandShortcut>
+                ) : null}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </React.Fragment>
+      ))}
     </>
   );
 }

--- a/app/src/lib/palette-commands/index.ts
+++ b/app/src/lib/palette-commands/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Aggregator entry point for the `>`-prefixed command palette mode.
+ *
+ * Every command source is a hook returning `PaletteCommand[]`. To
+ * add a new category:
+ *
+ *   1. Write `app/src/lib/palette-commands/<topic>-commands.ts`
+ *      exporting `use<Topic>Commands(): PaletteCommand[]`.
+ *   2. Import + concat it inside [`usePaletteCommands`] below.
+ *   3. Document the new commands in `docs/COMMAND_PALETTE.md`
+ *      (the canonical user-facing list).
+ *
+ * Sources can rely on any context (`useProject`, `useTheme`, …); the
+ * aggregator just composes them. Keep each source focused on a
+ * single subsystem so the dependency surface stays narrow.
+ */
+
+import * as React from "react";
+
+import { useProjectCommands } from "./project-commands";
+import { useThemeCommands } from "./theme-commands";
+import type { PaletteCommand } from "./types";
+
+export type { PaletteCommand } from "./types";
+export { fuzzyMatch } from "./types";
+
+export function usePaletteCommands(): PaletteCommand[] {
+  const project = useProjectCommands();
+  const theme = useThemeCommands();
+  return React.useMemo(() => [...project, ...theme], [project, theme]);
+}
+
+/**
+ * Group commands by their `group` field, preserving insertion order
+ * within each bucket and across buckets (first appearance wins).
+ * Commands without a group fall under the empty-string key, which
+ * the renderer treats as "no header".
+ */
+export function groupCommands(commands: PaletteCommand[]): Map<string, PaletteCommand[]> {
+  const out = new Map<string, PaletteCommand[]>();
+  for (const cmd of commands) {
+    const key = cmd.group ?? "";
+    const list = out.get(key);
+    if (list) {
+      list.push(cmd);
+    } else {
+      out.set(key, [cmd]);
+    }
+  }
+  return out;
+}

--- a/app/src/lib/palette-commands/project-commands.ts
+++ b/app/src/lib/palette-commands/project-commands.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+import { useProject } from "@/lib/project-context";
+
+import type { PaletteCommand } from "./types";
+
+/**
+ * Project-scoped commands: open a fresh project via the native
+ * folder picker, or jump straight into one of the recent entries.
+ *
+ * The recent list is dynamic — entries are emitted as commands so
+ * `> open recent <name>` can fuzzy-match by either the project's
+ * display name or its absolute root path.
+ */
+export function useProjectCommands(): PaletteCommand[] {
+  const { recent, openPicker, pickRecent } = useProject();
+  return React.useMemo<PaletteCommand[]>(() => {
+    const cmds: PaletteCommand[] = [
+      {
+        id: "project.open",
+        title: "Open project…",
+        group: "Project",
+        hint: "folder picker",
+        keywords: ["folder", "picker", "directory"],
+        run: () => {
+          void openPicker();
+        },
+      },
+    ];
+    for (const entry of recent) {
+      const display = entry.name || entry.root;
+      cmds.push({
+        id: `project.recent:${entry.root}`,
+        title: `Open recent: ${display}`,
+        group: "Recent projects",
+        hint: entry.root,
+        keywords: [entry.root, entry.name].filter(Boolean),
+        run: () => {
+          void pickRecent(entry);
+        },
+      });
+    }
+    return cmds;
+  }, [recent, openPicker, pickRecent]);
+}

--- a/app/src/lib/palette-commands/theme-commands.ts
+++ b/app/src/lib/palette-commands/theme-commands.ts
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { useTheme } from "next-themes";
+
+import type { PaletteCommand } from "./types";
+
+/**
+ * Theme switcher commands. Three discrete `Set theme: …` entries
+ * mirror what the TopBar icon button cycles through, so the user can
+ * jump straight to a specific mode without click-cycling.
+ *
+ * The currently-active mode gets `hint: "active"` so the palette
+ * shows a tiny indicator next to it.
+ */
+export function useThemeCommands(): PaletteCommand[] {
+  const { theme, setTheme } = useTheme();
+  return React.useMemo<PaletteCommand[]>(
+    () => [
+      {
+        id: "theme.system",
+        title: "Set theme: System",
+        group: "Theme",
+        hint: theme === "system" ? "active" : undefined,
+        keywords: ["auto", "os"],
+        run: () => setTheme("system"),
+      },
+      {
+        id: "theme.light",
+        title: "Set theme: Light",
+        group: "Theme",
+        hint: theme === "light" ? "active" : undefined,
+        run: () => setTheme("light"),
+      },
+      {
+        id: "theme.dark",
+        title: "Set theme: Dark",
+        group: "Theme",
+        hint: theme === "dark" ? "active" : undefined,
+        run: () => setTheme("dark"),
+      },
+    ],
+    [theme, setTheme],
+  );
+}

--- a/app/src/lib/palette-commands/types.ts
+++ b/app/src/lib/palette-commands/types.ts
@@ -1,0 +1,52 @@
+/**
+ * One actionable entry in the `>`-prefixed command palette mode.
+ *
+ * Sources contribute commands via custom hooks (see `index.ts`); each
+ * source is a small `useFooCommands()` that returns
+ * `PaletteCommand[]` and only depends on its own context. New
+ * categories slot in by:
+ *   1. writing a new `use<Foo>Commands()` hook,
+ *   2. adding it to `usePaletteCommands()` in `index.ts`,
+ *   3. listing the resulting commands in `docs/COMMAND_PALETTE.md`.
+ */
+export interface PaletteCommand {
+  /** Stable identifier (`project.open`, `theme.dark`). Used as the
+   *  cmdk `value` so navigation order is deterministic; never shown
+   *  to the user. */
+  id: string;
+  /** The line the user reads in the palette. */
+  title: string;
+  /** Optional bucket header (`Project`, `Theme`, …). Commands sharing
+   *  the same group render under one CommandGroup. */
+  group?: string | undefined;
+  /** Right-aligned secondary label (`active`, `~/Code/foo`, …). */
+  hint?: string | undefined;
+  /** Extra fuzzy-match keywords beyond the title. Useful for synonyms
+   *  (e.g. `"folder picker"` for the Open Project command). */
+  keywords?: string[] | undefined;
+  /** Action invoked when the command is selected. Errors should be
+   *  caught internally; the palette will not show them. */
+  run: () => void | Promise<void>;
+}
+
+/**
+ * Lightweight AND-match: every whitespace-separated needle must
+ * appear (case-insensitive) somewhere in the command's searchable
+ * surface (title + id + keywords). Empty needle list matches every
+ * command.
+ *
+ * Kept here instead of leaning on cmdk's built-in filter so the
+ * palette can keep `shouldFilter={false}` for the search-mode path
+ * — flipping cmdk's filter behavior between modes is fragile.
+ */
+export function fuzzyMatch(query: string, command: PaletteCommand): boolean {
+  const needles = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((s) => s.length > 0);
+  if (needles.length === 0) return true;
+  const haystack = [command.title, command.id, ...(command.keywords ?? [])]
+    .join(" ")
+    .toLowerCase();
+  return needles.every((n) => haystack.includes(n));
+}

--- a/docs/COMMAND_PALETTE.md
+++ b/docs/COMMAND_PALETTE.md
@@ -1,0 +1,90 @@
+# Command Palette
+
+Cmd+K でコマンドパレット起動。2 モード:
+
+| プレフィックス | モード | 説明 |
+| --- | --- | --- |
+| なし | 検索 | 検索 DSL（`docs/SEARCH_DSL.md`）でファイル検索 |
+| `>` | コマンド | アプリケーションコマンド実行（VS Code 風） |
+
+`>` を入力するとコマンドモード、削除すると検索モードに戻る。
+
+最終更新: 2026-04-27（初版、`>` プレフィックス + Project / Theme コマンド初期セット）
+
+---
+
+## 1. 利用可能なコマンド一覧
+
+**新コマンドを追加した PR は本セクションも同時更新する**（拡張性方針）。
+
+### 1.1 Project（`useProjectCommands`）
+
+| Title | Hint | 動作 |
+| --- | --- | --- |
+| `Open project…` | `folder picker` | Tauri folder picker → `project_open(path)` → AppState 差替え |
+| `Open recent: <name>` | `<absolute path>` | recent project エントリを即時 attach（ピッカー不要）。recent ごとに動的生成、`pickRecent(entry)` 経由 |
+
+### 1.2 Theme（`useThemeCommands`）
+
+| Title | Hint | 動作 |
+| --- | --- | --- |
+| `Set theme: System` | `active`（現在モード時） | `setTheme("system")` |
+| `Set theme: Light` | 同上 | `setTheme("light")` |
+| `Set theme: Dark` | 同上 | `setTheme("dark")` |
+
+`next-themes` が localStorage（key: `progest:theme`）に永続化、OS 追従は system モード時のみ。
+
+---
+
+## 2. 設計
+
+### 2.1 ファイル構成
+
+```
+app/src/lib/palette-commands/
+├── types.ts            # PaletteCommand interface + fuzzyMatch
+├── project-commands.ts # useProjectCommands
+├── theme-commands.ts   # useThemeCommands
+└── index.ts            # usePaletteCommands aggregator
+```
+
+`<CommandPalette>`（`app/src/components/command-palette.tsx`）が `usePaletteCommands()` を呼んで集約結果を `>` モードに表示。
+
+### 2.2 拡張方法
+
+新カテゴリのコマンドを追加する手順:
+
+1. `app/src/lib/palette-commands/<topic>-commands.ts` を新規作成、`use<Topic>Commands(): PaletteCommand[]` を export。
+2. `index.ts` の `usePaletteCommands()` で import + concat。
+3. **本ドキュメント §1 にテーブル追加**。
+
+`PaletteCommand` インターフェース:
+
+```ts
+interface PaletteCommand {
+  id: string;            // 安定 ID（例: `project.open`）。cmdk `value` として使用
+  title: string;         // 表示名
+  group?: string;        // セクションヘッダー
+  hint?: string;         // 右側補助ラベル
+  keywords?: string[];   // 追加 fuzzy 一致語
+  run: () => void | Promise<void>;
+}
+```
+
+`run()` 内のエラーハンドリングは各コマンドの責任（パレットは catch しない）。破壊的操作を追加する場合は確認 Dialog を `run` 内で開くこと。
+
+### 2.3 フィルタ
+
+`>` 後の文字列を AND-match で全 needle が title / id / keywords のいずれかに含まれるかチェック（`fuzzyMatch` in `types.ts`）。cmdk の built-in filter は使わない（検索モードと同じ `shouldFilter={false}` を流用するため）。
+
+---
+
+## 3. 将来計画（v1.x 候補）
+
+- `Reload window` / `Quit` 等のシステムコマンド（Tauri webview API 経由）
+- `Lint current project` / `Reconcile now` 等の core 操作起動
+- `Tag add: <name>` / `Tag remove: <name>` — 選択ファイルとの組合せ。コマンドパレット単独では難しいので、`tag.toml` の既存 tag を fuzzy 提示する形に
+- `Reveal in Finder` for selected hit（コマンドパレット内検索結果クリック時の選択状態を引き継ぐ）
+- 確認 Dialog 付き破壊的コマンド（Clear recent projects / Clear search history 等）
+
+追加時は必ず本ドキュメント §1 を更新。


### PR DESCRIPTION
## Summary
Typing `>` flips Cmd+K from search-mode (DSL queries against the index) to command-mode (application actions like opening another project or switching theme). Backspacing the `>` returns to search mode. Built around an extensibility-first registry so new command categories slot in without touching the palette internals.

## What ships in v1
| Group           | Command                          | Action                              |
| ---             | ---                              | ---                                 |
| Project         | Open project…                    | Native folder picker → project_open |
| Recent projects | Open recent: <name>              | Skip the picker, attach entry.root  |
| Theme           | Set theme: System / Light / Dark | next-themes setTheme                |

Project + Theme only this round — Clear recent / Clear history intentionally deferred (kickoff: destructive commands need a confirm Dialog flow first).

## Architecture (`docs/COMMAND_PALETTE.md`)
- `app/src/lib/palette-commands/types.ts` — `PaletteCommand` interface (id / title / group / hint / keywords / run) plus an AND-match `fuzzyMatch` helper kept here instead of leaning on cmdk's filter (search-mode keeps `shouldFilter={false}`).
- `project-commands.ts` and `theme-commands.ts` — one hook per category; each closes over its own context (`useProject`, `useTheme`) and returns a `PaletteCommand[]`.
- `index.ts` — `usePaletteCommands()` composes every source via `useMemo([...])`; also exposes `groupCommands()`. **Adding a category = new hook + concat here + add a row to `docs/COMMAND_PALETTE.md` §1** (per the kickoff agreement that the list stays in sync).

## Palette wiring (`command-palette.tsx`)
- `isCommandMode = query.startsWith(">")` decides between `<CommandsBody>` and the existing search/no-project/recent-history branches. Command mode preempts the no-project gate so themes are reachable even before a project is attached.
- Search effect skips when `isCommandMode` so a literal `>foo` never hits search_execute. CommandInput is no longer `disabled={!project}` so users can always type `>` to escape.
- `<CommandsBody>` buckets commands by `group`, separators between groups, `cmd.hint` rendered as a CommandShortcut (used for "active" markers and recent-project absolute paths). Selecting an item closes the dialog and `queueMicrotask`s the action so the close animation doesn't fight a follow-up dialog.
- Long hints (recent-project absolute paths) get `min-w-0 max-w-[55%] truncate` + `title=` tooltip on the shortcut so the row stays one line and the full path is reachable on hover. `min-w-0` on the title span lets the truncate kick in inside cmdk's flex row.

## Test plan
- [x] `mise run check` green
- [x] `pnpm --filter @progest/app build` green (316 KB / 98 KB gzip)
- [ ] `tauri dev` smoke — type `>` and confirm command list appears; type `> open` and confirm fuzzy filter; type `> dark` to switch theme; type `> open recent` and confirm long paths render on a single truncated line with full path on hover. **Not yet executed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)