### PR TITLE
feat(app): palette Enter sends query to FlatView, history only on commit

### DIFF
--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -17,6 +17,7 @@ import {
   searchExecute,
   searchHistoryClear,
   searchHistoryList,
+  searchHistoryRecord,
   type HistoryEntry,
   type RichSearchHit,
   type SearchResponse,
@@ -37,7 +38,8 @@ const COMMAND_PREFIX = ">";
 const SEARCH_DEBOUNCE_MS = 200;
 
 export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void }) {
-  const { project, recent, openPicker, pickRecent, clearRecent } = useProject();
+  const { project, recent, openPicker, pickRecent, clearRecent, submitFlatViewQuery } =
+    useProject();
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
   const [response, setResponse] = React.useState<SearchResponse | null>(null);
@@ -144,6 +146,47 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
     }
   };
 
+  // Commit the typed query to the FlatView and record it as a history
+  // entry. Triggered by Enter on the input — see `onInputKeyDown`.
+  // Empty / whitespace-only queries are no-ops (no history pollution,
+  // no FlatView reset). The palette closes regardless so the user
+  // lands on the result panel.
+  const commitSearch = React.useCallback(() => {
+    const trimmed = query.trim();
+    if (trimmed.length === 0) return;
+    submitFlatViewQuery(trimmed);
+    void searchHistoryRecord(trimmed).catch((e) => {
+      // History persistence is best-effort — surface the failure in
+      // the status row but don't keep the palette open for it.
+      const msg = e instanceof IpcError ? e.raw : String(e);
+      setError(msg);
+    });
+    setOpen(false);
+    setQuery("");
+  }, [query, submitFlatViewQuery]);
+
+  // Intercept Enter at the input layer so the typed query commits to
+  // the FlatView instead of cmdk's default behavior (selecting the
+  // first highlighted result row). Result rows still respond to mouse
+  // clicks via `onPickHit`. Skipped in `>command` mode so cmdk's
+  // built-in command-execution path keeps working there.
+  const onInputKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Enter") return;
+      if (isCommandMode) return;
+      if (project === null) return;
+      if (query.trim().length === 0) return;
+      // cmdk's default Enter behavior selects the highlighted item.
+      // Block it at every layer (React + native) so the typed query
+      // commits to the FlatView instead of opening the first hit.
+      e.preventDefault();
+      e.stopPropagation();
+      e.nativeEvent.stopImmediatePropagation();
+      commitSearch();
+    },
+    [isCommandMode, project, query, commitSearch],
+  );
+
   const onClearHistory = async () => {
     try {
       await searchHistoryClear();
@@ -170,11 +213,12 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
           <CommandInput
             value={query}
             onValueChange={setQuery}
+            onKeyDown={onInputKeyDown}
             placeholder={
               isCommandMode
                 ? "Type a command (Open project, Set theme, …)"
                 : project
-                  ? "tag:wip type:psd is:violation …  (>command for actions)"
+                  ? "tag:wip type:psd is:violation …  (Enter to open in FlatView)"
                   : "Open a project to search, or type > for commands"
             }
             autoFocus

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -39,7 +39,7 @@ import { ViolationBadges } from "@/components/violation-badges";
 const DEBOUNCE_MS = 200;
 
 export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
-  const { project, refreshTick } = useProject();
+  const { project, refreshTick, flatViewSubmission } = useProject();
   const reportSummary = useReportFlatView();
   const [query, setQuery] = React.useState("");
   const [display, setDisplay] = React.useState<ViewDisplay>("list");
@@ -96,6 +96,18 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     setDisplay("list");
     void refreshViews();
   }, [project?.root, refreshViews]);
+
+  // Subscribe to query commits from the command palette. When the
+  // user presses Enter on a typed query, project-context bumps the
+  // versioned `flatViewSubmission` slot — we mirror it into our own
+  // `query` state so the input shows the committed text and the
+  // existing search effect re-runs. Saved-view selection is cleared
+  // because the committed query overrides whichever view was active.
+  React.useEffect(() => {
+    if (!flatViewSubmission) return;
+    setQuery(flatViewSubmission.query);
+    setActiveViewId(null);
+  }, [flatViewSubmission]);
 
   // Debounced search whenever query changes. Empty query falls
   // through to `files_list_all` so the panel always shows *something*

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -141,6 +141,14 @@ export async function searchHistoryClear(): Promise<void> {
   }
 }
 
