### PR TITLE
feat(app): bottom status bar with project + violation summary badges

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import { ResultDetailDialog } from "@/components/result-detail-dialog";
 import { StatusBar } from "@/components/status-bar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { FlatViewSummaryProvider } from "@/lib/flat-view-context";
 import { ProjectProvider, useProject } from "@/lib/project-context";
 import { ThemeProvider } from "next-themes";
@@ -24,11 +25,13 @@ export function App() {
       storageKey="progest:theme"
       disableTransitionOnChange
     >
-      <ProjectProvider>
-        <FlatViewSummaryProvider>
-          <Shell />
-        </FlatViewSummaryProvider>
-      </ProjectProvider>
+      <TooltipProvider delayDuration={150}>
+        <ProjectProvider>
+          <FlatViewSummaryProvider>
+            <Shell />
+          </FlatViewSummaryProvider>
+        </ProjectProvider>
+      </TooltipProvider>
     </ThemeProvider>
   );
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,8 +5,10 @@ import { CommandPalette } from "@/components/command-palette";
 import { TreeView } from "@/components/tree-view";
 import { FlatView } from "@/components/flat-view";
 import { ResultDetailDialog } from "@/components/result-detail-dialog";
+import { StatusBar } from "@/components/status-bar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { FlatViewSummaryProvider } from "@/lib/flat-view-context";
 import { ProjectProvider, useProject } from "@/lib/project-context";
 import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
@@ -23,7 +25,9 @@ export function App() {
       disableTransitionOnChange
     >
       <ProjectProvider>
-        <Shell />
+        <FlatViewSummaryProvider>
+          <Shell />
+        </FlatViewSummaryProvider>
       </ProjectProvider>
     </ThemeProvider>
   );
