### PR TITLE
feat(cli): add global -p/--project option

### DIFF
--- a/crates/progest-cli/src/main.rs
+++ b/crates/progest-cli/src/main.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use commands::clean::{CaseFlag, CleanArgs, FillFlag};
@@ -30,6 +30,11 @@ mod walk;
 #[derive(Debug, Parser)]
 #[command(name = "progest", version, about, long_about = None)]
 struct Cli {
+    /// Path to the Progest project root. Defaults to discovering the
+    /// nearest `.progest/` directory from the current working directory.
+    #[arg(short = 'p', long = "project", global = true)]
+    project: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -278,7 +283,11 @@ fn main() -> Result<ExitCode> {
         .init();
 
     let cli = Cli::parse();
-    let cwd = std::env::current_dir()?;
+    let cwd = match cli.project {
+        Some(ref p) => std::fs::canonicalize(p)
+            .with_context(|| format!("resolving project path `{}`", p.display()))?,
+        None => std::env::current_dir()?,
+    };
     match cli.command {
         Command::Init { name } => {
             commands::init::run(&cwd, name)?;

--- a/crates/progest-cli/tests/cli_flow.rs
+++ b/crates/progest-cli/tests/cli_flow.rs
@@ -12,7 +12,7 @@ use std::process::Output;
 
 use tempfile::TempDir;
 
-use support::run;
+use support::{init_project, run, write_file};
 
 fn stdout_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -96,5 +96,30 @@ fn scan_outside_a_project_errors() {
     assert!(
         stderr.contains("could not find a Progest project"),
         "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn global_project_flag_overrides_cwd() {
+    let project = TempDir::new().unwrap();
+    init_project(project.path(), "remote-project").unwrap();
+    write_file(project.path(), "hero.psd", "bytes").unwrap();
+
+    // Run scan from a completely unrelated directory, pointing -p at
+    // the actual project.
+    let unrelated = TempDir::new().unwrap();
+    let out = run(
+        unrelated.path(),
+        &["-p", project.path().to_str().unwrap(), "scan"],
+    );
+    assert!(
+        out.status.success(),
+        "scan with -p failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        stdout.contains("added"),
+        "expected scan to find files via -p, got: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary
- Add `-p` / `--project` global option to the `progest` CLI, allowing commands to target a specific project root from any working directory
- When omitted, falls back to existing CWD-based `.progest/` discovery
- Works with all subcommands (`scan`, `lint`, `import`, `search`, etc.)

Usage: `progest -p ./path/to/project scan`

## Test plan
- [x] New CLI smoke test: `scan` from an unrelated directory using `-p`
- [x] All existing tests pass (the option is additive, no behavior change when omitted)
- [x] `mise run check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)