### PR TITLE
chore(app): switch body font to Geist Sans

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "check": "vp check && tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-table": "^8.21.3",

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,12 +1,14 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "@fontsource-variable/geist";
 @import "@fontsource-variable/geist-mono";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-heading: var(--font-mono);
+  --font-sans: "Geist Variable", sans-serif;
+  --font-heading: var(--font-sans);
   --font-mono: "Geist Mono Variable", monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -164,7 +166,7 @@
     cursor: pointer;
   }
   html {
-    @apply font-mono;
+    @apply font-sans;
   }
 
   /*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
 
   app:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource-variable/geist-mono':
         specifier: ^5.2.7
         version: 5.2.7
@@ -415,6 +418,9 @@ packages:
 
   '@fontsource-variable/geist-mono@5.2.7':
     resolution: {integrity: sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==}
+
+  '@fontsource-variable/geist@5.2.8':
+    resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -3668,6 +3674,8 @@ snapshots:
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/geist-mono@5.2.7': {}
+
+  '@fontsource-variable/geist@5.2.8': {}
 
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@fontsource-variable/geist` (Sans) alongside existing Geist Mono
- Set `--font-sans: "Geist Variable", sans-serif` as the default body font
- Change `html` from `font-mono` to `font-sans`
- `--font-heading` now uses Sans instead of Mono

Geist Mono remains available via `font-mono` for code/monospace contexts.
Fonts are bundled via Fontsource (npm package), so they work offline in Tauri.

## Test plan
- [x] `mise run check` green
- [x] `pnpm build` green
- [x] Visual: `tauri dev` で本文が Geist Sans、コード部分が Geist Mono であること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)