@@ -75,7 +79,7 @@ function MainShell(props: {
   onPickTreeFile: (entry: DirEntry) => void;
 }) {
   return (
-    <div className="grid h-screen grid-rows-[auto_1fr] bg-background">
+    <div className="grid h-screen grid-rows-[auto_1fr_auto] bg-background">
       <TopBar />
       <div className="grid grid-cols-[260px_1fr] overflow-hidden border-t">
         <aside className="overflow-hidden border-r">
@@ -85,6 +89,7 @@ function MainShell(props: {
           <FlatView onPickHit={props.onPickHit} />
         </main>
       </div>
+      <StatusBar />
     </div>
   );
 }
@@ -112,46 +117,49 @@ function TopBar() {
 function Welcome() {
   const { recent, openPicker, pickRecent, error } = useProject();
   return (
-    <div className="relative flex h-screen flex-col items-center justify-center gap-6 p-6">
-      <div className="absolute top-3 right-3">
-        <ThemeToggle />
-      </div>
-      <div className="text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">Progest</h1>
-        <p className="text-xs text-muted-foreground">
-          Open a project (a folder containing <code>.progest/</code>).
-        </p>
-      </div>
-      <Button onClick={() => void openPicker()}>
-        <FolderOpen /> Open project…
-      </Button>
-      {recent.length > 0 ? (
-        <div className="grid w-full max-w-md gap-1 text-xs">
-          <div className="text-muted-foreground">Recent</div>
-          <ul className="grid gap-1">
-            {recent.slice(0, 8).map((entry) => (
-              <li key={entry.root}>
-                <button
-                  type="button"
-                  className="grid w-full grid-cols-[1fr_auto] items-center gap-2 rounded-md border px-2 py-1.5 text-left hover:bg-accent"
-                  onClick={() => void pickRecent(entry)}
-                >
-                  <div className="min-w-0">
-                    <div className="truncate">{entry.name || entry.root}</div>
-                    <div className="truncate text-[0.625rem] text-muted-foreground">
-                      {entry.root}
-                    </div>
-                  </div>
-                  <span className="text-[0.625rem] text-muted-foreground">
-                    {relTime(entry.last_opened)}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
+    <div className="grid h-screen grid-rows-[1fr_auto] bg-background">
+      <div className="relative flex flex-col items-center justify-center gap-6 p-6">
+        <div className="absolute top-3 right-3">
+          <ThemeToggle />
         </div>
-      ) : null}
-      {error ? <div className="text-xs text-destructive">{error}</div> : null}
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">Progest</h1>
+          <p className="text-xs text-muted-foreground">
+            Open a project (a folder containing <code>.progest/</code>).
+          </p>
+        </div>
+        <Button onClick={() => void openPicker()}>
+          <FolderOpen /> Open project…
+        </Button>
+        {recent.length > 0 ? (
+          <div className="grid w-full max-w-md gap-1 text-xs">
+            <div className="text-muted-foreground">Recent</div>
+            <ul className="grid gap-1">
+              {recent.slice(0, 8).map((entry) => (
+                <li key={entry.root}>
+                  <button
+                    type="button"
+                    className="grid w-full grid-cols-[1fr_auto] items-center gap-2 rounded-md border px-2 py-1.5 text-left hover:bg-accent"
+                    onClick={() => void pickRecent(entry)}
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate">{entry.name || entry.root}</div>
+                      <div className="truncate text-[0.625rem] text-muted-foreground">
+                        {entry.root}
+                      </div>
+                    </div>
+                    <span className="text-[0.625rem] text-muted-foreground">
+                      {relTime(entry.last_opened)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {error ? <div className="text-xs text-destructive">{error}</div> : null}
+      </div>
+      <StatusBar />
     </div>
   );
 }

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -14,6 +14,7 @@ import {
   type ViewDisplay,
 } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
+import { useReportFlatView } from "@/lib/flat-view-context";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -30,6 +31,7 @@ const DEBOUNCE_MS = 200;
 
 export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   const { project } = useProject();
+  const reportSummary = useReportFlatView();
   const [query, setQuery] = React.useState("");
   const [display, setDisplay] = React.useState<ViewDisplay>("list");
   const [response, setResponse] = React.useState<SearchResponse | null>(null);
@@ -38,6 +40,23 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   const [views, setViews] = React.useState<View[]>([]);
   const [activeViewId, setActiveViewId] = React.useState<string | null>(null);
   const [saveOpen, setSaveOpen] = React.useState(false);
+
+  // Mirror our local state onto the FlatView summary context so the
+  // bottom <StatusBar> renders the same hit count / loading / warning
+  // / parse-error / active-view indicators without owning the search
+  // effect itself.
+  React.useEffect(() => {
+    const activeView =
+      activeViewId !== null ? (views.find((v) => v.id === activeViewId) ?? null) : null;
+    reportSummary({
+      loading,
+      hitCount: response && !response.parse_error ? response.hits.length : null,
+      warnings: response?.warnings ?? [],
+      parseError: response?.parse_error?.message ?? null,
+      error,
+      activeView,
+    });
+  }, [loading, response, error, views, activeViewId, reportSummary]);
 
   const refreshViews = React.useCallback(async () => {
     try {
@@ -187,26 +206,6 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
           </Button>
         </div>
       </header>
-      <div className="border-b px-3 py-1 text-[0.625rem]">
-        {loading ? <span className="text-muted-foreground">searching…</span> : null}
-        {response?.parse_error ? (
-          <span className="text-destructive">
-            parse error: {response.parse_error.message}
-          </span>
-        ) : null}
-        {response?.warnings && response.warnings.length > 0 ? (
-          <span className="text-warning">
-            {response.warnings.length} warning
-            {response.warnings.length === 1 ? "" : "s"}: {response.warnings.join("; ")}
-          </span>
-        ) : null}
-        {error ? <span className="text-destructive">{error}</span> : null}
-        {response && !response.parse_error ? (
-          <span className="ml-auto text-muted-foreground">
-            {response.hits.length} hit{response.hits.length === 1 ? "" : "s"}
-          </span>
-        ) : null}
-      </div>
       <div className="flex-1 overflow-auto">
         {response && !response.parse_error ? (
           display === "list" ? (

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -49,15 +49,21 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   React.useEffect(() => {
     const activeView =
       activeViewId !== null ? (views.find((v) => v.id === activeViewId) ?? null) : null;
-    const totals = (response?.hits ?? []).reduce(
-      (acc, h) => ({
-        naming: acc.naming + h.violations.naming,
-        placement: acc.placement + h.violations.placement,
-        sequence: acc.sequence + h.violations.sequence,
-      }),
-      { naming: 0, placement: 0, sequence: 0 },
-    );
-    reportSummary({ activeView, violationTotals: totals });
+    const totals = { naming: 0, placement: 0, sequence: 0 };
+    const files = {
+      naming: [] as string[],
+      placement: [] as string[],
+      sequence: [] as string[],
+    };
+    for (const hit of response?.hits ?? []) {
+      totals.naming += hit.violations.naming;
+      totals.placement += hit.violations.placement;
+      totals.sequence += hit.violations.sequence;
+      if (hit.violations.naming > 0) files.naming.push(hit.path);
+      if (hit.violations.placement > 0) files.placement.push(hit.path);
+      if (hit.violations.sequence > 0) files.sequence.push(hit.path);
+    }
+    reportSummary({ activeView, violationTotals: totals, violationFiles: files });
   }, [response, views, activeViewId, reportSummary]);
 
   const refreshViews = React.useCallback(async () => {

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { LayoutGrid, List as ListIcon, Save, Trash2, FileIcon } from "lucide-react";
+import { LayoutGrid, List as ListIcon, Save, Trash2, FileIcon, X } from "lucide-react";
 
 import {
   IpcError,
@@ -41,22 +41,24 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   const [activeViewId, setActiveViewId] = React.useState<string | null>(null);
   const [saveOpen, setSaveOpen] = React.useState(false);
 
-  // Mirror our local state onto the FlatView summary context so the
-  // bottom <StatusBar> renders the same hit count / loading / warning
-  // / parse-error / active-view indicators without owning the search
-  // effect itself.
+  // Mirror project-level state onto the FlatView summary context so
+  // <StatusBar> can render the active view + aggregate violation
+  // counts. Per-query feedback (parse error, warnings, IPC error,
+  // hit count, loading spinner) stays local — the user expects that
+  // information next to the input that produced it.
   React.useEffect(() => {
     const activeView =
       activeViewId !== null ? (views.find((v) => v.id === activeViewId) ?? null) : null;
-    reportSummary({
-      loading,
-      hitCount: response && !response.parse_error ? response.hits.length : null,
-      warnings: response?.warnings ?? [],
-      parseError: response?.parse_error?.message ?? null,
-      error,
-      activeView,
-    });
-  }, [loading, response, error, views, activeViewId, reportSummary]);
+    const totals = (response?.hits ?? []).reduce(
+      (acc, h) => ({
+        naming: acc.naming + h.violations.naming,
+        placement: acc.placement + h.violations.placement,
+        sequence: acc.sequence + h.violations.sequence,
+      }),
+      { naming: 0, placement: 0, sequence: 0 },
+    );
+    reportSummary({ activeView, violationTotals: totals });
+  }, [response, views, activeViewId, reportSummary]);
 
   const refreshViews = React.useCallback(async () => {
     try {
@@ -159,6 +161,15 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     if (activeViewId !== null) setActiveViewId(null);
   };
 
+  /** Clear the input. Triggered by the trailing X button and by
+   *  Esc while the input has focus. Decouples from the saved view
+   *  so the empty-query path runs against the live project, not the
+   *  view's frozen query. */
+  const onClearQuery = () => {
+    setQuery("");
+    if (activeViewId !== null) setActiveViewId(null);
+  };
+
   const onDeleteActive = async () => {
     if (!activeViewId) return;
     try {
@@ -173,12 +184,31 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   return (
     <section className="flex h-full flex-col">
       <header className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
-        <Input
-          value={query}
-          onChange={(e) => onUserEdit(e.target.value)}
-          placeholder="tag:wip type:psd is:violation …"
-          className="h-8 max-w-md text-xs"
-        />
+        <div className="relative flex max-w-md flex-1 items-center">
+          <Input
+            value={query}
+            onChange={(e) => onUserEdit(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && query.length > 0) {
+                e.preventDefault();
+                onClearQuery();
+              }
+            }}
+            placeholder="tag:wip type:psd is:violation …  (Esc to clear)"
+            className="h-8 pr-7 text-xs"
+          />
+          {query.length > 0 ? (
+            <button
+              type="button"
+              onClick={onClearQuery}
+              title="Clear query (Esc)"
+              aria-label="Clear query"
+              className="absolute right-1.5 inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          ) : null}
+        </div>
         <ViewSelect
           views={views}
           active={activeViewId}
@@ -206,6 +236,30 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
           </Button>
         </div>
       </header>
+      {/* Per-query feedback strip: searching spinner / parse error /
+          validate warnings / IPC error / hit count. Lives next to the
+          input (vs. in the status bar) because every line here is a
+          direct consequence of the query the user just typed. */}
+      <div className="flex items-center gap-3 border-b px-3 py-1 text-[0.625rem]">
+        {loading ? <span className="text-muted-foreground">searching…</span> : null}
+        {response?.parse_error ? (
+          <span className="text-destructive" title={response.parse_error.message}>
+            parse error: {response.parse_error.message}
+          </span>
+        ) : null}
+        {response?.warnings && response.warnings.length > 0 ? (
+          <span className="text-warning" title={response.warnings.join("\n")}>
+            {response.warnings.length} warning
+            {response.warnings.length === 1 ? "" : "s"}: {response.warnings.join("; ")}
+          </span>
+        ) : null}
+        {error ? <span className="text-destructive">{error}</span> : null}
+        {response && !response.parse_error ? (
+          <span className="ml-auto text-muted-foreground">
+            {response.hits.length} hit{response.hits.length === 1 ? "" : "s"}
+          </span>
+        ) : null}
+      </div>
       <div className="flex-1 overflow-auto">
         {response && !response.parse_error ? (
           display === "list" ? (

--- a/app/src/components/status-bar.tsx
+++ b/app/src/components/status-bar.tsx
@@ -13,16 +13,50 @@ import { ViolationBadges } from "@/components/violation-badges";
  * loading spinner) lives in the FlatView header next to the input
  * that produced it.
  */
+/** Maximum entries listed inside a violation-badge tooltip. Extra
+ *  files collapse into a `+N more` line so the OS-rendered tooltip
+ *  doesn't try to show 10k paths. */
+const TOOLTIP_FILE_LIMIT = 25;
+
+function listForTooltip(label: string, paths: string[]): string {
+  if (paths.length === 0) return "";
+  const head = paths.slice(0, TOOLTIP_FILE_LIMIT).join("\n");
+  const extra = paths.length - TOOLTIP_FILE_LIMIT;
+  const tail = extra > 0 ? `\n+${extra} more` : "";
+  return `${label} (${paths.length}):\n${head}${tail}`;
+}
+
 export function StatusBar() {
   const { project } = useProject();
   const summary = useFlatViewSummary();
   const totals = summary.violationTotals;
+  const files = summary.violationFiles;
   const hasViolations = totals.naming + totals.placement + totals.sequence > 0;
 
   return (
     <footer className="flex h-6 items-center gap-3 overflow-hidden border-t bg-card px-3 text-[0.625rem] text-muted-foreground">
-      {/* Left section can shrink (min-w-0 + shrink) so a long project
-          root doesn't push the right-side badges out of view. */}
+      {/* Violation badges go first — most prominent corner of the
+          window, easiest to glance at. ViolationBadges' optional
+          per-category title shows the contributing file paths on
+          hover (capped at TOOLTIP_FILE_LIMIT to keep the OS tooltip
+          manageable on huge projects). */}
+      <span className="flex shrink-0 items-center">
+        {hasViolations ? (
+          <ViolationBadges
+            counts={totals}
+            titles={{
+              naming: listForTooltip("naming violations", files.naming),
+              placement: listForTooltip("placement violations", files.placement),
+              sequence: listForTooltip("sequence violations", files.sequence),
+            }}
+          />
+        ) : (
+          <span className="text-foreground/60">no violations</span>
+        )}
+      </span>
+
+      {/* Project info shrinks (min-w-0 + truncate) so a long root
+          doesn't push the active-view chip off the right edge. */}
       {project ? (
         <span
           className="flex min-w-0 shrink items-center gap-1 truncate"
@@ -40,27 +74,13 @@ export function StatusBar() {
 
       {summary.activeView ? (
         <span
-          className="flex min-w-0 shrink items-center gap-1 truncate"
+          className="ml-auto flex min-w-0 shrink-0 items-center gap-1 truncate"
           title={summary.activeView.query}
         >
           <Eye className="size-3 shrink-0" />
           <span className="truncate">view: {summary.activeView.name}</span>
         </span>
       ) : null}
-
-      {/* Right section never shrinks — badges stay visible even when
-          the left side is wide. Reuses <ViolationBadges> so the colour
-          palette (naming amber / placement sky / sequence violet)
-          matches the per-row chips in the result list. */}
-      <span className="ml-auto flex shrink-0 items-center gap-2">
-        {hasViolations ? (
-          <span className="flex items-center">
-            <ViolationBadges counts={totals} />
-          </span>
-        ) : (
-          <span className="text-foreground/60">no violations</span>
-        )}
-      </span>
     </footer>
   );
 }

--- a/app/src/components/status-bar.tsx
+++ b/app/src/components/status-bar.tsx
@@ -42,32 +42,37 @@ export function StatusBar() {
 
   return (
     <footer className="flex h-6 items-center gap-3 overflow-hidden border-t bg-card px-3 text-[0.625rem] text-muted-foreground">
+      {/* Left section can shrink (min-w-0 + shrink) so a long project
+          root doesn't push the right-side badges out of view. */}
       {project ? (
         <span
-          className="flex min-w-0 items-center gap-1"
+          className="flex min-w-0 shrink items-center gap-1 truncate"
           title={project.root}
         >
-          <Folder className="size-3" />
+          <Folder className="size-3 shrink-0" />
           <span className="truncate font-medium text-foreground">{project.name}</span>
           <span className="hidden truncate sm:inline">— {project.root}</span>
         </span>
       ) : (
-        <span className="flex items-center gap-1 italic">
+        <span className="flex shrink-0 items-center gap-1 italic">
           <Folder className="size-3" /> No project attached
         </span>
       )}
 
       {summary.activeView ? (
         <span
-          className="flex min-w-0 items-center gap-1"
+          className="flex min-w-0 shrink items-center gap-1 truncate"
           title={summary.activeView.query}
         >
-          <Eye className="size-3" />
+          <Eye className="size-3 shrink-0" />
           <span className="truncate">view: {summary.activeView.name}</span>
         </span>
       ) : null}
 
-      <span className="ml-auto flex items-center gap-2">
+      {/* Right section never shrinks — badges + counts stay visible
+          even when the left side is wide. `gap-2` between badges,
+          `shrink-0` on the row so flex doesn't squeeze counts to 0. */}
+      <span className="ml-auto flex shrink-0 items-center gap-2">
         {summary.warnings.length > 0 ? (
           <Badge tone="warning" title={summary.warnings.join("\n")}>
             <AlertTriangle className="inline size-2.5" /> {summary.warnings.length}

--- a/app/src/components/status-bar.tsx
+++ b/app/src/components/status-bar.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { Folder, Loader2, Eye, AlertTriangle, AlertCircle } from "lucide-react";
+
+import { useProject } from "@/lib/project-context";
+import { useFlatViewSummary } from "@/lib/flat-view-context";
+
+/**
+ * Tiny inline badge used in the status bar for warning / error
+ * counts. Styled like the violation chips in `ViolationBadges` —
+ * rounded pill, semantic-token tinted background. Kept local to
+ * the status bar; if a third caller appears, hoist into the shared
+ * components directory.
+ */
+function Badge(props: {
+  tone: "warning" | "destructive";
+  title?: string;
+  children: React.ReactNode;
+}) {
+  const tones: Record<typeof props.tone, string> = {
+    warning: "bg-warning/15 text-warning",
+    destructive: "bg-destructive/15 text-destructive",
+  };
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 ${tones[props.tone]}`}
+      title={props.title}
+    >
+      {props.children}
+    </span>
+  );
+}
+
+/**
+ * Bottom-of-window status row. Always visible — no project shows
+ * "No project attached", a loaded project shows root + active view +
+ * hit summary + warnings. Read-only; actions live on the TopBar /
+ * inside the palette.
+ */
+export function StatusBar() {
+  const { project } = useProject();
+  const summary = useFlatViewSummary();
+
+  return (
+    <footer className="flex h-6 items-center gap-3 overflow-hidden border-t bg-card px-3 text-[0.625rem] text-muted-foreground">
+      {project ? (
+        <span
+          className="flex min-w-0 items-center gap-1"
+          title={project.root}
+        >
+          <Folder className="size-3" />
+          <span className="truncate font-medium text-foreground">{project.name}</span>
+          <span className="hidden truncate sm:inline">— {project.root}</span>
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 italic">
+          <Folder className="size-3" /> No project attached
+        </span>
+      )}
+
+      {summary.activeView ? (
+        <span
+          className="flex min-w-0 items-center gap-1"
+          title={summary.activeView.query}
+        >
+          <Eye className="size-3" />
+          <span className="truncate">view: {summary.activeView.name}</span>
+        </span>
+      ) : null}
+
+      <span className="ml-auto flex items-center gap-2">
+        {summary.warnings.length > 0 ? (
+          <Badge tone="warning" title={summary.warnings.join("\n")}>
+            <AlertTriangle className="inline size-2.5" /> {summary.warnings.length}
+          </Badge>
+        ) : null}
+        {summary.parseError ? (
+          <Badge tone="destructive" title={summary.parseError}>
+            <AlertCircle className="inline size-2.5" /> parse error
+          </Badge>
+        ) : null}
+        {summary.error ? (
+          <Badge tone="destructive" title={summary.error}>
+            <AlertCircle className="inline size-2.5" /> error
+          </Badge>
+        ) : null}
+        {summary.loading ? (
+          <span className="flex items-center gap-1">
+            <Loader2 className="size-3 animate-spin" /> searching…
+          </span>
+        ) : summary.hitCount !== null ? (
+          <span>
+            {summary.hitCount.toLocaleString()} hit
+            {summary.hitCount === 1 ? "" : "s"}
+          </span>
+        ) : null}
+      </span>
+    </footer>
+  );
+}

--- a/app/src/components/status-bar.tsx
+++ b/app/src/components/status-bar.tsx
@@ -1,44 +1,23 @@
-import * as React from "react";
-import { Folder, Loader2, Eye, AlertTriangle, AlertCircle } from "lucide-react";
+import { Folder, Eye } from "lucide-react";
 
 import { useProject } from "@/lib/project-context";
 import { useFlatViewSummary } from "@/lib/flat-view-context";
-
-/**
- * Tiny inline badge used in the status bar for warning / error
- * counts. Styled like the violation chips in `ViolationBadges` —
- * rounded pill, semantic-token tinted background. Kept local to
- * the status bar; if a third caller appears, hoist into the shared
- * components directory.
- */
-function Badge(props: {
-  tone: "warning" | "destructive";
-  title?: string;
-  children: React.ReactNode;
-}) {
-  const tones: Record<typeof props.tone, string> = {
-    warning: "bg-warning/15 text-warning",
-    destructive: "bg-destructive/15 text-destructive",
-  };
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 ${tones[props.tone]}`}
-      title={props.title}
-    >
-      {props.children}
-    </span>
-  );
-}
+import { ViolationBadges } from "@/components/violation-badges";
 
 /**
  * Bottom-of-window status row. Always visible — no project shows
  * "No project attached", a loaded project shows root + active view +
- * hit summary + warnings. Read-only; actions live on the TopBar /
- * inside the palette.
+ * aggregate violation badges across the current FlatView result set.
+ * Read-only; actions live on the TopBar / inside the palette, and
+ * per-query feedback (parse error, warnings, IPC error, hit count,
+ * loading spinner) lives in the FlatView header next to the input
+ * that produced it.
  */
 export function StatusBar() {
   const { project } = useProject();
   const summary = useFlatViewSummary();
+  const totals = summary.violationTotals;
+  const hasViolations = totals.naming + totals.placement + totals.sequence > 0;
 
   return (
     <footer className="flex h-6 items-center gap-3 overflow-hidden border-t bg-card px-3 text-[0.625rem] text-muted-foreground">
@@ -69,35 +48,18 @@ export function StatusBar() {
         </span>
       ) : null}
 
-      {/* Right section never shrinks — badges + counts stay visible
-          even when the left side is wide. `gap-2` between badges,
-          `shrink-0` on the row so flex doesn't squeeze counts to 0. */}
+      {/* Right section never shrinks — badges stay visible even when
+          the left side is wide. Reuses <ViolationBadges> so the colour
+          palette (naming amber / placement sky / sequence violet)
+          matches the per-row chips in the result list. */}
       <span className="ml-auto flex shrink-0 items-center gap-2">
-        {summary.warnings.length > 0 ? (
-          <Badge tone="warning" title={summary.warnings.join("\n")}>
-            <AlertTriangle className="inline size-2.5" /> {summary.warnings.length}
-          </Badge>
-        ) : null}
-        {summary.parseError ? (
-          <Badge tone="destructive" title={summary.parseError}>
-            <AlertCircle className="inline size-2.5" /> parse error
-          </Badge>
-        ) : null}
-        {summary.error ? (
-          <Badge tone="destructive" title={summary.error}>
-            <AlertCircle className="inline size-2.5" /> error
-          </Badge>
-        ) : null}
-        {summary.loading ? (
-          <span className="flex items-center gap-1">
-            <Loader2 className="size-3 animate-spin" /> searching…
+        {hasViolations ? (
+          <span className="flex items-center">
+            <ViolationBadges counts={totals} />
           </span>
-        ) : summary.hitCount !== null ? (
-          <span>
-            {summary.hitCount.toLocaleString()} hit
-            {summary.hitCount === 1 ? "" : "s"}
-          </span>
-        ) : null}
+        ) : (
+          <span className="text-foreground/60">no violations</span>
+        )}
       </span>
     </footer>
   );

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/app/src/components/violation-badges.tsx
+++ b/app/src/components/violation-badges.tsx
@@ -1,20 +1,28 @@
+import * as React from "react";
 import { Triangle, Hash } from "lucide-react";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { RichViolationCounts } from "@/lib/ipc";
 
 /**
  * Full violation badges with category icon + count. Designed for
  * inline rows where horizontal space is plentiful (palette results,
- * flat list).
+ * flat list, status bar).
  *
  * Colors come from semantic tokens defined in `index.css`
  * (`--badge-naming` / `--badge-placement` / `--badge-sequence`) so
  * dark mode swaps one variable instead of every utility — see
  * `customization.md §Dark Mode` in the shadcn skill for the rule.
  *
- * Optional `titles` populates a `title=` tooltip per category — the
- * status bar uses this to show which files contributed to each
- * count on hover.
+ * Optional `titles` wraps each badge in a shadcn `<Tooltip>` whose
+ * content is the supplied (often multi-line) string. Status bar
+ * uses this to surface the contributing files on hover. Callers
+ * that don't pass `titles` get a plain badge — no Tooltip wrapper,
+ * no behavioral cost.
  */
 export function ViolationBadges({
   counts,
@@ -28,30 +36,51 @@ export function ViolationBadges({
   return (
     <span className="ml-auto flex items-center gap-1 text-[0.625rem] tracking-wide">
       {counts.naming > 0 ? (
-        <span
-          className="rounded bg-badge-naming/15 px-1 py-0.5 text-badge-naming"
-          title={titles?.naming}
-        >
-          <Triangle className="inline size-2.5" /> {counts.naming}
-        </span>
+        <Badge tooltip={titles?.naming}>
+          <span className="rounded bg-badge-naming/15 px-1 py-0.5 text-badge-naming">
+            <Triangle className="inline size-2.5" /> {counts.naming}
+          </span>
+        </Badge>
       ) : null}
       {counts.placement > 0 ? (
-        <span
-          className="rounded bg-badge-placement/15 px-1 py-0.5 text-badge-placement"
-          title={titles?.placement}
-        >
-          <Hash className="inline size-2.5" /> {counts.placement}
-        </span>
+        <Badge tooltip={titles?.placement}>
+          <span className="rounded bg-badge-placement/15 px-1 py-0.5 text-badge-placement">
+            <Hash className="inline size-2.5" /> {counts.placement}
+          </span>
+        </Badge>
       ) : null}
       {counts.sequence > 0 ? (
-        <span
-          className="rounded bg-badge-sequence/15 px-1 py-0.5 text-badge-sequence"
-          title={titles?.sequence}
-        >
-          ≡ {counts.sequence}
-        </span>
+        <Badge tooltip={titles?.sequence}>
+          <span className="rounded bg-badge-sequence/15 px-1 py-0.5 text-badge-sequence">
+            ≡ {counts.sequence}
+          </span>
+        </Badge>
       ) : null}
     </span>
+  );
+}
+
+/**
+ * Wrap `children` in a shadcn Tooltip when `tooltip` is non-empty,
+ * otherwise pass `children` straight through. Keeps the badge JSX
+ * above linear and avoids spinning up a Tooltip portal for every
+ * row in dense lists where no tooltip is configured.
+ */
+function Badge({
+  tooltip,
+  children,
+}: {
+  tooltip: string | undefined;
+  children: React.ReactNode;
+}) {
+  if (!tooltip) return <>{children}</>;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent className="max-w-md font-mono whitespace-pre-line text-[0.625rem]">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/app/src/components/violation-badges.tsx
+++ b/app/src/components/violation-badges.tsx
@@ -11,24 +11,43 @@ import type { RichViolationCounts } from "@/lib/ipc";
  * (`--badge-naming` / `--badge-placement` / `--badge-sequence`) so
  * dark mode swaps one variable instead of every utility — see
  * `customization.md §Dark Mode` in the shadcn skill for the rule.
+ *
+ * Optional `titles` populates a `title=` tooltip per category — the
+ * status bar uses this to show which files contributed to each
+ * count on hover.
  */
-export function ViolationBadges({ counts }: { counts: RichViolationCounts }) {
+export function ViolationBadges({
+  counts,
+  titles,
+}: {
+  counts: RichViolationCounts;
+  titles?: { naming?: string; placement?: string; sequence?: string };
+}) {
   const total = counts.naming + counts.placement + counts.sequence;
   if (total === 0) return null;
   return (
     <span className="ml-auto flex items-center gap-1 text-[0.625rem] tracking-wide">
       {counts.naming > 0 ? (
-        <span className="rounded bg-badge-naming/15 px-1 py-0.5 text-badge-naming">
+        <span
+          className="rounded bg-badge-naming/15 px-1 py-0.5 text-badge-naming"
+          title={titles?.naming}
+        >
           <Triangle className="inline size-2.5" /> {counts.naming}
         </span>
       ) : null}
       {counts.placement > 0 ? (
-        <span className="rounded bg-badge-placement/15 px-1 py-0.5 text-badge-placement">
+        <span
+          className="rounded bg-badge-placement/15 px-1 py-0.5 text-badge-placement"
+          title={titles?.placement}
+        >
           <Hash className="inline size-2.5" /> {counts.placement}
         </span>
       ) : null}
       {counts.sequence > 0 ? (
-        <span className="rounded bg-badge-sequence/15 px-1 py-0.5 text-badge-sequence">
+        <span
+          className="rounded bg-badge-sequence/15 px-1 py-0.5 text-badge-sequence"
+          title={titles?.sequence}
+        >
           ≡ {counts.sequence}
         </span>
       ) : null}

--- a/app/src/lib/flat-view-context.tsx
+++ b/app/src/lib/flat-view-context.tsx
@@ -1,12 +1,19 @@
 import * as React from "react";
 
-import type { View } from "@/lib/ipc";
+import type { RichViolationCounts, View } from "@/lib/ipc";
 
 /**
- * Cross-component summary of the FlatView's current state, lifted
- * out of `<FlatView>` so the bottom status bar can render the same
- * "searching… / 1234 hits / warnings" indicators without duplicating
- * the search effect.
+ * Cross-component summary of project-level state surfaced by the
+ * FlatView, lifted out of `<FlatView>` so the bottom status bar can
+ * render the same "active view / total violations" indicators
+ * without duplicating the search effect.
+ *
+ * Per-query feedback (parse error, validate warnings, IPC error,
+ * hit count, loading spinner) lives inside `<FlatView>`'s own
+ * header — those belong next to the input that produced them.
+ * Cross-cutting health indicators (project info, saved view,
+ * aggregate violation counts) live in the status bar so the user
+ * can glance at them regardless of which panel has focus.
  *
  * `<FlatView>` still owns the underlying state — query, response,
  * saved-view selection, debouncer — and `<StatusBar>` is a passive
@@ -18,28 +25,19 @@ import type { View } from "@/lib/ipc";
  *   3. `<StatusBar>` calls `useFlatViewSummary()` to render.
  */
 export type FlatViewSummary = {
-  /** True while the search effect is in flight. */
-  loading: boolean;
-  /** Total hits in the current response. `null` when no response is
-   *  loaded (e.g. before the first fetch on a fresh project). */
-  hitCount: number | null;
-  /** Validate-stage warnings (`unknown_key`, `type_and_multi`, …). */
-  warnings: string[];
-  /** Parse error message, if the current query failed to parse. */
-  parseError: string | null;
-  /** IPC-level error (e.g. `no_project`, sqlite errors). */
-  error: string | null;
   /** Saved view currently driving the FlatView, if any. */
   activeView: View | null;
+  /** Sum of naming / placement / sequence violations across the
+   *  current FlatView result set. When the query is empty (showing
+   *  every file) this acts as the project-wide health summary;
+   *  when filtered, it shows the violation count within that
+   *  filter — useful for "how many psd files still have violations". */
+  violationTotals: RichViolationCounts;
 };
 
 const DEFAULT_SUMMARY: FlatViewSummary = {
-  loading: false,
-  hitCount: null,
-  warnings: [],
-  parseError: null,
-  error: null,
   activeView: null,
+  violationTotals: { naming: 0, placement: 0, sequence: 0 },
 };
 
 const SummaryContext = React.createContext<FlatViewSummary>(DEFAULT_SUMMARY);

--- a/app/src/lib/flat-view-context.tsx
+++ b/app/src/lib/flat-view-context.tsx
@@ -33,11 +33,20 @@ export type FlatViewSummary = {
    *  when filtered, it shows the violation count within that
    *  filter — useful for "how many psd files still have violations". */
   violationTotals: RichViolationCounts;
+  /** Per-category list of file paths that contributed to the totals
+   *  above, so the status bar can surface them on hover. Sorted in
+   *  the same order they appear in the FlatView results. */
+  violationFiles: {
+    naming: string[];
+    placement: string[];
+    sequence: string[];
+  };
 };
 
 const DEFAULT_SUMMARY: FlatViewSummary = {
   activeView: null,
   violationTotals: { naming: 0, placement: 0, sequence: 0 },
+  violationFiles: { naming: [], placement: [], sequence: [] },
 };
 
 const SummaryContext = React.createContext<FlatViewSummary>(DEFAULT_SUMMARY);

--- a/app/src/lib/flat-view-context.tsx
+++ b/app/src/lib/flat-view-context.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+import type { View } from "@/lib/ipc";
+
+/**
+ * Cross-component summary of the FlatView's current state, lifted
+ * out of `<FlatView>` so the bottom status bar can render the same
+ * "searching… / 1234 hits / warnings" indicators without duplicating
+ * the search effect.
+ *
+ * `<FlatView>` still owns the underlying state — query, response,
+ * saved-view selection, debouncer — and `<StatusBar>` is a passive
+ * consumer. The contract is:
+ *
+ *   1. `<App>` wraps everything in `<FlatViewSummaryProvider>`.
+ *   2. `<FlatView>` calls `useReportFlatView()` and pushes a fresh
+ *      summary on every state change via `useEffect`.
+ *   3. `<StatusBar>` calls `useFlatViewSummary()` to render.
+ */
+export type FlatViewSummary = {
+  /** True while the search effect is in flight. */
+  loading: boolean;
+  /** Total hits in the current response. `null` when no response is
+   *  loaded (e.g. before the first fetch on a fresh project). */
+  hitCount: number | null;
+  /** Validate-stage warnings (`unknown_key`, `type_and_multi`, …). */
+  warnings: string[];
+  /** Parse error message, if the current query failed to parse. */
+  parseError: string | null;
+  /** IPC-level error (e.g. `no_project`, sqlite errors). */
+  error: string | null;
+  /** Saved view currently driving the FlatView, if any. */
+  activeView: View | null;
+};
+
+const DEFAULT_SUMMARY: FlatViewSummary = {
+  loading: false,
+  hitCount: null,
+  warnings: [],
+  parseError: null,
+  error: null,
+  activeView: null,
+};
+
+const SummaryContext = React.createContext<FlatViewSummary>(DEFAULT_SUMMARY);
+const ReportContext = React.createContext<(patch: Partial<FlatViewSummary>) => void>(
+  () => {},
+);
+
+export function FlatViewSummaryProvider({ children }: { children: React.ReactNode }) {
+  const [summary, setSummary] = React.useState<FlatViewSummary>(DEFAULT_SUMMARY);
+  const report = React.useCallback(
+    (patch: Partial<FlatViewSummary>) => {
+      // Functional update so multiple reports inside one tick don't
+      // clobber each other.
+      setSummary((prev) => ({ ...prev, ...patch }));
+    },
+    [],
+  );
+  return (
+    <SummaryContext.Provider value={summary}>
+      <ReportContext.Provider value={report}>{children}</ReportContext.Provider>
+    </SummaryContext.Provider>
+  );
+}
+
+export function useFlatViewSummary(): FlatViewSummary {
+  return React.useContext(SummaryContext);
+}
+
+export function useReportFlatView(): (patch: Partial<FlatViewSummary>) => void {
+  return React.useContext(ReportContext);
+}


### PR DESCRIPTION
## Summary
Add a persistent bottom status row (`<StatusBar>`) so the FlatView header doesn't have to double as both toolbar and indicator strip, and the user always has the project + violation health summary in the same place. While here, give the search input a clear button + Esc-to-clear shortcut.

## Layout split (per design feedback during the PR)
| Surface              | Content                                                              |
| ---                  | ---                                                                  |
| StatusBar (left)     | Aggregate violation badges (naming / placement / sequence)           |
| StatusBar (center)   | Project name + root path                                             |
| StatusBar (right)    | `view: <name>` chip when a saved view is active                      |
| StatusBar (no-proj)  | "No project attached"                                                |
| FlatView header      | searching… / parse error / validate warnings / IPC error / hit count |

Per-query feedback stays inside FlatView next to the input that produced it; cross-cutting health (project, view, totals) lives in the status bar.

## Status bar specifics
- Reuses `<ViolationBadges>` so the colour palette (naming amber / placement sky / sequence violet) matches the per-row chips. Empty result-set shows a quiet "no violations" instead of an empty corner.
- **Hover a category badge** to see the contributing file paths — capped at 25 entries with a `+N more` tail so projects with thousands of violations don't break the OS tooltip.
- Layout uses `min-w-0 shrink truncate` on the project section + `shrink-0` on the badge / view-chip rows so a long project root never pushes the badges off-screen.

## State plumbing (`flat-view-context.tsx`)
- New `<FlatViewSummaryProvider>` + `useFlatViewSummary()` / `useReportFlatView()` hooks.
- FlatView pushes `{ activeView, violationTotals, violationFiles }` on every state change via `useEffect`. StatusBar is a passive consumer.
- File lists for the tooltip are populated by the same reducer that computes the numeric totals — single pass over `response.hits`.

## Input UX
- Trailing `<X>` icon button inside the search input clears the query and decouples from any active saved view.
- Esc keyboard handler does the same when the input is focused and non-empty (so it doesn't fight Esc-to-close on the surrounding palette / dialogs).
- Placeholder updated to mention "Esc to clear".

## Test plan
- [x] `mise run check` green
- [x] `pnpm --filter @progest/app build` green (~319 KB / 99 KB gzip)
- [ ] `tauri dev` smoke — open a project with known violations, confirm badges on the left, hover each → file list tooltip; type a query that filters to a subset, badge counts shrink; Esc / clear button empties the input and switches back to "all files" mode. **Not yet executed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)