+export async function searchHistoryRecord(query: string): Promise<void> {
+  try {
+    await invoke<void>("search_history_record", { query });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 export async function projectOpen(path: string): Promise<AppInfo> {
   try {
     return await invoke<AppInfo>("project_open", { path });

--- a/app/src/lib/project-context.tsx
+++ b/app/src/lib/project-context.tsx
@@ -48,6 +48,21 @@ type ProjectContextValue = {
   initDialog: { open: boolean; mode: InitDialogMode };
   /** Dialog close handler. */
   closeInitDialog: () => void;
+  /**
+   * Submit a query to the FlatView. Used by the command palette when
+   * the user presses Enter on a typed search — the palette closes and
+   * the FlatView's input is populated with `query` so the result list
+   * (including hover/click affordances and saved-view tooling) takes
+   * over from the dropdown preview.
+   *
+   * Implemented as a versioned slot so the same query can be submitted
+   * twice in a row (e.g. user types `tag:wip` → Enter, edits something
+   * else, then submits the same query again to re-execute).
+   */
+  submitFlatViewQuery: (query: string) => void;
+  /** FlatView subscribes via `useEffect` and re-runs whenever `version`
+   *  changes; ignored if `null` (no submission yet this session). */
+  flatViewSubmission: { query: string; version: number } | null;
 };
 
 export type InitDialogMode = "new" | "existing";
@@ -174,6 +189,17 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
     setInitDialog((d) => ({ ...d, open: false }));
   }, []);
 
+  const [flatViewSubmission, setFlatViewSubmission] = React.useState<{
+    query: string;
+    version: number;
+  } | null>(null);
+  const submitFlatViewQuery = React.useCallback((query: string) => {
+    setFlatViewSubmission((prev) => ({
+      query,
+      version: (prev?.version ?? 0) + 1,
+    }));
+  }, []);
+
   const value = React.useMemo<ProjectContextValue>(
     () => ({
       project,
@@ -191,6 +217,8 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
       openInitDialog,
       initDialog,
       closeInitDialog,
+      submitFlatViewQuery,
+      flatViewSubmission,
     }),
     [
       project,
@@ -208,6 +236,8 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
       openInitDialog,
       initDialog,
       closeInitDialog,
+      submitFlatViewQuery,
+      flatViewSubmission,
     ],
   );
 

--- a/crates/progest-tauri/src/commands.rs
+++ b/crates/progest-tauri/src/commands.rs
@@ -194,12 +194,10 @@ pub fn search_execute(query: String, state: State<'_, AppState>) -> Result<Searc
 
     let warnings: Vec<String> = validated.warnings.iter().map(ToString::to_string).collect();
 
-    // Successful executions auto-record into the recent-query log.
-    // Logging is best-effort: a write failure should not turn a
-    // good search into a UI error.
-    if let Err(e) = record_history(ctx, &query) {
-        tracing::warn!("could not append to search history: {e}");
-    }
+    // Search history is no longer auto-recorded here — debounced
+    // keystrokes from the palette would otherwise pollute the recent
+    // list. The frontend calls `search_history_record` explicitly when
+    // the user commits a query (Enter key).
 
     Ok(SearchResponse {
         query,
@@ -207,6 +205,22 @@ pub fn search_execute(query: String, state: State<'_, AppState>) -> Result<Searc
         warnings,
         parse_error: None,
     })
+}
+
+/// Append `query` to `.progest/local/search-history.json`. Called by
+/// the frontend on explicit user commit (Enter in the palette) so the
+/// recent-query log only contains queries the user intended to keep.
+/// Empty / whitespace-only queries are no-ops (history dedup also
+/// drops them, this just avoids the round-trip).
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn search_history_record(query: String, state: State<'_, AppState>) -> Result<(), String> {
+    if query.trim().is_empty() {
+        return Ok(());
+    }
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+    record_history(ctx, &query)
 }
 
 #[tauri::command]

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             commands::search_execute,
             commands::search_history_list,
             commands::search_history_clear,
+            commands::search_history_record,
             commands::view_list,
             commands::view_save,
             commands::view_delete,


### PR DESCRIPTION
## Summary

- コマンドパレット（Cmd+K）の検索モードで Enter を押すと、入力したクエリが FlatView に送られて open する。クエリは FlatView の Input に入り、既存の search effect で結果表示。
- 検索履歴（recent queries）は Enter で commit したときだけ残る。debounced 入力ごとに記録される従来挙動が原因で `t`, `ta`, `tag`, ... のような部分一致が履歴を埋めていたのを修正。
- 結果行（hit）はマウスクリックで詳細 Dialog を開く既存挙動を維持。Enter は専ら「FlatView に送る」アクション。

## Implementation

- backend: `search_execute` から history 記録を撤去、`search_history_record(query)` IPC を新設して explicit commit 時のみ呼ぶ。
- frontend: `useProject()` に versioned `flatViewSubmission` slot + `submitFlatViewQuery(query)` を追加。`<CommandPalette>` が `<CommandInput>` の onKeyDown で Enter を捕まえ、cmdk のデフォルト挙動を React + native の両層で stop してから commit。`<FlatView>` は submission を `useEffect` で監視して `query` を mirror、active saved view は cleared（commit がそれを上書きする方が UX として自然）。
- `>command` モード時は intercept しない（cmdk の command-execution パスをそのまま使う）。

## Test plan

- [ ] Cmd+K → `tag:wip` → Enter → palette が閉じて FlatView の Input に `tag:wip` が入って結果が出る
- [ ] 同じく Cmd+K → `tag:wip` → Enter（再度）→ FlatView が再実行される（versioned slot の確認）
- [ ] Cmd+K → `tag` まで打って閉じる → 履歴に `tag` が**残らない**（debounced execute はもう記録しない）
- [ ] Cmd+K → `tag:wip` → Enter → 再度 Cmd+K で空クエリ Recent に `tag:wip` が出る
- [ ] Cmd+K → `>new project` → Enter → init dialog が開く（command mode は従来通り）
- [ ] Cmd+K → 結果行をクリック → 詳細 Dialog が開く（既存挙動維持）
- [ ] Cmd+K → 何も打たずに Enter → no-op（履歴に空文字も残らない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)