### PR TITLE
fix(app): widen command palette to max-w-2xl

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"61f9a284-784c-4069-8880-663fc999d2d1","pid":99691,"procStart":"Tue Apr 28 01:50:32 2026","acquiredAt":1777346823593}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"61f9a284-784c-4069-8880-663fc999d2d1","pid":99691,"procStart":"Tue Apr 28 01:50:32 2026","acquiredAt":1777346823593}

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ desktop.ini
 .progest/thumbs
 .progest/local
 
+# Claude Code per-user agent state.
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
 # Local scratch
 /scratch
 /tmp

--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -161,6 +161,10 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
         onOpenChange={setOpen}
         title="Search"
         description="Find files by tag, type, name, or arbitrary DSL query."
+        // Override the shadcn `sm:max-w-sm` default — palette hits and
+        // long DSL queries need more horizontal room than a confirm
+        // dialog. `2xl` ≈ 672 px matches the Linear / Raycast feel.
+        className="sm:max-w-2xl"
       >
         <Command shouldFilter={false}>
           <CommandInput


### PR DESCRIPTION
## Summary

- Override the shadcn Dialog default `sm:max-w-sm` (~384 px) on the command palette: long DSL queries and hit rows with paths + violation badges need more horizontal room.
- New width: `sm:max-w-2xl` (~672 px), matching the Linear / Raycast feel.
- Cleanup: gitignore `.claude/scheduled_tasks.lock` (and `settings.local.json`) — a per-user agent runtime file that slipped into the previous commit.

## Test plan
- [x] `pnpm --filter @progest/app check` + `build` green
- [x] `tauri dev` smoke: Cmd+K opens the palette at the new width, results render with breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)