### PR TITLE
feat(app): suggest aliases and project extensions in accepts editor

### DIFF
--- a/app/src/components/directory-inspector.tsx
+++ b/app/src/components/directory-inspector.tsx
@@ -1,22 +1,32 @@
 import * as React from "react";
-import { Check, ChevronUp, Plus, Trash2, X } from "lucide-react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Check, Plus, Trash2, X } from "lucide-react";
 
 import {
   acceptsRead,
   acceptsWrite,
+  extensionsCatalog,
   IpcError,
   lintRun,
   type AcceptsMode,
   type AcceptsReadResponse,
   type AcceptsToken,
   type AliasEntry,
+  type ExtensionSummary,
   type RawAccepts,
 } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -33,6 +43,7 @@ export function DirectoryInspector(props: { dir: string }) {
   const dir = props.dir;
   const [data, setData] = React.useState<AcceptsReadResponse | null>(null);
   const [draft, setDraft] = React.useState<RawAccepts | null>(null);
+  const [extensions, setExtensions] = React.useState<ExtensionSummary[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -43,8 +54,9 @@ export function DirectoryInspector(props: { dir: string }) {
     setLoading(true);
     setError(null);
     try {
-      const res = await acceptsRead(dir);
+      const [res, exts] = await Promise.all([acceptsRead(dir), extensionsCatalog()]);
       setData(res);
+      setExtensions(exts);
       // Initialize draft from server. Cloning to a fresh object so the
       // chip input mutates a draft copy, not the snapshot we render the
       // "Effective" section from.
@@ -54,6 +66,7 @@ export function DirectoryInspector(props: { dir: string }) {
       setError(msg);
       setData(null);
       setDraft(null);
+      setExtensions([]);
     } finally {
       setLoading(false);
     }
@@ -144,6 +157,7 @@ export function DirectoryInspector(props: { dir: string }) {
               draft={draft}
               setDraft={setDraft}
               aliases={aliases}
+              extensions={extensions}
               onDeclareEmpty={onDeclareEmpty}
               onClearAccepts={onClearAccepts}
             />
@@ -242,10 +256,11 @@ function OwnSection(props: {
   draft: RawAccepts | null;
   setDraft: (next: RawAccepts | null) => void;
   aliases: AliasEntry[];
+  extensions: ExtensionSummary[];
   onDeclareEmpty: () => void;
   onClearAccepts: () => void;
 }) {
-  const { draft, setDraft, aliases, onDeclareEmpty, onClearAccepts } = props;
+  const { draft, setDraft, aliases, extensions, onDeclareEmpty, onClearAccepts } = props;
 
   if (!draft) {
     return (
@@ -281,6 +296,7 @@ function OwnSection(props: {
         <ExtsEditor
           tokens={draft.exts}
           aliases={aliases}
+          extensions={extensions}
           onChange={(next) => setDraft({ ...draft, exts: next })}
         />
 
@@ -326,49 +342,49 @@ function OwnSection(props: {
 function ExtsEditor(props: {
   tokens: AcceptsToken[];
   aliases: AliasEntry[];
+  extensions: ExtensionSummary[];
   onChange: (next: AcceptsToken[]) => void;
 }) {
-  const { tokens, aliases, onChange } = props;
+  const { tokens, aliases, extensions, onChange } = props;
   const [input, setInput] = React.useState("");
-  const [error, setError] = React.useState<string | null>(null);
-  const [aliasMenu, setAliasMenu] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   function add(token: AcceptsToken) {
-    setError(null);
     if (containsToken(tokens, token)) return;
     onChange([...tokens, token]);
+    setInput("");
   }
 
   function remove(idx: number) {
     onChange(tokens.filter((_, i) => i !== idx));
   }
 
-  function commit() {
-    const raw = input.trim();
-    if (raw === "") return;
-    const parsed = parseTokenInput(raw);
-    if (!parsed) {
-      setError(`Invalid entry "${raw}". Use ".psd", ":image", or "" for no-extension.`);
-      return;
-    }
-    add(parsed);
-    setInput("");
-  }
+  // Project extensions that aren't already a token. The dedicated
+  // no-extension item below covers `value: ""`, so we filter empties
+  // out here too.
+  const projectExtSuggestions = extensions
+    .filter((e) => e.ext !== "")
+    .filter((e) => !containsToken(tokens, { type: "ext", value: e.ext }));
+
+  const trimmed = input.trim();
+  const typedToken = parseTokenInput(trimmed);
+  const hasNoExtToken = containsToken(tokens, { type: "ext", value: "" });
+  // Only show "Add new" when the typed entry parses and isn't already
+  // discoverable via the suggestion groups (otherwise it duplicates).
+  const showCustom =
+    typedToken !== null &&
+    !containsToken(tokens, typedToken) &&
+    !(typedToken.type === "alias" && aliases.some((a) => a.name === typedToken.name)) &&
+    !(
+      typedToken.type === "ext" &&
+      typedToken.value !== "" &&
+      projectExtSuggestions.some((e) => e.ext === typedToken.value)
+    );
 
   return (
     <div className="grid gap-1">
-      <div className="flex items-center justify-between">
-        <span className="text-muted-foreground">Extensions</span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setAliasMenu((v) => !v)}
-          title="Add a category alias"
-        >
-          {aliasMenu ? <ChevronUp /> : <Plus />}
-          Alias…
-        </Button>
-      </div>
+      <span className="text-muted-foreground">Extensions</span>
 
       {tokens.length === 0 ? (
         <div className="text-muted-foreground">
@@ -396,60 +412,131 @@ function ExtsEditor(props: {
         </ul>
       )}
 
-      <div className="flex items-center gap-1">
-        <Input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
+      <Popover open={open} onOpenChange={setOpen}>
+        <Command
+          shouldFilter
+          className="overflow-visible bg-transparent p-0"
+          // Without this, cmdk swallows Escape — but Radix Popover
+          // already handles Escape, and we want it to close the
+          // dropdown rather than no-op.
           onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commit();
-            }
+            if (e.key === "Escape") setOpen(false);
           }}
-          placeholder=".psd, :image, or empty for no-extension"
-          className="h-7 text-xs"
-        />
-        <Button variant="outline" size="sm" onClick={commit} disabled={input.trim() === ""}>
-          Add
-        </Button>
-      </div>
-      {error ? <div className="text-destructive">{error}</div> : null}
+        >
+          <PopoverAnchor asChild>
+            <CommandPrimitive.Input
+              ref={inputRef}
+              value={input}
+              onValueChange={setInput}
+              onFocus={() => setOpen(true)}
+              onMouseDown={() => setOpen(true)}
+              placeholder=".psd, :image, or pick from below"
+              className={cn(
+                "flex h-7 w-full rounded-md border border-input bg-transparent px-2 text-xs",
+                "placeholder:text-muted-foreground focus-visible:outline-hidden",
+                "focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            />
+          </PopoverAnchor>
+          <PopoverContent
+            align="start"
+            sideOffset={4}
+            className="w-[var(--radix-popover-trigger-width)] min-w-64 p-0"
+            // Keep focus on the input; the popover content is just a
+            // dropdown surface.
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            // Without this Radix treats clicks/focus on the anchored
+            // input as "outside" the popover and closes it. The dropdown
+            // is conceptually attached to the input, so suppress close
+            // when the interaction target is the input itself. Covers
+            // both pointerdown (mouse click) and focus (tab into input)
+            // via the unified onInteractOutside hook.
+            onInteractOutside={(e) => {
+              const target = e.target;
+              if (target instanceof Node && inputRef.current && inputRef.current.contains(target)) {
+                e.preventDefault();
+              }
+            }}
+          >
+            <CommandList className="max-h-64">
+              <CommandEmpty>No matching alias or extension.</CommandEmpty>
 
-      {aliasMenu ? (
-        <div className="rounded border bg-popover p-1">
-          {aliases.length === 0 ? (
-            <div className="px-2 py-1 text-muted-foreground">No aliases registered.</div>
-          ) : (
-            <ul className="grid max-h-40 gap-0.5 overflow-auto">
-              {aliases.map((a) => {
-                const already = tokens.some((t) => t.type === "alias" && t.name === a.name);
-                return (
-                  <li key={a.name}>
-                    <button
-                      type="button"
-                      className="grid w-full grid-cols-[1fr_auto] items-center gap-2 rounded px-2 py-1 text-left hover:bg-accent disabled:opacity-50"
-                      disabled={already}
-                      onClick={() => add({ type: "alias", name: a.name })}
+              {showCustom && typedToken ? (
+                <CommandGroup heading="New">
+                  <CommandItem
+                    value={`__custom__:${trimmed}`}
+                    keywords={[trimmed]}
+                    onSelect={() => add(typedToken)}
+                  >
+                    <Plus />
+                    <span>
+                      Add <span className="font-medium">{tokenLabel(typedToken)}</span>
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              ) : null}
+
+              <CommandGroup heading="Special">
+                <CommandItem
+                  value="(no extension) noext nothing none"
+                  disabled={hasNoExtToken}
+                  onSelect={() => add({ type: "ext", value: "" })}
+                >
+                  <span>(no extension)</span>
+                  <span className="ml-auto text-[0.625rem] text-muted-foreground">
+                    files without an extension
+                  </span>
+                </CommandItem>
+              </CommandGroup>
+
+              {aliases.length > 0 ? (
+                <CommandGroup heading="Aliases">
+                  {aliases.map((a) => {
+                    const already = tokens.some((t) => t.type === "alias" && t.name === a.name);
+                    return (
+                      <CommandItem
+                        key={`alias-${a.name}`}
+                        value={`:${a.name}`}
+                        disabled={already}
+                        onSelect={() => add({ type: "alias", name: a.name })}
+                      >
+                        <span>
+                          :{a.name}
+                          {a.builtin ? null : (
+                            <span className="ml-1 text-[0.625rem] text-muted-foreground">
+                              (project)
+                            </span>
+                          )}
+                        </span>
+                        <span className="ml-auto text-[0.625rem] text-muted-foreground">
+                          {a.exts.length} ext{a.exts.length === 1 ? "" : "s"}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              ) : null}
+
+              {projectExtSuggestions.length > 0 ? (
+                <CommandGroup heading="In project">
+                  {projectExtSuggestions.map((e) => (
+                    <CommandItem
+                      key={`ext-${e.ext}`}
+                      value={`.${e.ext}`}
+                      onSelect={() => add({ type: "ext", value: e.ext })}
                     >
-                      <span>
-                        :{a.name}
-                        {a.builtin ? null : (
-                          <span className="ml-1 text-[0.625rem] text-muted-foreground">
-                            (project)
-                          </span>
-                        )}
+                      <span>.{e.ext}</span>
+                      <span className="ml-auto text-[0.625rem] text-muted-foreground">
+                        {e.count}
                       </span>
-                      <span className="truncate text-[0.625rem] text-muted-foreground">
-                        {a.exts.length} ext{a.exts.length === 1 ? "" : "s"}
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      ) : null}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              ) : null}
+            </CommandList>
+          </PopoverContent>
+        </Command>
+      </Popover>
     </div>
   );
 }

--- a/app/src/components/directory-inspector.tsx
+++ b/app/src/components/directory-inspector.tsx
@@ -24,6 +24,7 @@ import {
   CommandGroup,
   CommandItem,
   CommandList,
+  CommandShortcut,
 } from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
@@ -483,9 +484,7 @@ function ExtsEditor(props: {
                   onSelect={() => add({ type: "ext", value: "" })}
                 >
                   <span>(no extension)</span>
-                  <span className="ml-auto text-[0.625rem] text-muted-foreground">
-                    files without an extension
-                  </span>
+                  <CommandShortcut>files without an extension</CommandShortcut>
                 </CommandItem>
               </CommandGroup>
 
@@ -508,9 +507,9 @@ function ExtsEditor(props: {
                             </span>
                           )}
                         </span>
-                        <span className="ml-auto text-[0.625rem] text-muted-foreground">
+                        <CommandShortcut>
                           {a.exts.length} ext{a.exts.length === 1 ? "" : "s"}
-                        </span>
+                        </CommandShortcut>
                       </CommandItem>
                     );
                   })}
@@ -526,9 +525,7 @@ function ExtsEditor(props: {
                       onSelect={() => add({ type: "ext", value: e.ext })}
                     >
                       <span>.{e.ext}</span>
-                      <span className="ml-auto text-[0.625rem] text-muted-foreground">
-                        {e.count}
-                      </span>
+                      <CommandShortcut>{e.count}</CommandShortcut>
                     </CommandItem>
                   ))}
                 </CommandGroup>

--- a/app/src/components/ui/popover.tsx
+++ b/app/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-4 rounded-lg bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -205,6 +205,19 @@ export async function filesListAll(): Promise<RichSearchHit[]> {
   }
 }
 
+export type ExtensionSummary = {
+  ext: string;
+  count: number;
+};
+
+export async function extensionsCatalog(): Promise<ExtensionSummary[]> {
+  try {
+    return await invoke<ExtensionSummary[]>("extensions_catalog");
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- accepts (directory inspector) ----------------------------------------
 
 // Tagged-union mirror of `AcceptsTokenWire` in

--- a/crates/progest-core/src/index/mod.rs
+++ b/crates/progest-core/src/index/mod.rs
@@ -24,6 +24,6 @@ pub use error::IndexError;
 pub use migration::{MIGRATIONS, Migration, MigrationError, apply, current_version};
 pub use row::FileRow;
 pub use store::{
-    CustomFieldEntry, CustomFieldValue, Index, RichRow, SearchProjection, SqliteIndex,
-    ViolationCounts, ViolationRecord,
+    CustomFieldEntry, CustomFieldValue, ExtensionSummary, Index, RichRow, SearchProjection,
+    SqliteIndex, ViolationCounts, ViolationRecord,
 };

--- a/crates/progest-core/src/index/store.rs
+++ b/crates/progest-core/src/index/store.rs
@@ -201,6 +201,43 @@ impl SqliteIndex {
     pub fn with_connection<R>(&self, f: impl FnOnce(&Connection) -> R) -> R {
         self.with_conn(f)
     }
+
+    /// Distinct file extensions present in the index, each paired with the
+    /// number of files carrying it. Extensions are normalized to the form
+    /// stored by reconcile (lowercase, no leading dot), and rows whose
+    /// `ext` is NULL are skipped — files without an extension surface
+    /// through the dedicated empty-token UX rather than this list. Result
+    /// is ordered by descending count so the combobox surfaces the most
+    /// common extensions first.
+    pub fn extensions_summary(&self) -> Result<Vec<ExtensionSummary>, IndexError> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT ext, COUNT(*) AS n \
+                 FROM files \
+                 WHERE ext IS NOT NULL AND ext <> '' \
+                 GROUP BY ext \
+                 ORDER BY n DESC, ext ASC",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok(ExtensionSummary {
+                    ext: row.get::<_, String>(0)?,
+                    count: row.get::<_, i64>(1)?,
+                })
+            })?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r?);
+            }
+            Ok(out)
+        })
+    }
+}
+
+/// One row of [`SqliteIndex::extensions_summary`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionSummary {
+    pub ext: String,
+    pub count: i64,
 }
 
 const UPSERT_SQL: &str = "\
@@ -788,6 +825,55 @@ mod tests {
 
         let tags = idx.list_tags_for_file(&row.file_id).unwrap();
         assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn extensions_summary_groups_and_sorts_by_count() {
+        let idx = SqliteIndex::open_in_memory().unwrap();
+
+        // Insert three files: two .psd, one .mov. Use the search-projection
+        // path so this also exercises the read path the UI sees.
+        for (path, ext) in [
+            ("a.psd", Some("psd")),
+            ("b.psd", Some("psd")),
+            ("c.mov", Some("mov")),
+            ("d.unknown", None),
+        ] {
+            let mut r = sample_row();
+            r.file_id = FileId::new_v7();
+            r.path = ProjectPath::new(path).unwrap();
+            idx.upsert_file(&r).unwrap();
+            idx.set_search_projection(
+                &r.file_id,
+                &SearchProjection {
+                    name: Some(path.into()),
+                    ext: ext.map(str::to_string),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+
+        let summary = idx.extensions_summary().unwrap();
+        assert_eq!(
+            summary,
+            vec![
+                ExtensionSummary {
+                    ext: "psd".into(),
+                    count: 2
+                },
+                ExtensionSummary {
+                    ext: "mov".into(),
+                    count: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn extensions_summary_is_empty_for_empty_index() {
+        let idx = SqliteIndex::open_in_memory().unwrap();
+        assert!(idx.extensions_summary().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/progest-tauri/src/commands.rs
+++ b/crates/progest-tauri/src/commands.rs
@@ -372,6 +372,34 @@ pub fn files_list_all(state: State<'_, AppState>) -> Result<Vec<RichSearchHit>, 
     Ok(rich)
 }
 
+/// One row of [`extensions_catalog`].
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtensionSummaryWire {
+    pub ext: String,
+    pub count: i64,
+}
+
+/// Distinct file extensions present in the index plus their occurrence
+/// counts. The accepts editor combobox shows these as suggestions so
+/// the user can pick an extension already in use without typing.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn extensions_catalog(state: State<'_, AppState>) -> Result<Vec<ExtensionSummaryWire>, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+    let rows = ctx
+        .index
+        .extensions_summary()
+        .map_err(|e| format!("extensions: {e}"))?;
+    Ok(rows
+        .into_iter()
+        .map(|r| ExtensionSummaryWire {
+            ext: r.ext,
+            count: r.count,
+        })
+        .collect())
+}
+
 /// True for paths whose basename is project plumbing (`.meta` /
 /// `.meta.tmp` sidecar, or `.dirmeta.toml` directory metadata) that
 /// should never reach the user-visible result lists. The scanner now

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::view_delete,
             commands::files_list_dir,
             commands::files_list_all,
+            commands::extensions_catalog,
             accepts_commands::accepts_read,
             accepts_commands::accepts_write,
             lint_commands::lint_run,


### PR DESCRIPTION
## Summary
- New `extensions_catalog` IPC backed by a `SqliteIndex::extensions_summary` query (DISTINCT ext + count, ordered by frequency)
- Accepts editor's plain `<Input>` is replaced with a Popover + cmdk Command combobox sourcing aliases (built-in + project) and the project's actual extensions in two grouped lists
- A dedicated `(no extension)` item handles the empty-extension token cleanly, and an inline `Add new` row commits typed entries that don't match a suggestion
- Drops the separate "Alias…" toggle button — aliases are reachable directly from the dropdown
- Suppresses Radix Popover's outside-close logic for clicks/focus on the anchored input so the dropdown doesn't flash open and immediately close when focusing from a blurred state
- Counts use `CommandShortcut` (instead of an ad-hoc `<span ml-auto>`) so they don't fight CommandItem's trailing CheckIcon

## Test plan
- [x] `mise run check` green locally
- [x] Vite production build succeeds
- [x] `cargo test -p progest-core` covers `extensions_summary` (group/sort + empty-index)
- [ ] Visual: open a project with mixed extensions and confirm suggestions list is grouped, counts align flush right, focus from blur opens dropdown without flashing closed
- [ ] Visual: typing `.xyz` (not in project) shows the "Add new" row; selecting commits a custom token

🤖 Generated with [Claude Code](https://claude.com/claude-code)