### PR TITLE
feat(app): default to user-select: none with content opt-in

### DIFF
--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -356,7 +356,9 @@ function SearchBody(props: {
   if (response.parse_error) {
     return (
       <CommandEmpty>
-        <div className="text-destructive">Parse error: {response.parse_error.message}</div>
+        <div className="select-text text-destructive">
+          Parse error: {response.parse_error.message}
+        </div>
       </CommandEmpty>
     );
   }
@@ -412,7 +414,7 @@ function PaletteStatus(props: {
   }
   if (error) {
     lines.push(
-      <span key="err" className="text-destructive">
+      <span key="err" className="select-text text-destructive">
         {error}
       </span>,
     );

--- a/app/src/components/directory-inspector.tsx
+++ b/app/src/components/directory-inspector.tsx
@@ -129,7 +129,7 @@ export function DirectoryInspector(props: { dir: string }) {
       <header className="flex items-center gap-2 border-b px-3 py-2">
         <div className="min-w-0 flex-1">
           <div className="text-muted-foreground">Directory</div>
-          <div className="truncate font-medium" title={dir || "(root)"}>
+          <div className="select-text truncate font-medium" title={dir || "(root)"}>
             {dir === "" ? "(project root)" : dir}
           </div>
         </div>
@@ -147,7 +147,7 @@ export function DirectoryInspector(props: { dir: string }) {
       <div className="flex-1 overflow-auto">
         {loading && !data ? <div className="p-3 text-muted-foreground">Loading…</div> : null}
         {error ? (
-          <div className="m-3 rounded border border-destructive/40 bg-destructive/5 p-2 text-destructive">
+          <div className="m-3 select-text rounded border border-destructive/40 bg-destructive/5 p-2 text-destructive">
             {error}
           </div>
         ) : null}

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -257,7 +257,7 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
       <div className="flex items-center gap-3 border-b px-3 py-1 text-[0.625rem]">
         {loading ? <span className="text-muted-foreground">searching…</span> : null}
         {response?.parse_error ? (
-          <span className="text-destructive" title={response.parse_error.message}>
+          <span className="select-text text-destructive" title={response.parse_error.message}>
             parse error: {response.parse_error.message}
           </span>
         ) : null}
@@ -267,7 +267,7 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
             {response.warnings.length === 1 ? "" : "s"}: {response.warnings.join("; ")}
           </span>
         ) : null}
-        {error ? <span className="text-destructive">{error}</span> : null}
+        {error ? <span className="select-text text-destructive">{error}</span> : null}
         {response && !response.parse_error ? (
           <span className="ml-auto text-muted-foreground">
             {response.hits.length} hit{response.hits.length === 1 ? "" : "s"}
@@ -520,7 +520,7 @@ function SaveAsDialog(props: {
               className="text-xs"
             />
           </Field>
-          {error ? <div className="text-destructive">{error}</div> : null}
+          {error ? <div className="select-text text-destructive">{error}</div> : null}
         </div>
         <DialogFooter>
           <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>

--- a/app/src/components/result-detail-dialog.tsx
+++ b/app/src/components/result-detail-dialog.tsx
@@ -17,7 +17,9 @@ export function ResultDetailDialog(props: {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle className="font-mono text-sm break-all">{hit?.path ?? ""}</DialogTitle>
+          <DialogTitle className="select-text font-mono text-sm break-all">
+            {hit?.path ?? ""}
+          </DialogTitle>
           <DialogDescription>{hit?.kind ?? ""}</DialogDescription>
         </DialogHeader>
         {hit ? <Detail hit={hit} /> : null}
@@ -28,7 +30,7 @@ export function ResultDetailDialog(props: {
 
 function Detail({ hit }: { hit: RichSearchHit }) {
   return (
-    <div className="grid gap-3 text-xs">
+    <div className="grid select-text gap-3 text-xs">
       <Row label="file_id" value={hit.file_id} />
       {hit.name ? <Row label="name" value={hit.name} /> : null}
       {hit.ext ? <Row label="ext" value={hit.ext} /> : null}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -138,6 +138,23 @@
   }
   body {
     @apply bg-background text-foreground;
+    /*
+     * Default to native-app selection behavior: chrome and labels
+     * aren't selectable, but anything that looks like content
+     * (file paths, error text, result rows) opts in via the
+     * `select-text` Tailwind utility. Form controls stay selectable
+     * via the override below so users can still edit / copy from
+     * inputs and textareas.
+     */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  input,
+  textarea,
+  [contenteditable="true"],
+  [contenteditable=""] {
+    -webkit-user-select: auto;
+    user-select: auto;
   }
   button:not(:disabled),
   [role="button"]:not(:disabled) {


### PR DESCRIPTION
## Summary
- `body { user-select: none }` (vendor-prefixed) so chrome, labels, and list rows behave like a native desktop app
- `input` / `textarea` / `[contenteditable]` keep `user-select: auto` so form controls remain editable and copyable
- Opt-in `select-text` for surfaces users do want to copy: the result detail dialog values, the directory inspector path, and the parse-error / IPC-error message slots in the command palette, flat view, and directory inspector

## Test plan
- [x] `mise run check` green
- [ ] Visual: drag-select across the tree / flat view / sidebar produces no highlight
- [ ] Visual: result detail dialog values, directory inspector path, and error messages can be selected and copied
- [ ] Visual: typing into accepts ext combobox, search input, and view dialog form works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)