### PR TITLE
feat: D&D import UI + grid thumbnail display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,6 +3623,7 @@ dependencies = [
 name = "progest-tauri"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "progest-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +134,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +161,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "atk"
@@ -163,6 +207,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +319,12 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -268,6 +376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +398,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -374,6 +494,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -490,6 +612,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "objc",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +699,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -606,7 +776,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -627,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -931,6 +1101,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "drag"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fd9ae1736d6ebb2e472740fbee86fb2178b8d56feb98a6751411d4c95b7e72"
+dependencies = [
+ "cocoa",
+ "core-graphics 0.24.0",
+ "dunce",
+ "gdk",
+ "gdkx11",
+ "gtk",
+ "log",
+ "objc",
+ "raw-window-handle",
+ "serde",
+ "thiserror 1.0.69",
+ "windows 0.52.0",
+ "windows-core 0.58.0",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1175,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1233,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1264,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1125,6 +1368,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "four-cc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
 
 [[package]]
 name = "fsevent-sys"
@@ -1379,6 +1628,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1751,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1886,6 +2145,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "ravif",
+ "rayon",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +2235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2283,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2050,6 +2367,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2142,6 +2469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2503,40 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libheif-rs"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a26370abb4723a3ce73083e479b98017604206cadb0e35da5eac4813600d85"
+dependencies = [
+ "enumn",
+ "four-cc",
+ "libc",
+ "libheif-sys",
+]
+
+[[package]]
+name = "libheif-sys"
+version = "3.1.0+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e663db80d4272b60c066c5a9d17370ffa0433a31d424152f95f1e1effb9b3860"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "vcpkg",
+ "walkdir",
+]
 
 [[package]]
 name = "libloading"
@@ -2229,10 +2596,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2286,6 +2671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,7 +2748,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2386,10 +2791,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -2441,10 +2870,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2475,6 +2945,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2672,6 +3151,18 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -2933,6 +3424,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3545,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "progest-cli"
 version = "0.1.0"
 dependencies = [
@@ -3067,9 +3590,12 @@ dependencies = [
  "globset",
  "heck 0.5.0",
  "ignore",
+ "image",
+ "libheif-rs",
  "notify",
  "notify-debouncer-full",
  "proptest",
+ "psd",
  "regex",
  "rusqlite",
  "serde",
@@ -3105,6 +3631,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-drag",
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
@@ -3130,10 +3657,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "psd"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a25f9b8cfffd65d911baf31a033239f7a0facb755faa2481575b70db5dc9195"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3282,6 +3830,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error 2.0.1",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -3449,6 +4047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,7 +4107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -3840,6 +4444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,7 +4670,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",
@@ -4080,7 +4693,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4151,7 +4764,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4187,7 +4800,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4253,6 +4866,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-drag"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57788e3175d71de47f449e642ebf135e86a41279be1e4714c7eb8c682abb37ca"
+dependencies = [
+ "base64 0.21.7",
+ "drag",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,7 +4926,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4323,7 +4951,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4457,6 +5085,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4779,7 +5421,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4935,6 +5577,17 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -5216,10 +5869,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -5240,9 +5893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5292,6 +5951,18 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-implement 0.52.0",
+ "windows-interface 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5314,12 +5985,34 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5331,8 +6024,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5351,9 +6044,53 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5395,6 +6132,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -5409,6 +6155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5907,7 +6663,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5933,6 +6689,12 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -6036,3 +6798,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/app/.oxlintrc.json
+++ b/app/.oxlintrc.json
@@ -1,6 +1,11 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["dist/**", "src/components/ui/**"],
+  "ignorePatterns": [
+    "dist/**",
+    "src/components/ui/**",
+    "src/lib/dotmatrix-*.ts*",
+    "src/components/dotmatrix-*.css"
+  ],
   "categories": {
     "correctness": "error",
     "suspicious": "warn",

--- a/app/components.json
+++ b/app/components.json
@@ -12,6 +12,8 @@
   },
   "iconLibrary": "lucide",
   "rtl": false,
+  "menuColor": "default",
+  "menuAccent": "subtle",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -19,7 +21,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "menuColor": "default",
-  "menuAccent": "subtle",
-  "registries": {}
+  "registries": {
+    "@dotmatrix": "https://dotmatrix.zzzzshawn.cloud/r/{name}.json"
+  }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "check": "vp check && tsc --noEmit"
   },
   "dependencies": {
+    "@crabnebula/tauri-plugin-drag": "^2.1.0",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.2.4",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import { FolderOpen, FolderPlus, Sparkles } from "lucide-react";
 import { CommandPalette } from "@/components/command-palette";
 import { DirectoryInspector } from "@/components/directory-inspector";
 import { DragDropProvider, DropOverlay, useDropZone } from "@/components/drag-drop-overlay";
+import { dirPathAtPoint } from "@/components/tree-view";
 import { FileInspector } from "@/components/file-inspector";
 import { FlatView } from "@/components/flat-view";
 import { ImportModal } from "@/components/import-modal";
@@ -119,28 +120,15 @@ function Shell() {
   const [importOpen, setImportOpen] = React.useState(false);
 
   const treeRef = React.useRef<HTMLElement>(null);
-  const dragHoverDirRef = React.useRef<string | null>(null);
 
   const handleDrop = React.useCallback(
     (paths: string[], position: { x: number; y: number }) => {
       if (!project || paths.length === 0) return;
 
-      // If the drop lands on the tree pane and a specific folder is
-      // highlighted, use that folder as the destination.
-      let dest: string | undefined;
-      if (treeRef.current) {
-        const rect = treeRef.current.getBoundingClientRect();
-        if (
-          position.x >= rect.left &&
-          position.x <= rect.right &&
-          position.y >= rect.top &&
-          position.y <= rect.bottom &&
-          dragHoverDirRef.current != null
-        ) {
-          dest = dragHoverDirRef.current;
-        }
-      }
-      dragHoverDirRef.current = null;
+      // Check if the drop landed on a TreeView folder button by
+      // inspecting the DOM at the drop point.
+      const dirPath = dirPathAtPoint(position);
+      const dest = dirPath != null ? dirPath : undefined;
 
       setImportSources(paths);
       setImportDest(dest);
@@ -162,7 +150,6 @@ function Shell() {
             onSelectDir={onSelectDir}
             panels={panels}
             treeRef={treeRef}
-            dragHoverDirRef={dragHoverDirRef}
           />
         ) : (
           <Welcome />
@@ -189,7 +176,6 @@ function MainShell(props: {
   onSelectDir: (path: string) => void;
   panels: PanelVisibility;
   treeRef: React.RefObject<HTMLElement | null>;
-  dragHoverDirRef: React.MutableRefObject<string | null>;
 }) {
   const flatRef = React.useRef<HTMLElement>(null);
   const flatDrop = useDropZone(flatRef);
@@ -205,7 +191,6 @@ function MainShell(props: {
               onPickFile={props.onPickTreeFile}
               selectedDir={props.selectedDir}
               onSelectDir={props.onSelectDir}
-              dragHoverDirRef={props.dragHoverDirRef}
             />
           </aside>
         </ResizablePanel>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,11 +3,13 @@ import { FolderOpen, FolderPlus, Sparkles } from "lucide-react";
 
 import { CommandPalette } from "@/components/command-palette";
 import { DirectoryInspector } from "@/components/directory-inspector";
+import { DragDropProvider, DropOverlay, useDropZone } from "@/components/drag-drop-overlay";
 import { FileInspector } from "@/components/file-inspector";
-import { TreeView } from "@/components/tree-view";
 import { FlatView } from "@/components/flat-view";
+import { ImportModal } from "@/components/import-modal";
 import { InitProjectDialog } from "@/components/init-project-dialog";
 import { StatusBar } from "@/components/status-bar";
+import { TreeView } from "@/components/tree-view";
 import {
   ALL_PANELS_VISIBLE,
   TitleBar,
@@ -111,8 +113,43 @@ function Shell() {
 
   const selectedDir = selection?.kind === "dir" ? selection.path : "";
 
+  // --- import via drag & drop -----------------------------------------------
+  const [importSources, setImportSources] = React.useState<string[]>([]);
+  const [importDest, setImportDest] = React.useState<string | undefined>();
+  const [importOpen, setImportOpen] = React.useState(false);
+
+  // Refs for the tree and flat panes — used to determine which pane
+  // received the drop so we can pre-select the destination.
+  const treeRef = React.useRef<HTMLElement>(null);
+
+  const handleDrop = React.useCallback(
+    (paths: string[], position: { x: number; y: number }) => {
+      if (!project || paths.length === 0) return;
+
+      // If the drop lands on the tree pane, use the currently selected
+      // directory as the destination; otherwise leave it to ranking.
+      let dest: string | undefined;
+      if (treeRef.current) {
+        const rect = treeRef.current.getBoundingClientRect();
+        if (
+          position.x >= rect.left &&
+          position.x <= rect.right &&
+          position.y >= rect.top &&
+          position.y <= rect.bottom
+        ) {
+          dest = selectedDir || undefined;
+        }
+      }
+
+      setImportSources(paths);
+      setImportDest(dest);
+      setImportOpen(true);
+    },
+    [project, selectedDir],
+  );
+
   return (
-    <>
+    <DragDropProvider onDrop={handleDrop}>
       <div className="grid h-screen grid-rows-[auto_1fr_auto] bg-background">
         <TitleBar panels={panels} onTogglePanel={togglePanel} />
         {project ? (
@@ -123,21 +160,22 @@ function Shell() {
             selectedDir={selectedDir}
             onSelectDir={onSelectDir}
             panels={panels}
+            treeRef={treeRef}
           />
         ) : (
           <Welcome />
         )}
         <StatusBar />
       </div>
-      {/*
-        CommandPalette is mounted globally so Cmd+K works even from the
-        Welcome screen. Hit picks now flow into the same selection slot
-        as TreeView / FlatView clicks — the file inspector renders the
-        details that used to live in the dialog.
-      */}
       <CommandPalette onPickHit={onPickFlatHit} />
       <InitProjectDialog />
-    </>
+      <ImportModal
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        sources={importSources}
+        initialDest={importDest}
+      />
+    </DragDropProvider>
   );
 }
 
@@ -148,22 +186,28 @@ function MainShell(props: {
   selectedDir: string;
   onSelectDir: (path: string) => void;
   panels: PanelVisibility;
+  treeRef: React.RefObject<HTMLElement | null>;
 }) {
-  // Build the panel list dynamically so hidden panels disappear from
-  // the Resizable group entirely (and so do their handles). Each
-  // ResizablePanel keeps its `id` so the library's persisted layout
-  // can rehydrate correctly when the panel returns.
+  const flatRef = React.useRef<HTMLElement>(null);
+  const treeDrop = useDropZone(props.treeRef);
+  const flatDrop = useDropZone(flatRef);
+
   const panes: { key: PanelKey; node: React.ReactNode }[] = [];
   if (props.panels.tree) {
     panes.push({
       key: "tree",
       node: (
         <ResizablePanel id="tree" key="tree" defaultSize={22} minSize={12}>
-          <aside className="h-full overflow-hidden">
+          <aside ref={props.treeRef} className="relative h-full overflow-hidden">
             <TreeView
               onPickFile={props.onPickTreeFile}
               selectedDir={props.selectedDir}
               onSelectDir={props.onSelectDir}
+            />
+            <DropOverlay
+              isOver={treeDrop.isOver}
+              fileCount={treeDrop.fileCount}
+              label={props.selectedDir ? `→ ${props.selectedDir}` : "Select a directory first"}
             />
           </aside>
         </ResizablePanel>
@@ -175,8 +219,13 @@ function MainShell(props: {
       key: "flat",
       node: (
         <ResizablePanel id="flat" key="flat" defaultSize={40} minSize={20}>
-          <main className="h-full overflow-hidden">
+          <main ref={flatRef} className="relative h-full overflow-hidden">
             <FlatView onPickHit={props.onPickHit} />
+            <DropOverlay
+              isOver={flatDrop.isOver}
+              fileCount={flatDrop.fileCount}
+              label="Auto-suggest destination"
+            />
           </main>
         </ResizablePanel>
       ),

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -118,16 +118,15 @@ function Shell() {
   const [importDest, setImportDest] = React.useState<string | undefined>();
   const [importOpen, setImportOpen] = React.useState(false);
 
-  // Refs for the tree and flat panes — used to determine which pane
-  // received the drop so we can pre-select the destination.
   const treeRef = React.useRef<HTMLElement>(null);
+  const dragHoverDirRef = React.useRef<string | null>(null);
 
   const handleDrop = React.useCallback(
     (paths: string[], position: { x: number; y: number }) => {
       if (!project || paths.length === 0) return;
 
-      // If the drop lands on the tree pane, use the currently selected
-      // directory as the destination; otherwise leave it to ranking.
+      // If the drop lands on the tree pane and a specific folder is
+      // highlighted, use that folder as the destination.
       let dest: string | undefined;
       if (treeRef.current) {
         const rect = treeRef.current.getBoundingClientRect();
@@ -135,17 +134,19 @@ function Shell() {
           position.x >= rect.left &&
           position.x <= rect.right &&
           position.y >= rect.top &&
-          position.y <= rect.bottom
+          position.y <= rect.bottom &&
+          dragHoverDirRef.current != null
         ) {
-          dest = selectedDir || undefined;
+          dest = dragHoverDirRef.current;
         }
       }
+      dragHoverDirRef.current = null;
 
       setImportSources(paths);
       setImportDest(dest);
       setImportOpen(true);
     },
-    [project, selectedDir],
+    [project],
   );
 
   return (
@@ -161,6 +162,7 @@ function Shell() {
             onSelectDir={onSelectDir}
             panels={panels}
             treeRef={treeRef}
+            dragHoverDirRef={dragHoverDirRef}
           />
         ) : (
           <Welcome />
@@ -187,9 +189,9 @@ function MainShell(props: {
   onSelectDir: (path: string) => void;
   panels: PanelVisibility;
   treeRef: React.RefObject<HTMLElement | null>;
+  dragHoverDirRef: React.MutableRefObject<string | null>;
 }) {
   const flatRef = React.useRef<HTMLElement>(null);
-  const treeDrop = useDropZone(props.treeRef);
   const flatDrop = useDropZone(flatRef);
 
   const panes: { key: PanelKey; node: React.ReactNode }[] = [];
@@ -198,16 +200,12 @@ function MainShell(props: {
       key: "tree",
       node: (
         <ResizablePanel id="tree" key="tree" defaultSize={22} minSize={12}>
-          <aside ref={props.treeRef} className="relative h-full overflow-hidden">
+          <aside ref={props.treeRef} className="h-full overflow-hidden">
             <TreeView
               onPickFile={props.onPickTreeFile}
               selectedDir={props.selectedDir}
               onSelectDir={props.onSelectDir}
-            />
-            <DropOverlay
-              isOver={treeDrop.isOver}
-              fileCount={treeDrop.fileCount}
-              label={props.selectedDir ? `→ ${props.selectedDir}` : "Select a directory first"}
+              dragHoverDirRef={props.dragHoverDirRef}
             />
           </aside>
         </ResizablePanel>

--- a/app/src/components/dotmatrix-loader.css
+++ b/app/src/components/dotmatrix-loader.css
@@ -1,0 +1,902 @@
+.dmx-root {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  /* One base loop at speed=1; --dmx-speed from JS scales inversely with the speed prop */
+  --dmx-cycle: 1500ms;
+  /* Rest / mid / bright — override via opacityBase, opacityMid, opacityPeak on the component */
+  --dmx-opacity-base: 0.16;
+  --dmx-opacity-mid: 0.32;
+  --dmx-opacity-peak: 1;
+}
+
+.dmx-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+}
+
+.dmx-dot {
+  border-radius: 999px;
+  display: block;
+  background: currentColor;
+  /* Matches prior 0.24 with default base/mid */
+  opacity: calc(0.5 * (var(--dmx-opacity-base) + var(--dmx-opacity-mid)));
+  transform-origin: center;
+  transform: none;
+  will-change: opacity;
+}
+
+.dmx-muted .dmx-dot {
+  opacity: calc(0.44 * var(--dmx-opacity-mid));
+}
+
+/* Inactive off-cells (Base also sets inline opacity/animation:none so keyframes cannot win). */
+.dmx-dot.dmx-inactive {
+  opacity: 0 !important;
+  animation: none !important;
+  visibility: hidden;
+  pointer-events: none;
+  will-change: auto;
+}
+
+.dmx-ripple {
+  animation: dmx-ripple calc(var(--dmx-cycle) * var(--dmx-speed, 1)) cubic-bezier(0.42, 0, 0.58, 1)
+    infinite;
+  animation-delay: calc(
+    var(--dmx-ripple-ring, 0) * 0.2333 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-ripple-echo {
+  animation: dmx-ripple-echo calc(var(--dmx-cycle) * var(--dmx-speed, 1)) ease-in-out infinite;
+  animation-delay: calc(
+    (var(--dmx-ripple-ring, 0) * 0.14 + var(--dmx-ripple-parity, 0) * 0.03) * var(--dmx-cycle) *
+      var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-center-origin-ripple {
+  animation: dmx-center-origin-ripple calc(var(--dmx-cycle) * var(--dmx-speed, 1)) ease-in-out
+    infinite;
+  animation-delay: calc(
+    var(--dmx-center-ripple-ring, 0) * 0.16 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-collapse {
+  animation: dmx-collapse calc(var(--dmx-cycle) * 0.2 * var(--dmx-speed, 1)) ease-in forwards;
+  animation-delay: calc(
+    (4 - var(--dmx-manhattan, 0)) * 0.032 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+}
+
+.dmx-hover-ripple {
+  animation: dmx-hover-ripple calc(var(--dmx-cycle) * var(--dmx-speed, 1)) ease-in-out infinite;
+  animation-delay: calc(var(--dmx-distance, 0) * 0.127 * var(--dmx-cycle) * var(--dmx-speed, 1));
+}
+
+.dmx-path {
+  animation: dmx-ripple calc(var(--dmx-cycle) * var(--dmx-speed, 1)) cubic-bezier(0.42, 0, 0.58, 1)
+    infinite;
+  animation-delay: calc(var(--dmx-path, 0) * 0.2333 * var(--dmx-cycle) * var(--dmx-speed, 1));
+  will-change: opacity;
+}
+
+.dmx-diagonal-alt-sweep {
+  animation: dmx-diagonal-alt-sweep calc(var(--dmx-cycle) * var(--dmx-speed, 1)) linear infinite;
+  animation-delay: calc(
+    (var(--dmx-path, 0) * 0.2 + var(--dmx-diagonal-parity, 0) * 0.5) * var(--dmx-cycle) *
+      var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-spiral-snake {
+  animation: dmx-spiral-snake calc(var(--dmx-cycle) * var(--dmx-speed, 1)) linear infinite;
+  animation-delay: calc(var(--dmx-spiral-order, 0) * 0.04 * var(--dmx-cycle) * var(--dmx-speed, 1));
+  will-change: opacity;
+}
+
+.dmx-diagonal-snake {
+  animation: dmx-diagonal-snake calc(var(--dmx-cycle) * var(--dmx-speed, 1)) linear infinite;
+  animation-delay: calc(
+    var(--dmx-diagonal-snake-order, 0) * 0.04 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-outer-snake {
+  animation: dmx-ring-snake calc(var(--dmx-cycle) * var(--dmx-speed, 1)) linear infinite;
+  animation-delay: calc(
+    var(--dmx-outer-order, 0) * 0.0625 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+.dmx-middle-snake {
+  animation: dmx-ring-snake calc(var(--dmx-cycle) * var(--dmx-speed, 1)) linear infinite;
+  animation-delay: calc(
+    var(--dmx-middle-order, 0) * 0.125 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+@keyframes dmx-ripple {
+  0%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  50% {
+    opacity: var(--dmx-opacity-peak);
+  }
+}
+
+@keyframes dmx-ripple-echo {
+  0%,
+  100% {
+    opacity: calc(0.625 * var(--dmx-opacity-base));
+  }
+
+  28% {
+    opacity: calc(0.98 * var(--dmx-opacity-peak));
+  }
+
+  56% {
+    opacity: var(--dmx-opacity-mid);
+  }
+
+  78% {
+    opacity: calc(0.68 * var(--dmx-opacity-peak) + 0.32 * var(--dmx-opacity-mid));
+  }
+}
+
+@keyframes dmx-center-origin-ripple {
+  0%,
+  100% {
+    opacity: calc(0.625 * var(--dmx-opacity-base));
+  }
+
+  34% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  60% {
+    opacity: calc(0.5 * (var(--dmx-opacity-base) + var(--dmx-opacity-mid)));
+  }
+}
+
+@keyframes dmx-collapse {
+  0% {
+    opacity: calc(0.95 * var(--dmx-opacity-peak) + 0.05 * var(--dmx-opacity-mid));
+  }
+
+  100% {
+    opacity: calc(0.375 * var(--dmx-opacity-base));
+  }
+}
+
+@keyframes dmx-hover-ripple {
+  0% {
+    opacity: calc(0.5 * var(--dmx-opacity-base));
+  }
+
+  45% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-diagonal-alt-sweep {
+  0%,
+  100% {
+    opacity: calc(0.5 * var(--dmx-opacity-base));
+  }
+
+  14% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  30% {
+    opacity: calc(0.75 * var(--dmx-opacity-base));
+  }
+}
+
+@keyframes dmx-spiral-snake {
+  0%,
+  100% {
+    opacity: calc(0.5 * var(--dmx-opacity-base));
+  }
+
+  8% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  16% {
+    opacity: calc(
+      0.5 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid) + 0.1 * var(--dmx-opacity-base)
+    );
+  }
+
+  24% {
+    opacity: calc(
+      0.25 * var(--dmx-opacity-peak) + 0.45 * var(--dmx-opacity-mid) + 0.3 * var(--dmx-opacity-base)
+    );
+  }
+
+  32% {
+    opacity: calc(0.5 * var(--dmx-opacity-mid) + 0.5 * var(--dmx-opacity-base));
+  }
+
+  40% {
+    opacity: calc(0.75 * var(--dmx-opacity-base));
+  }
+}
+
+@keyframes dmx-diagonal-snake {
+  0%,
+  100% {
+    opacity: calc(0.5 * var(--dmx-opacity-base));
+  }
+
+  8% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  16% {
+    opacity: calc(
+      0.5 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid) + 0.1 * var(--dmx-opacity-base)
+    );
+  }
+
+  24% {
+    opacity: calc(
+      0.25 * var(--dmx-opacity-peak) + 0.45 * var(--dmx-opacity-mid) + 0.3 * var(--dmx-opacity-base)
+    );
+  }
+
+  32% {
+    opacity: calc(0.5 * var(--dmx-opacity-mid) + 0.5 * var(--dmx-opacity-base));
+  }
+
+  40% {
+    opacity: calc(0.75 * var(--dmx-opacity-base));
+  }
+}
+
+@keyframes dmx-ring-snake {
+  0%,
+  100% {
+    opacity: calc(0.5 * var(--dmx-opacity-base));
+  }
+
+  10% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  20% {
+    opacity: calc(
+      0.45 * var(--dmx-opacity-peak) + 0.45 * var(--dmx-opacity-mid) + 0.1 * var(--dmx-opacity-base)
+    );
+  }
+
+  30% {
+    opacity: calc(
+      0.2 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid) + 0.4 * var(--dmx-opacity-base)
+    );
+  }
+
+  40% {
+    opacity: calc(0.875 * var(--dmx-opacity-base));
+  }
+}
+
+.dmx-square9-bit {
+  animation-duration: calc(5200ms * var(--dmx-speed, 1));
+  animation-timing-function: steps(52, end);
+  animation-iteration-count: infinite;
+  will-change: opacity;
+}
+
+.dmx-square9-d1 {
+  animation-name: dmx-square9-d1;
+}
+
+.dmx-square9-d2 {
+  animation-name: dmx-square9-d2;
+}
+
+.dmx-square9-d3 {
+  animation-name: dmx-square9-d3;
+}
+
+.dmx-square9-d4 {
+  animation-name: dmx-square9-d4;
+}
+
+.dmx-square9-d5 {
+  animation-name: dmx-square9-d5;
+}
+
+.dmx-square9-d6 {
+  animation-name: dmx-square9-d6;
+}
+
+@keyframes dmx-square9-d1 {
+  0%,
+  3.846154% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  3.846154%,
+  30.769231% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  30.769231%,
+  46.153846% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  46.153846%,
+  50% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  57.692308%,
+  65.384615% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  65.384615%,
+  71.153846% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  71.153846%,
+  80.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  80.769231%,
+  84.615385% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  92.307692%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-square9-d2 {
+  0%,
+  5.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  5.769231%,
+  25% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  25%,
+  30.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  30.769231%,
+  36.538462% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  36.538462%,
+  50% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  57.692308%,
+  61.538462% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  61.538462%,
+  65.384615% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  65.384615%,
+  76.923077% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  76.923077%,
+  80.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  80.769231%,
+  84.615385% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  92.307692%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-square9-d3 {
+  0%,
+  7.692308% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  7.692308%,
+  25% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  25%,
+  36.538462% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  36.538462%,
+  42.307692% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  42.307692%,
+  46.153846% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  46.153846%,
+  50% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  57.692308%,
+  71.153846% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  71.153846%,
+  76.923077% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  76.923077%,
+  80.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  80.769231%,
+  84.615385% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  92.307692%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-square9-d4 {
+  0%,
+  13.461538% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  13.461538%,
+  30.769231% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  30.769231%,
+  50% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  57.692308%,
+  61.538462% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  61.538462%,
+  65.384615% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  65.384615%,
+  71.153846% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  71.153846%,
+  84.615385% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  92.307692%,
+  96.153846% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  96.153846%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-square9-d5 {
+  0%,
+  15.384615% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  15.384615%,
+  25% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  25%,
+  30.769231% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  30.769231%,
+  36.538462% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  36.538462%,
+  46.153846% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  46.153846%,
+  50% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  57.692308%,
+  65.384615% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  65.384615%,
+  76.923077% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  76.923077%,
+  84.615385% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  92.307692%,
+  96.153846% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  96.153846%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+@keyframes dmx-square9-d6 {
+  0%,
+  17.307692% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  17.307692%,
+  25% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  25%,
+  36.538462% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  36.538462%,
+  42.307692% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  42.307692%,
+  50% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  50%,
+  53.846154% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  53.846154%,
+  57.692308% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  57.692308%,
+  61.538462% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  61.538462%,
+  71.153846% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  71.153846%,
+  76.923077% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  76.923077%,
+  84.615385% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  84.615385%,
+  88.461538% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  88.461538%,
+  92.307692% {
+    opacity: var(--dmx-opacity-base);
+  }
+
+  92.307692%,
+  96.153846% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  96.153846%,
+  100% {
+    opacity: var(--dmx-opacity-base);
+  }
+}
+
+.dmx-square6-col-snake {
+  animation: dmx-square6-col-snake calc(var(--dmx-cycle) * var(--dmx-speed, 1)) steps(5, end)
+    infinite;
+  animation-delay: calc(var(--dmx-col-pos, 0) * 0.2 * var(--dmx-cycle) * var(--dmx-speed, 1));
+  will-change: opacity;
+}
+
+@keyframes dmx-square6-col-snake {
+  0%,
+  20% {
+    opacity: calc(
+      0.6 * var(--dmx-opacity-peak) + 0.25 * var(--dmx-opacity-mid) + 0.15 * var(--dmx-opacity-base)
+    );
+  }
+
+  20%,
+  40% {
+    opacity: calc(
+      0.3 * var(--dmx-opacity-peak) + 0.5 * var(--dmx-opacity-mid) + 0.2 * var(--dmx-opacity-base)
+    );
+  }
+
+  40%,
+  60% {
+    opacity: calc(0.6 * var(--dmx-opacity-mid) + 0.4 * var(--dmx-opacity-base));
+  }
+
+  60%,
+  80% {
+    opacity: calc(0.2 * var(--dmx-opacity-mid) + 0.8 * var(--dmx-opacity-base));
+  }
+
+  80%,
+  100% {
+    opacity: calc(0.625 * var(--dmx-opacity-base));
+  }
+}
+
+.dmx-circular2-ring {
+  animation: dmx-circular2-ring calc(var(--dmx-cycle) * var(--dmx-speed, 1)) steps(12, end) infinite;
+  animation-delay: calc(
+    var(--dmx-ring-order, 0) * 0.0833333333 * var(--dmx-cycle) * var(--dmx-speed, 1)
+  );
+  will-change: opacity;
+}
+
+@keyframes dmx-circular2-ring {
+  0%,
+  8.333333% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  8.333333%,
+  16.666667% {
+    opacity: calc(0.6 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid));
+  }
+
+  16.666667%,
+  25% {
+    opacity: calc(0.5 * var(--dmx-opacity-mid) + 0.5 * var(--dmx-opacity-base));
+  }
+
+  25%,
+  33.333333% {
+    opacity: calc(0.3 * var(--dmx-opacity-mid) + 0.7 * var(--dmx-opacity-base));
+  }
+
+  33.333333%,
+  41.666667% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  41.666667%,
+  50% {
+    opacity: calc(0.6 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid));
+  }
+
+  50%,
+  58.333333% {
+    opacity: calc(0.5 * var(--dmx-opacity-mid) + 0.5 * var(--dmx-opacity-base));
+  }
+
+  58.333333%,
+  66.666667% {
+    opacity: calc(0.3 * var(--dmx-opacity-mid) + 0.7 * var(--dmx-opacity-base));
+  }
+
+  66.666667%,
+  75% {
+    opacity: var(--dmx-opacity-peak);
+  }
+
+  75%,
+  83.333333% {
+    opacity: calc(0.6 * var(--dmx-opacity-peak) + 0.4 * var(--dmx-opacity-mid));
+  }
+
+  83.333333%,
+  91.666667% {
+    opacity: calc(0.5 * var(--dmx-opacity-mid) + 0.5 * var(--dmx-opacity-base));
+  }
+
+  91.666667%,
+  100% {
+    opacity: calc(0.3 * var(--dmx-opacity-mid) + 0.7 * var(--dmx-opacity-base));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dmx-dot,
+  .dmx-ripple,
+  .dmx-ripple-echo,
+  .dmx-center-origin-ripple,
+  .dmx-collapse,
+  .dmx-hover-ripple,
+  .dmx-path,
+  .dmx-diagonal-alt-sweep,
+  .dmx-spiral-snake,
+  .dmx-diagonal-snake,
+  .dmx-outer-snake,
+  .dmx-middle-snake,
+  .dmx-square9-bit,
+  .dmx-square6-col-snake,
+  .dmx-circular2-ring {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/app/src/components/drag-drop-overlay.tsx
+++ b/app/src/components/drag-drop-overlay.tsx
@@ -16,11 +16,12 @@ const DragDropCtx = React.createContext<DragDropContextValue>({
   state: { active: false, paths: [], position: null },
 });
 
-/**
- * Check whether the current drag cursor is within a given element.
- * Returns `isOver` plus the drop-zone label (for the import modal to
- * know whether the drop landed on a tree directory or the flat pane).
- */
+/** Convert Tauri PhysicalPosition to CSS logical pixels. */
+function toLogical(pos: { x: number; y: number }): { x: number; y: number } {
+  const dpr = window.devicePixelRatio || 1;
+  return { x: pos.x / dpr, y: pos.y / dpr };
+}
+
 export function useDropZone(ref: React.RefObject<HTMLElement | null>): {
   isOver: boolean;
   fileCount: number;
@@ -30,32 +31,17 @@ export function useDropZone(ref: React.RefObject<HTMLElement | null>): {
   const isOver = React.useMemo(() => {
     if (!state.active || !state.position || !ref.current) return false;
     const rect = ref.current.getBoundingClientRect();
-    return (
-      state.position.x >= rect.left &&
-      state.position.x <= rect.right &&
-      state.position.y >= rect.top &&
-      state.position.y <= rect.bottom
-    );
+    const pos = state.position;
+    return pos.x >= rect.left && pos.x <= rect.right && pos.y >= rect.top && pos.y <= rect.bottom;
   }, [state.active, state.position, ref]);
 
   return { isOver, fileCount: state.paths.length };
 }
 
-/**
- * Expose the raw drag state for components that need fine-grained
- * hit-testing (e.g. TreeView folder highlight).
- */
 export function useDragActive(): DragDropState {
   return React.useContext(DragDropCtx).state;
 }
 
-/**
- * Full-window provider that listens to Tauri's native drag-drop events.
- * Individual panes use `useDropZone(ref)` to show per-pane overlays.
- *
- * When the user drops, `onDrop` fires with the absolute file paths
- * and the drop position (to determine which pane received the drop).
- */
 export function DragDropProvider(props: {
   children: React.ReactNode;
   onDrop: (paths: string[], position: { x: number; y: number }) => void;
@@ -65,6 +51,9 @@ export function DragDropProvider(props: {
     paths: [],
     position: null,
   });
+
+  const onDropRef = React.useRef(props.onDrop);
+  onDropRef.current = props.onDrop;
 
   React.useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -77,17 +66,20 @@ export function DragDropProvider(props: {
           setState({
             active: true,
             paths: p.paths,
-            position: p.position,
+            position: toLogical(p.position),
           });
         } else if (p.type === "over") {
           setState((prev) => ({
             ...prev,
-            position: p.position,
+            position: toLogical(p.position),
           }));
         } else if (p.type === "drop") {
+          const logicalPos = toLogical(p.position);
           setState((prev) => {
             const paths = prev.paths.length > 0 ? prev.paths : p.paths;
-            props.onDrop(paths, p.position);
+            // Schedule the callback outside the state updater to avoid
+            // side effects inside setState.
+            queueMicrotask(() => onDropRef.current(paths, logicalPos));
             return { active: false, paths: [], position: null };
           });
         } else {
@@ -101,17 +93,13 @@ export function DragDropProvider(props: {
     return () => {
       unlisten?.();
     };
-  }, [props.onDrop]);
+  }, []);
 
   const ctxValue = React.useMemo(() => ({ state }), [state]);
 
   return <DragDropCtx.Provider value={ctxValue}>{props.children}</DragDropCtx.Provider>;
 }
 
-/**
- * Per-pane drop overlay — render as a sibling of the pane content
- * inside a `relative` container.
- */
 export function DropOverlay(props: { isOver: boolean; fileCount: number; label?: string }) {
   if (!props.isOver) return null;
   return (

--- a/app/src/components/drag-drop-overlay.tsx
+++ b/app/src/components/drag-drop-overlay.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { Import } from "lucide-react";
+
+type DragDropState = {
+  active: boolean;
+  paths: string[];
+  position: { x: number; y: number } | null;
+};
+
+type DragDropContextValue = {
+  state: DragDropState;
+};
+
+const DragDropCtx = React.createContext<DragDropContextValue>({
+  state: { active: false, paths: [], position: null },
+});
+
+/**
+ * Check whether the current drag cursor is within a given element.
+ * Returns `isOver` plus the drop-zone label (for the import modal to
+ * know whether the drop landed on a tree directory or the flat pane).
+ */
+export function useDropZone(ref: React.RefObject<HTMLElement | null>): {
+  isOver: boolean;
+  fileCount: number;
+} {
+  const { state } = React.useContext(DragDropCtx);
+
+  const isOver = React.useMemo(() => {
+    if (!state.active || !state.position || !ref.current) return false;
+    const rect = ref.current.getBoundingClientRect();
+    return (
+      state.position.x >= rect.left &&
+      state.position.x <= rect.right &&
+      state.position.y >= rect.top &&
+      state.position.y <= rect.bottom
+    );
+  }, [state.active, state.position, ref]);
+
+  return { isOver, fileCount: state.paths.length };
+}
+
+/**
+ * Full-window provider that listens to Tauri's native drag-drop events.
+ * Individual panes use `useDropZone(ref)` to show per-pane overlays.
+ *
+ * When the user drops, `onDrop` fires with the absolute file paths
+ * and the drop position (to determine which pane received the drop).
+ */
+export function DragDropProvider(props: {
+  children: React.ReactNode;
+  onDrop: (paths: string[], position: { x: number; y: number }) => void;
+}) {
+  const [state, setState] = React.useState<DragDropState>({
+    active: false,
+    paths: [],
+    position: null,
+  });
+
+  React.useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    const setup = async () => {
+      const appWindow = getCurrentWebviewWindow();
+      unlisten = await appWindow.onDragDropEvent((event) => {
+        const p = event.payload;
+        if (p.type === "enter") {
+          setState({
+            active: true,
+            paths: p.paths,
+            position: p.position,
+          });
+        } else if (p.type === "over") {
+          setState((prev) => ({
+            ...prev,
+            position: p.position,
+          }));
+        } else if (p.type === "drop") {
+          setState((prev) => {
+            const paths = prev.paths.length > 0 ? prev.paths : p.paths;
+            props.onDrop(paths, p.position);
+            return { active: false, paths: [], position: null };
+          });
+        } else {
+          setState({ active: false, paths: [], position: null });
+        }
+      });
+    };
+
+    void setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [props.onDrop]);
+
+  const ctxValue = React.useMemo(() => ({ state }), [state]);
+
+  return <DragDropCtx.Provider value={ctxValue}>{props.children}</DragDropCtx.Provider>;
+}
+
+/**
+ * Per-pane drop overlay — render as a sibling of the pane content
+ * inside a `relative` container.
+ */
+export function DropOverlay(props: { isOver: boolean; fileCount: number; label?: string }) {
+  if (!props.isOver) return null;
+  return (
+    <div className="absolute inset-0 z-40 flex items-center justify-center bg-background/60 backdrop-blur-sm rounded-md border-2 border-dashed border-primary/50 transition-all">
+      <div className="flex flex-col items-center gap-2">
+        <Import className="size-8 text-primary animate-pulse" />
+        <div className="text-xs font-medium">
+          Drop to import {props.fileCount} file{props.fileCount === 1 ? "" : "s"}
+        </div>
+        {props.label ? (
+          <div className="text-[0.625rem] text-muted-foreground">{props.label}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/drag-drop-overlay.tsx
+++ b/app/src/components/drag-drop-overlay.tsx
@@ -42,6 +42,14 @@ export function useDropZone(ref: React.RefObject<HTMLElement | null>): {
 }
 
 /**
+ * Expose the raw drag state for components that need fine-grained
+ * hit-testing (e.g. TreeView folder highlight).
+ */
+export function useDragActive(): DragDropState {
+  return React.useContext(DragDropCtx).state;
+}
+
+/**
  * Full-window provider that listens to Tauri's native drag-drop events.
  * Individual panes use `useDropZone(ref)` to show per-pane overlays.
  *

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -23,6 +23,7 @@ import {
   type View,
   type ViewDisplay,
 } from "@/lib/ipc";
+import { useThumbnails } from "@/lib/use-thumbnails";
 import { useProject } from "@/lib/project-context";
 import { useReportFlatView } from "@/lib/flat-view-context";
 import { Button } from "@/components/ui/button";
@@ -118,6 +119,12 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     () => sortHits(response?.hits ?? [], sorting),
     [response, sorting],
   );
+
+  const gridFileIds = React.useMemo(
+    () => (display === "grid" ? sortedHits.map((h) => h.file_id).filter(Boolean) : []),
+    [display, sortedHits],
+  );
+  const thumbUrls = useThumbnails(gridFileIds);
 
   // Mirror project-level state onto the FlatView summary context so
   // <StatusBar> can render the active view + aggregate violation
@@ -375,7 +382,7 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
               onColumnVisibilityChange={setColumnVisibility}
             />
           ) : (
-            <HitGrid hits={sortedHits} onPick={props.onPickHit} />
+            <HitGrid hits={sortedHits} onPick={props.onPickHit} thumbUrls={thumbUrls} />
           )
         ) : null}
       </div>
@@ -553,6 +560,7 @@ function GridSortControls(props: {
 function HitGrid(props: {
   hits: RichSearchHit[];
   onPick: ((hit: RichSearchHit) => void) | undefined;
+  thumbUrls: Record<string, string>;
 }) {
   if (props.hits.length === 0) return <Empty>No results.</Empty>;
   return (
@@ -560,25 +568,38 @@ function HitGrid(props: {
       className="grid gap-2 p-3"
       style={{ gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))" }}
     >
-      {props.hits.map((hit) => (
-        <button
-          key={hit.file_id}
-          type="button"
-          className="flex flex-col gap-1 rounded-md border p-2 text-left hover:bg-accent"
-          onClick={() => props.onPick?.(hit)}
-        >
-          <div className="flex w-full h-full aspect-square items-center justify-center rounded bg-muted/40">
-            <FileIcon className="size-8 opacity-50" />
-          </div>
-          <div className="truncate text-xs font-mono" title={hit.path}>
-            {hit.name ?? hit.path.split("/").pop()}
-          </div>
-          <div className="flex items-center justify-between text-[0.625rem] text-muted-foreground">
-            <span>{hit.kind}</span>
-            <ViolationBadges counts={hit.violations} />
-          </div>
-        </button>
-      ))}
+      {props.hits.map((hit) => {
+        const thumbUrl = props.thumbUrls[hit.file_id];
+        return (
+          <button
+            key={hit.file_id}
+            type="button"
+            className="flex flex-col gap-1 rounded-md border p-2 text-left hover:bg-accent"
+            onClick={() => props.onPick?.(hit)}
+          >
+            <div className="flex w-full h-full aspect-square items-center justify-center rounded bg-muted/40 overflow-hidden">
+              {thumbUrl ? (
+                <img
+                  src={thumbUrl}
+                  alt=""
+                  className="size-full object-cover"
+                  loading="lazy"
+                  draggable={false}
+                />
+              ) : (
+                <FileIcon className="size-8 opacity-50" />
+              )}
+            </div>
+            <div className="truncate text-xs font-mono" title={hit.path}>
+              {hit.name ?? hit.path.split("/").pop()}
+            </div>
+            <div className="flex items-center justify-between text-[0.625rem] text-muted-foreground">
+              <span>{hit.kind}</span>
+              <ViolationBadges counts={hit.violations} />
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -1,5 +1,15 @@
 import * as React from "react";
-import { AlertTriangle, Check, Copy, FileWarning, FolderInput, Scissors } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronsUpDown,
+  Copy,
+  FileWarning,
+  Folder,
+  FolderInput,
+  Scissors,
+  Star,
+} from "lucide-react";
 
 import {
   importApply,
@@ -15,6 +25,13 @@ import {
 import { useProject } from "@/lib/project-context";
 import { Button } from "@/components/ui/button";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+} from "@/components/ui/command";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -22,22 +39,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 type ImportModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Absolute paths of files dropped by the user. */
   sources: string[];
-  /** Pre-selected destination directory (from TreeView drop). */
   initialDest: string | undefined;
 };
 
@@ -48,12 +56,13 @@ export function ImportModal(props: ImportModalProps) {
   const [mode, setMode] = React.useState<"copy" | "move">("copy");
   const [dest, setDest] = React.useState("");
   const [suggestions, setSuggestions] = React.useState<SuggestedDestination[]>([]);
+  const [allDirs, setAllDirs] = React.useState<string[]>([]);
   const [preview, setPreview] = React.useState<ImportPreview | null>(null);
   const [outcome, setOutcome] = React.useState<ImportOutcome | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [busy, setBusy] = React.useState(false);
+  const [dirPickerOpen, setDirPickerOpen] = React.useState(false);
 
-  // Fetch ranking suggestions when the modal opens.
   React.useEffect(() => {
     if (!open || sources.length === 0) return;
     setDest(initialDest ?? "");
@@ -62,21 +71,20 @@ export function ImportModal(props: ImportModalProps) {
     setError(null);
     setMode("copy");
     setSuggestions([]);
+    setAllDirs([]);
 
     importRanking(sources)
       .then((resp) => {
         setSuggestions(resp.suggestions);
+        setAllDirs(resp.all_dirs);
         const first = resp.suggestions[0];
         if (!initialDest && first) {
           setDest(first.path);
         }
       })
-      .catch(() => {
-        // Non-fatal — user can still type a dest.
-      });
+      .catch(() => {});
   }, [open, sources, initialDest]);
 
-  // Build preview whenever dest or mode changes.
   React.useEffect(() => {
     if (!open || sources.length === 0) return;
     if (!dest && !initialDest) {
@@ -126,6 +134,11 @@ export function ImportModal(props: ImportModalProps) {
   }, [preview, sources, dest, mode, bumpRefresh]);
 
   const fileNames = React.useMemo(() => sources.map((s) => s.split("/").pop() ?? s), [sources]);
+
+  const suggestedPaths = React.useMemo(
+    () => new Set(suggestions.map((s) => s.path)),
+    [suggestions],
+  );
 
   if (outcome) {
     return (
@@ -191,38 +204,81 @@ export function ImportModal(props: ImportModalProps) {
             ))}
           </div>
 
-          {/* Destination */}
+          {/* Destination — combobox with autocomplete */}
           <div className="grid gap-1.5">
-            <Label htmlFor="import-dest">Destination directory</Label>
-            {suggestions.length > 0 ? (
-              <Select value={dest} onValueChange={setDest}>
-                <SelectTrigger id="import-dest">
-                  <SelectValue placeholder="Select destination…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {suggestions.map((s) => (
-                    <SelectItem key={s.path} value={s.path}>
-                      <span className="font-mono text-xs">{s.path || "(project root)"}</span>
-                      <span className="ml-2 text-muted-foreground">
-                        {s.score === 3
-                          ? "exact match"
-                          : s.score === 2
-                            ? "alias match"
-                            : "inherited"}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                id="import-dest"
-                value={dest}
-                onChange={(e) => setDest(e.target.value)}
-                placeholder="e.g. assets/textures"
-                className="font-mono text-xs"
-              />
-            )}
+            <Label>Destination directory</Label>
+            <Popover open={dirPickerOpen} onOpenChange={setDirPickerOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={dirPickerOpen}
+                  className="justify-between font-mono text-xs h-9"
+                >
+                  <span className="truncate">{dest || "(project root)"}</span>
+                  <ChevronsUpDown className="ml-2 size-3.5 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                <Command>
+                  <CommandInput placeholder="Search directories…" className="text-xs" />
+                  <CommandEmpty>No directory found.</CommandEmpty>
+                  {suggestions.length > 0 ? (
+                    <CommandGroup heading="Suggested">
+                      {suggestions.map((s) => (
+                        <CommandItem
+                          key={`suggest-${s.path}`}
+                          value={s.path || "(root)"}
+                          onSelect={() => {
+                            setDest(s.path);
+                            setDirPickerOpen(false);
+                          }}
+                          className="text-xs font-mono"
+                        >
+                          <Star className="mr-1.5 size-3 text-primary shrink-0" />
+                          <span className="truncate">{s.path || "(project root)"}</span>
+                          <span className="ml-auto text-[0.625rem] text-muted-foreground shrink-0">
+                            {scoreLabel(s.score)}
+                          </span>
+                          {dest === s.path ? <Check className="ml-1 size-3 shrink-0" /> : null}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  ) : null}
+                  <CommandGroup heading="All directories" className="max-h-48 overflow-auto">
+                    <CommandItem
+                      value="(root)"
+                      onSelect={() => {
+                        setDest("");
+                        setDirPickerOpen(false);
+                      }}
+                      className="text-xs font-mono"
+                    >
+                      <Folder className="mr-1.5 size-3 shrink-0" />
+                      (project root)
+                      {dest === "" ? <Check className="ml-auto size-3 shrink-0" /> : null}
+                    </CommandItem>
+                    {allDirs
+                      .filter((d) => !suggestedPaths.has(d))
+                      .map((d) => (
+                        <CommandItem
+                          key={d}
+                          value={d}
+                          onSelect={() => {
+                            setDest(d);
+                            setDirPickerOpen(false);
+                          }}
+                          className="text-xs font-mono"
+                        >
+                          <Folder className="mr-1.5 size-3 shrink-0" />
+                          <span className="truncate">{d}</span>
+                          {dest === d ? <Check className="ml-auto size-3 shrink-0" /> : null}
+                        </CommandItem>
+                      ))}
+                  </CommandGroup>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </div>
 
           {/* Mode toggle */}
@@ -289,6 +345,12 @@ export function ImportModal(props: ImportModalProps) {
       </DialogContent>
     </Dialog>
   );
+}
+
+function scoreLabel(score: number): string {
+  if (score === 3) return "exact";
+  if (score === 2) return "alias";
+  return "inherited";
 }
 
 function ConflictRow(props: { op: ImportOp }) {

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -7,6 +7,7 @@ import {
   FileWarning,
   Folder,
   FolderInput,
+  Loader2,
   Scissors,
   Star,
 } from "lucide-react";
@@ -337,9 +338,14 @@ export function ImportModal(props: ImportModalProps) {
             Cancel
           </Button>
           <Button onClick={() => void handleApply()} disabled={busy || !preview?.clean}>
-            {busy
-              ? "Importing…"
-              : `Import ${sources.length} file${sources.length === 1 ? "" : "s"}`}
+            {busy ? (
+              <>
+                <Loader2 className="size-3.5 mr-1 animate-spin" />
+                Importing…
+              </>
+            ) : (
+              `Import ${sources.length} file${sources.length === 1 ? "" : "s"}`
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -1,0 +1,341 @@
+import * as React from "react";
+import { AlertTriangle, Check, Copy, FileWarning, FolderInput, Scissors } from "lucide-react";
+
+import {
+  importApply,
+  importPreview,
+  importRanking,
+  type ImportConflict,
+  type ImportOp,
+  type ImportOutcome,
+  type ImportPreview,
+  type ImportRequestWire,
+  type SuggestedDestination,
+} from "@/lib/ipc";
+import { useProject } from "@/lib/project-context";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type ImportModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Absolute paths of files dropped by the user. */
+  sources: string[];
+  /** Pre-selected destination directory (from TreeView drop). */
+  initialDest: string | undefined;
+};
+
+export function ImportModal(props: ImportModalProps) {
+  const { open, onOpenChange, sources, initialDest } = props;
+  const { bumpRefresh } = useProject();
+
+  const [mode, setMode] = React.useState<"copy" | "move">("copy");
+  const [dest, setDest] = React.useState("");
+  const [suggestions, setSuggestions] = React.useState<SuggestedDestination[]>([]);
+  const [preview, setPreview] = React.useState<ImportPreview | null>(null);
+  const [outcome, setOutcome] = React.useState<ImportOutcome | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  // Fetch ranking suggestions when the modal opens.
+  React.useEffect(() => {
+    if (!open || sources.length === 0) return;
+    setDest(initialDest ?? "");
+    setPreview(null);
+    setOutcome(null);
+    setError(null);
+    setMode("copy");
+    setSuggestions([]);
+
+    importRanking(sources)
+      .then((resp) => {
+        setSuggestions(resp.suggestions);
+        const first = resp.suggestions[0];
+        if (!initialDest && first) {
+          setDest(first.path);
+        }
+      })
+      .catch(() => {
+        // Non-fatal — user can still type a dest.
+      });
+  }, [open, sources, initialDest]);
+
+  // Build preview whenever dest or mode changes.
+  React.useEffect(() => {
+    if (!open || sources.length === 0) return;
+    if (!dest && !initialDest) {
+      setPreview(null);
+      return;
+    }
+
+    const activeDest = dest || "";
+    const requests: ImportRequestWire[] = sources.map((src) => {
+      const filename = src.split("/").pop() ?? src;
+      const destPath = activeDest ? `${activeDest}/${filename}` : filename;
+      return { source: src, dest: destPath, mode };
+    });
+
+    let cancelled = false;
+    importPreview(requests)
+      .then((p) => {
+        if (!cancelled) setPreview(p);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, sources, dest, mode, initialDest]);
+
+  const handleApply = React.useCallback(async () => {
+    if (!preview || !preview.clean) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const requests: ImportRequestWire[] = sources.map((src) => {
+        const filename = src.split("/").pop() ?? src;
+        const destPath = dest ? `${dest}/${filename}` : filename;
+        return { source: src, dest: destPath, mode };
+      });
+      const result = await importApply(requests);
+      setOutcome(result);
+      bumpRefresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [preview, sources, dest, mode, bumpRefresh]);
+
+  const fileNames = React.useMemo(() => sources.map((s) => s.split("/").pop() ?? s), [sources]);
+
+  if (outcome) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Check className="size-5 text-green-500" />
+              Import complete
+            </DialogTitle>
+            <DialogDescription>
+              {outcome.imported.length} file{outcome.imported.length === 1 ? "" : "s"} imported
+              {outcome.warnings.length > 0 ? ` with ${outcome.warnings.length} warning(s)` : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-48 overflow-auto text-xs font-mono space-y-0.5">
+            {outcome.imported.map((f) => (
+              <div key={f.dest} className="flex items-center gap-1.5 text-muted-foreground">
+                {f.mode === "move" ? (
+                  <Scissors className="size-3 shrink-0" />
+                ) : (
+                  <Copy className="size-3 shrink-0" />
+                )}
+                <span className="truncate">{f.dest}</span>
+              </div>
+            ))}
+          </div>
+          {outcome.warnings.length > 0 ? (
+            <div className="rounded border border-warning/30 bg-warning/5 p-2 text-xs space-y-0.5">
+              {outcome.warnings.map((w, i) => (
+                <div key={`${w.dest}-${i}`} className="text-warning">
+                  {w.kind}: {w.message}
+                </div>
+              ))}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button onClick={() => onOpenChange(false)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderInput className="size-5" />
+            Import {sources.length} file{sources.length === 1 ? "" : "s"}
+          </DialogTitle>
+          <DialogDescription>Choose a destination directory and import mode.</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          {/* File list preview */}
+          <div className="max-h-32 overflow-auto rounded border bg-muted/30 p-2 text-xs font-mono space-y-0.5">
+            {fileNames.map((name, i) => (
+              <div key={`${name}-${i}`} className="truncate">
+                {name}
+              </div>
+            ))}
+          </div>
+
+          {/* Destination */}
+          <div className="grid gap-1.5">
+            <Label htmlFor="import-dest">Destination directory</Label>
+            {suggestions.length > 0 ? (
+              <Select value={dest} onValueChange={setDest}>
+                <SelectTrigger id="import-dest">
+                  <SelectValue placeholder="Select destination…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {suggestions.map((s) => (
+                    <SelectItem key={s.path} value={s.path}>
+                      <span className="font-mono text-xs">{s.path || "(project root)"}</span>
+                      <span className="ml-2 text-muted-foreground">
+                        {s.score === 3
+                          ? "exact match"
+                          : s.score === 2
+                            ? "alias match"
+                            : "inherited"}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id="import-dest"
+                value={dest}
+                onChange={(e) => setDest(e.target.value)}
+                placeholder="e.g. assets/textures"
+                className="font-mono text-xs"
+              />
+            )}
+          </div>
+
+          {/* Mode toggle */}
+          <div className="grid gap-1.5">
+            <Label>Import mode</Label>
+            <div className="flex gap-2">
+              <Button
+                variant={mode === "copy" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setMode("copy")}
+              >
+                <Copy className="size-3.5 mr-1" /> Copy
+              </Button>
+              <Button
+                variant={mode === "move" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setMode("move")}
+              >
+                <Scissors className="size-3.5 mr-1" /> Move
+              </Button>
+            </div>
+            {mode === "move" ? (
+              <p className="text-xs text-warning">Move deletes the original files after import.</p>
+            ) : null}
+          </div>
+
+          {/* Preview / conflicts */}
+          {preview ? (
+            preview.clean ? (
+              <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
+                <Check className="size-3.5" />
+                {preview.ops.length} file{preview.ops.length === 1 ? "" : "s"} ready to import
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-1.5 text-xs text-warning">
+                  <AlertTriangle className="size-3.5" />
+                  {preview.conflict_count} conflict{preview.conflict_count === 1 ? "" : "s"}
+                </div>
+                <div className="max-h-32 overflow-auto rounded border border-warning/30 bg-warning/5 p-2 text-xs space-y-1">
+                  {preview.ops
+                    .filter((op) => op.conflicts.length > 0)
+                    .map((op) => (
+                      <ConflictRow key={op.source} op={op} />
+                    ))}
+                </div>
+              </div>
+            )
+          ) : null}
+
+          {error ? <div className="text-xs text-destructive">{error}</div> : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleApply()} disabled={busy || !preview?.clean}>
+            {busy
+              ? "Importing…"
+              : `Import ${sources.length} file${sources.length === 1 ? "" : "s"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ConflictRow(props: { op: ImportOp }) {
+  const filename = props.op.source.split("/").pop() ?? props.op.source;
+  return (
+    <div>
+      <div className="font-mono truncate font-medium">{filename}</div>
+      {props.op.conflicts.map((c, i) => (
+        <ConflictDetail key={i} conflict={c} />
+      ))}
+    </div>
+  );
+}
+
+function ConflictDetail(props: { conflict: ImportConflict }) {
+  const c = props.conflict;
+  switch (c.kind) {
+    case "dest_exists":
+      return (
+        <div className="flex items-center gap-1 text-warning pl-2">
+          <FileWarning className="size-3 shrink-0" />
+          Destination exists: {c.existing_path}
+        </div>
+      );
+    case "source_missing":
+      return (
+        <div className="flex items-center gap-1 text-destructive pl-2">
+          <AlertTriangle className="size-3 shrink-0" />
+          Source not found: {c.reason}
+        </div>
+      );
+    case "source_is_project":
+      return (
+        <div className="flex items-center gap-1 text-warning pl-2">
+          <AlertTriangle className="size-3 shrink-0" />
+          Already in project — use rename instead
+        </div>
+      );
+    case "placement_mismatch":
+      return (
+        <div className="flex items-center gap-1 text-warning pl-2">
+          <AlertTriangle className="size-3 shrink-0" />
+          Dir doesn't accept this extension
+          {c.suggestion ? ` (try ${c.suggestion})` : ""}
+        </div>
+      );
+    default:
+      return null;
+  }
+}

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -7,10 +7,11 @@ import {
   FileWarning,
   Folder,
   FolderInput,
-  Loader2,
   Scissors,
   Star,
 } from "lucide-react";
+
+import { DotmSquare8 } from "@/components/ui/dotm-square-8";
 
 import {
   importApply,
@@ -340,7 +341,7 @@ export function ImportModal(props: ImportModalProps) {
           <Button onClick={() => void handleApply()} disabled={busy || !preview?.clean}>
             {busy ? (
               <>
-                <Loader2 className="size-3.5 mr-1 animate-spin" />
+                <DotmSquare8 size={16} dotSize={2} animated className="mr-1.5" />
                 Importing…
               </>
             ) : (

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -113,8 +113,8 @@ export function ImportModal(props: ImportModalProps) {
     };
   }, [open, sources, dest, mode, initialDest]);
 
-  const handleApply = React.useCallback(async () => {
-    if (!preview || !preview.clean) return;
+  const handleApply = async () => {
+    if (!preview || !preview.clean || busy) return;
     setBusy(true);
     setError(null);
     try {
@@ -131,7 +131,7 @@ export function ImportModal(props: ImportModalProps) {
     } finally {
       setBusy(false);
     }
-  }, [preview, sources, dest, mode, bumpRefresh]);
+  };
 
   const fileNames = React.useMemo(() => sources.map((s) => s.split("/").pop() ?? s), [sources]);
 

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -16,16 +16,24 @@ type DirState = {
   error?: string;
 };
 
+/**
+ * Given a CSS-pixel position, find the closest `[data-dir-path]`
+ * ancestor of the element under that point.  Returns the path string
+ * or `null` if the cursor is not over any DirNode.
+ */
+export function dirPathAtPoint(pos: { x: number; y: number }): string | null {
+  const el = document.elementFromPoint(pos.x, pos.y);
+  const btn = el?.closest("[data-dir-path]");
+  if (!btn) return null;
+  return btn.getAttribute("data-dir-path");
+}
+
 export function TreeView(props: {
   onPickFile?: (entry: DirEntry) => void;
   selectedDir?: string;
   onSelectDir?: (path: string) => void;
-  /** Ref updated with the path of the directory currently under the drag cursor. */
-  dragHoverDirRef?: React.MutableRefObject<string | null>;
 }) {
   const { project, refreshTick } = useProject();
-  // path "" = root; cache keeps loaded children + error per path so
-  // collapsing/re-expanding doesn't re-fetch.
   const [cache, setCache] = React.useState<Record<string, DirState>>({});
   const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set([""]));
 
@@ -46,20 +54,12 @@ export function TreeView(props: {
     }
   }, []);
 
-  // Reset cache + expanded set when the attached project changes,
-  // then refetch the new root. Without this, the tree would keep
-  // showing the old project's directory snapshot until the user
-  // collapsed and re-expanded each branch.
   React.useEffect(() => {
     setCache({});
     setExpanded(new Set([""]));
     void fetchDir("");
   }, [project?.root, fetchDir]);
 
-  // `refreshTick` is bumped by long-lived workflows that mutate
-  // indexed state (accepts edits → lint refresh). Drop the cache and
-  // re-fetch every currently-expanded path so the badges update
-  // without forcing the user to collapse / re-expand each branch.
   const expandedSnapshot = React.useRef(expanded);
   expandedSnapshot.current = expanded;
   React.useEffect(() => {
@@ -102,7 +102,6 @@ export function TreeView(props: {
         onSelectDir={props.onSelectDir}
         dragActive={dragState.active}
         dragPosition={dragState.position}
-        dragHoverDirRef={props.dragHoverDirRef}
       />
     </nav>
   );
@@ -120,7 +119,6 @@ function DirNode(props: {
   onSelectDir: ((path: string) => void) | undefined;
   dragActive: boolean;
   dragPosition: { x: number; y: number } | null;
-  dragHoverDirRef: React.MutableRefObject<string | null> | undefined;
 }) {
   const {
     path,
@@ -134,7 +132,6 @@ function DirNode(props: {
     onSelectDir,
     dragActive,
     dragPosition,
-    dragHoverDirRef,
   } = props;
   const isOpen = expanded.has(path);
   const isSelected = selectedDir === path;
@@ -156,15 +153,12 @@ function DirNode(props: {
       );
     })();
 
-  if (isDragOver && dragHoverDirRef) {
-    dragHoverDirRef.current = path;
-  }
-
   return (
     <div>
       <button
         ref={btnRef}
         type="button"
+        data-dir-path={path}
         className={cn(
           "flex w-full items-center gap-1 rounded px-1 py-0.5 hover:bg-accent",
           isSelected && "bg-accent text-accent-foreground",
@@ -220,7 +214,6 @@ function DirNode(props: {
                   onSelectDir={onSelectDir}
                   dragActive={dragActive}
                   dragPosition={dragPosition}
-                  dragHoverDirRef={dragHoverDirRef}
                 />
               ) : (
                 <FileNode key={child.path} entry={child} depth={depth + 1} onPick={onPickFile} />

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ChevronRight, ChevronDown, Folder, FolderOpen, FileIcon } from "lucide-react";
 
+import { useDragActive } from "@/components/drag-drop-overlay";
 import { filesListDir, IpcError, type DirEntry, type FileEntry } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
 
@@ -19,6 +20,8 @@ export function TreeView(props: {
   onPickFile?: (entry: DirEntry) => void;
   selectedDir?: string;
   onSelectDir?: (path: string) => void;
+  /** Ref updated with the path of the directory currently under the drag cursor. */
+  dragHoverDirRef?: React.MutableRefObject<string | null>;
 }) {
   const { project, refreshTick } = useProject();
   // path "" = root; cache keeps loaded children + error per path so
@@ -83,6 +86,8 @@ export function TreeView(props: {
     [expanded, cache, fetchDir],
   );
 
+  const dragState = useDragActive();
+
   return (
     <nav className="h-full overflow-auto p-1 text-xs">
       <DirNode
@@ -95,6 +100,9 @@ export function TreeView(props: {
         onPickFile={props.onPickFile}
         selectedDir={props.selectedDir}
         onSelectDir={props.onSelectDir}
+        dragActive={dragState.active}
+        dragPosition={dragState.position}
+        dragHoverDirRef={props.dragHoverDirRef}
       />
     </nav>
   );
@@ -110,20 +118,57 @@ function DirNode(props: {
   onPickFile: ((entry: DirEntry) => void) | undefined;
   selectedDir: string | undefined;
   onSelectDir: ((path: string) => void) | undefined;
+  dragActive: boolean;
+  dragPosition: { x: number; y: number } | null;
+  dragHoverDirRef: React.MutableRefObject<string | null> | undefined;
 }) {
-  const { path, name, depth, expanded, cache, toggle, onPickFile, selectedDir, onSelectDir } =
-    props;
+  const {
+    path,
+    name,
+    depth,
+    expanded,
+    cache,
+    toggle,
+    onPickFile,
+    selectedDir,
+    onSelectDir,
+    dragActive,
+    dragPosition,
+    dragHoverDirRef,
+  } = props;
   const isOpen = expanded.has(path);
   const isSelected = selectedDir === path;
   const entry = cache[path];
   const indent = depth * 12;
+
+  const btnRef = React.useRef<HTMLButtonElement>(null);
+  const isDragOver =
+    dragActive &&
+    dragPosition != null &&
+    btnRef.current != null &&
+    (() => {
+      const rect = btnRef.current!.getBoundingClientRect();
+      return (
+        dragPosition.x >= rect.left &&
+        dragPosition.x <= rect.right &&
+        dragPosition.y >= rect.top &&
+        dragPosition.y <= rect.bottom
+      );
+    })();
+
+  if (isDragOver && dragHoverDirRef) {
+    dragHoverDirRef.current = path;
+  }
+
   return (
     <div>
       <button
+        ref={btnRef}
         type="button"
         className={cn(
           "flex w-full items-center gap-1 rounded px-1 py-0.5 hover:bg-accent",
           isSelected && "bg-accent text-accent-foreground",
+          isDragOver && "bg-primary/20 ring-1 ring-primary/50",
         )}
         style={{ paddingLeft: indent + 4 }}
         onClick={() => {
@@ -173,6 +218,9 @@ function DirNode(props: {
                   onPickFile={onPickFile}
                   selectedDir={selectedDir}
                   onSelectDir={onSelectDir}
+                  dragActive={dragActive}
+                  dragPosition={dragPosition}
+                  dragHoverDirRef={dragHoverDirRef}
                 />
               ) : (
                 <FileNode key={child.path} entry={child} depth={depth + 1} onPick={onPickFile} />

--- a/app/src/components/ui/dotm-square-8.tsx
+++ b/app/src/components/ui/dotm-square-8.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { DotMatrixBase } from "@/lib/dotmatrix-core";
+import { useDotMatrixPhases } from "@/lib/dotmatrix-hooks";
+import { MATRIX_SIZE } from "@/lib/dotmatrix-core";
+import { usePrefersReducedMotion } from "@/lib/dotmatrix-hooks";
+import { useSteppedCycle } from "@/lib/dotmatrix-hooks";
+import type { DotAnimationResolver, DotMatrixCommonProps } from "@/lib/dotmatrix-core";
+
+export type DotmSquare8Props = DotMatrixCommonProps;
+
+const ROWS = MATRIX_SIZE;
+const COLS = MATRIX_SIZE;
+
+/** Steps 0..FILL_LAST: column `c` gains one row from the bottom each tick, delayed by `c` (col 0 full at `ROWS`, last col at `ROWS + COLS - 1`). */
+const FILL_LAST = ROWS + COLS - 1;
+
+const BLINK_STEPS = 4;
+const BLINK_OPACITIES = [0.38, 1, 0.38, 1] as const;
+
+const DRAIN_LAST = FILL_LAST;
+
+/** fillTick 0..FILL_LAST → drainTick 0..DRAIN_LAST → + blink in between */
+const SEQUENCE_LEN = FILL_LAST + 1 + BLINK_STEPS + DRAIN_LAST + 1;
+
+const BASE_OPACITY = 0.08;
+const SETTLED_OPACITY = 0.52;
+const CAP_OPACITY = 1;
+
+function fillHeight(col: number, fillTick: number): number {
+  return Math.max(0, Math.min(ROWS, fillTick - col));
+}
+
+function drainHeight(col: number, drainTick: number): number {
+  return Math.max(0, Math.min(ROWS, ROWS - Math.max(0, drainTick - col)));
+}
+
+export function DotmSquare8({
+  speed = 1.4,
+  pattern = "full",
+  animated = true,
+  hoverAnimated = false,
+  ...rest
+}: DotmSquare8Props) {
+  const reducedMotion = usePrefersReducedMotion();
+  const { phase: matrixPhase, onMouseEnter, onMouseLeave } = useDotMatrixPhases({
+    animated: Boolean(animated && !reducedMotion),
+    hoverAnimated: Boolean(hoverAnimated && !reducedMotion),
+    speed
+  });
+  const step = useSteppedCycle({
+    active: !reducedMotion && matrixPhase !== "idle" && SEQUENCE_LEN > 0,
+    cycleMsBase: 2000,
+    steps: SEQUENCE_LEN,
+    speed,
+  });
+
+  const resolver = useMemo<DotAnimationResolver>(() => {
+    return ({ isActive, row, col, phase }) => {
+      if (!isActive) {
+        return { className: "dmx-inactive" };
+      }
+
+      if (reducedMotion || phase === "idle") {
+        return { style: { opacity: BASE_OPACITY } };
+      }
+
+      let height = 0;
+      let blinkOpacity: number | null = null;
+
+      if (step <= FILL_LAST) {
+        height = fillHeight(col, step);
+      } else if (step < FILL_LAST + 1 + BLINK_STEPS) {
+        height = ROWS;
+        blinkOpacity = BLINK_OPACITIES[step - (FILL_LAST + 1)] ?? 1;
+      } else {
+        const drainTick = step - (FILL_LAST + 1 + BLINK_STEPS);
+        height = drainHeight(col, drainTick);
+      }
+
+      const bottomRow = ROWS - 1;
+      const topLitRow = ROWS - height;
+      const isLit = height > 0 && row >= topLitRow && row <= bottomRow;
+      if (!isLit) {
+        return { style: { opacity: BASE_OPACITY } };
+      }
+
+      if (blinkOpacity !== null) {
+        return { style: { opacity: blinkOpacity } };
+      }
+
+      const isCap = row === topLitRow && height > 0 && height < ROWS;
+      return {
+        style: { opacity: isCap ? CAP_OPACITY : SETTLED_OPACITY }
+      };
+    };
+  }, [reducedMotion, step]);
+
+  return (
+    <DotMatrixBase
+      {...rest}
+      size={rest.size ?? 36}
+      dotSize={rest.dotSize ?? 5}
+      speed={speed}
+      pattern={pattern}
+      animated={animated}
+      phase={matrixPhase}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      reducedMotion={reducedMotion}
+      animationResolver={resolver}
+    />
+  );
+}

--- a/app/src/lib/dotmatrix-core.tsx
+++ b/app/src/lib/dotmatrix-core.tsx
@@ -1,0 +1,800 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import "@/components/dotmatrix-loader.css";
+import { useDotMatrixPhases, usePrefersReducedMotion } from "@/lib/dotmatrix-hooks";
+
+export type MatrixPattern = "diamond" | "full" | "outline" | "rose" | "cross" | "rings";
+export type DotMatrixPhase = "idle" | "collapse" | "hoverRipple" | "loadingRipple";
+
+export interface DotMatrixCommonProps {
+  size?: number;
+  dotSize?: number;
+  color?: string;
+  speed?: number;
+  ariaLabel?: string;
+  className?: string;
+  pattern?: MatrixPattern;
+  muted?: boolean;
+  animated?: boolean;
+  hoverAnimated?: boolean;
+  dotClassName?: string;
+  opacityBase?: number;
+  opacityMid?: number;
+  opacityPeak?: number;
+  cellPadding?: number;
+  boxSize?: number;
+  minSize?: number;
+}
+
+export interface DotAnimationContext {
+  index: number;
+  row: number;
+  col: number;
+  distanceFromCenter: number;
+  angleFromCenter: number;
+  radiusNormalized: number;
+  manhattanDistance: number;
+  phase: DotMatrixPhase;
+  isActive: boolean;
+  reducedMotion: boolean;
+}
+
+export interface DotAnimationState {
+  className?: string;
+  style?: CSSProperties;
+}
+
+export type DotAnimationResolver = (ctx: DotAnimationContext) => DotAnimationState;
+
+export function cx(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export const MATRIX_SIZE = 5;
+const CENTER = Math.floor(MATRIX_SIZE / 2);
+const RANGE = Array.from({ length: MATRIX_SIZE }, (_, index) => index);
+const MAX_RADIUS = Math.hypot(CENTER, CENTER);
+
+export const FULL_INDEXES = RANGE.flatMap((row) => RANGE.map((col) => rowMajorIndex(row, col)));
+
+export const DIAMOND_INDEXES = FULL_INDEXES.filter((index) => {
+  const { row, col } = indexToCoord(index);
+  return Math.abs(row - CENTER) + Math.abs(col - CENTER) <= 2;
+});
+
+export const OUTLINE_INDEXES = FULL_INDEXES.filter((index) => {
+  const { row, col } = indexToCoord(index);
+  return row === 0 || row === MATRIX_SIZE - 1 || col === 0 || col === MATRIX_SIZE - 1;
+});
+
+export const CROSS_INDEXES = FULL_INDEXES.filter((index) => {
+  const { row, col } = indexToCoord(index);
+  return row === CENTER || col === CENTER;
+});
+
+export const RINGS_INDEXES = FULL_INDEXES.filter((index) => {
+  const { row, col } = indexToCoord(index);
+  const radius = Math.hypot(row - CENTER, col - CENTER);
+  return Math.round(radius) === 1 || Math.round(radius) === 2;
+});
+
+export const ROSE_INDEXES = FULL_INDEXES.filter((index) => {
+  const { row, col } = indexToCoord(index);
+  const dx = col - CENTER;
+  const dy = row - CENTER;
+  const angle = Math.atan2(dy, dx);
+  const radius = Math.hypot(dx, dy);
+  const rose = Math.abs(Math.sin(3 * angle));
+  return rose > 0.6 && radius >= 1;
+});
+
+const PATTERN_INDEXES: Record<MatrixPattern, number[]> = {
+  diamond: DIAMOND_INDEXES,
+  full: FULL_INDEXES,
+  outline: OUTLINE_INDEXES,
+  rose: ROSE_INDEXES,
+  cross: CROSS_INDEXES,
+  rings: RINGS_INDEXES,
+};
+
+export function getPatternIndexes(pattern: MatrixPattern = "diamond"): number[] {
+  return PATTERN_INDEXES[pattern];
+}
+
+export function rowMajorIndex(row: number, col: number): number {
+  return row * MATRIX_SIZE + col;
+}
+
+export function indexToCoord(index: number): { row: number; col: number } {
+  return {
+    row: Math.floor(index / MATRIX_SIZE),
+    col: index % MATRIX_SIZE,
+  };
+}
+
+export function distanceFromCenter(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return Math.hypot(row - CENTER, col - CENTER);
+}
+
+export function rowDistance(index: number): number {
+  const { row } = indexToCoord(index);
+  return Math.abs(row - CENTER);
+}
+
+export function polarAngle(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return Math.atan2(row - CENTER, col - CENTER);
+}
+
+export function normalizedRadius(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return Math.hypot(row - CENTER, col - CENTER) / MAX_RADIUS;
+}
+
+export function manhattanDistance(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return Math.abs(row - CENTER) + Math.abs(col - CENTER);
+}
+
+export function harmonicPhase(row: number, col: number, a: number, b: number): number {
+  return Math.sin((row + 1) * a + (col + 1) * b);
+}
+
+export function lissajousOffset(
+  row: number,
+  col: number,
+  amplitude = 2.25,
+): { x: number; y: number; phase: number } {
+  const x = Math.sin((row + 1) * 1.15 + (col + 1) * 2.2) * amplitude;
+  const y = Math.cos((row + 1) * 2.45 + (col + 1) * 0.95) * amplitude;
+  const phase = Math.abs(Math.sin((row + 1) * 0.7 + (col + 1) * 1.1));
+  return { x, y, phase };
+}
+
+export function spiralOffset(
+  angle: number,
+  radiusNormalizedValue: number,
+  amplitude = 2.8,
+): { x: number; y: number; phase: number } {
+  const spin = angle + radiusNormalizedValue * Math.PI * 2.1;
+  const radius = radiusNormalizedValue * amplitude;
+  const x = Math.cos(spin) * radius;
+  const y = Math.sin(spin) * radius;
+  const phase = Math.abs(Math.sin(spin * 0.5));
+  return { x, y, phase };
+}
+
+export function isPrime(value: number): boolean {
+  if (value <= 1) {
+    return false;
+  }
+  if (value === 2) {
+    return true;
+  }
+  if (value % 2 === 0) {
+    return false;
+  }
+
+  const limit = Math.floor(Math.sqrt(value));
+  for (let divisor = 3; divisor <= limit; divisor += 2) {
+    if (value % divisor === 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const N = MATRIX_SIZE;
+const C = Math.floor(MATRIX_SIZE / 2);
+const CELLS = N * N;
+const MAX_TRBL = (N - 1) * 2;
+
+export function trBlPathNormFromIndex(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return (row + (N - 1 - col)) / MAX_TRBL;
+}
+
+function buildSnakeOrderToIndexMap(): number[] {
+  const pathOrder = new Array<number>(CELLS);
+  const key = (row: number, col: number) => rowMajorIndex(row, col);
+  let t = 0;
+  for (let row = 0; row < N; row += 1) {
+    if (row % 2 === 0) {
+      for (let col = 0; col < N; col += 1) {
+        pathOrder[key(row, col)] = t;
+        t += 1;
+      }
+    } else {
+      for (let col = N - 1; col >= 0; col -= 1) {
+        pathOrder[key(row, col)] = t;
+        t += 1;
+      }
+    }
+  }
+  return pathOrder;
+}
+
+const SNAKE_ORDER: readonly number[] = buildSnakeOrderToIndexMap();
+
+export function snakePathNormFromIndex(index: number): number {
+  return SNAKE_ORDER[index]! / (CELLS - 1);
+}
+
+export function snakePathOrderValue(index: number): number {
+  return SNAKE_ORDER[index]!;
+}
+
+function buildSpiralInwardOrderToIndexMap(): number[] {
+  const order = new Array<number>(CELLS);
+  let top = 0;
+  let bottom = N - 1;
+  let left = 0;
+  let right = N - 1;
+  let t = 0;
+
+  while (top <= bottom && left <= right) {
+    for (let col = left; col <= right; col += 1) {
+      order[rowMajorIndex(top, col)] = t;
+      t += 1;
+    }
+
+    for (let row = top + 1; row <= bottom; row += 1) {
+      order[rowMajorIndex(row, right)] = t;
+      t += 1;
+    }
+
+    if (top < bottom) {
+      for (let col = right - 1; col >= left; col -= 1) {
+        order[rowMajorIndex(bottom, col)] = t;
+        t += 1;
+      }
+    }
+
+    if (left < right) {
+      for (let row = bottom - 1; row > top; row -= 1) {
+        order[rowMajorIndex(row, left)] = t;
+        t += 1;
+      }
+    }
+
+    top += 1;
+    bottom -= 1;
+    left += 1;
+    right -= 1;
+  }
+
+  return order;
+}
+
+const SPIRAL_INWARD_ORDER: readonly number[] = buildSpiralInwardOrderToIndexMap();
+
+export function spiralInwardNormFromIndex(index: number): number {
+  return SPIRAL_INWARD_ORDER[index]! / (CELLS - 1);
+}
+
+export function spiralInwardOrderValue(index: number): number {
+  return SPIRAL_INWARD_ORDER[index]!;
+}
+
+function buildOuterRingClockwiseOrderToIndexMap(): number[] {
+  const order = new Array<number>(CELLS).fill(-1);
+  const coords: Array<[number, number]> = [
+    [0, 0],
+    [0, 1],
+    [0, 2],
+    [0, 3],
+    [0, 4],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+    [4, 4],
+    [4, 3],
+    [4, 2],
+    [4, 1],
+    [4, 0],
+    [3, 0],
+    [2, 0],
+    [1, 0],
+  ];
+
+  for (let t = 0; t < coords.length; t += 1) {
+    const [row, col] = coords[t]!;
+    order[rowMajorIndex(row, col)] = t;
+  }
+
+  return order;
+}
+
+function buildMiddleRingAntiClockwiseOrderToIndexMap(): number[] {
+  const order = new Array<number>(CELLS).fill(-1);
+  const coords: Array<[number, number]> = [
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [3, 2],
+    [3, 3],
+    [2, 3],
+    [1, 3],
+    [1, 2],
+  ];
+
+  for (let t = 0; t < coords.length; t += 1) {
+    const [row, col] = coords[t]!;
+    order[rowMajorIndex(row, col)] = t;
+  }
+
+  return order;
+}
+
+const OUTER_RING_CLOCKWISE_ORDER: readonly number[] = buildOuterRingClockwiseOrderToIndexMap();
+const MIDDLE_RING_ANTI_CLOCKWISE_ORDER: readonly number[] =
+  buildMiddleRingAntiClockwiseOrderToIndexMap();
+
+export function outerRingClockwiseOrderValue(index: number): number {
+  return OUTER_RING_CLOCKWISE_ORDER[index]!;
+}
+
+export function outerRingClockwiseNormFromIndex(index: number): number {
+  const order = outerRingClockwiseOrderValue(index);
+  return order >= 0 ? order / 15 : 0;
+}
+
+export function middleRingAntiClockwiseOrderValue(index: number): number {
+  return MIDDLE_RING_ANTI_CLOCKWISE_ORDER[index]!;
+}
+
+export function middleRingAntiClockwiseNormFromIndex(index: number): number {
+  const order = middleRingAntiClockwiseOrderValue(index);
+  return order >= 0 ? order / 7 : 0;
+}
+
+function buildDiagonalSnakeOrderToIndexMap(): number[] {
+  const order = new Array<number>(CELLS);
+  let t = 0;
+
+  for (let diagonal = 0; diagonal <= (N - 1) * 2; diagonal += 1) {
+    const rowStart = Math.max(0, diagonal - (N - 1));
+    const rowEnd = Math.min(N - 1, diagonal);
+
+    if (diagonal % 2 === 0) {
+      for (let row = rowEnd; row >= rowStart; row -= 1) {
+        const col = diagonal - row;
+        order[rowMajorIndex(row, col)] = t;
+        t += 1;
+      }
+    } else {
+      for (let row = rowStart; row <= rowEnd; row += 1) {
+        const col = diagonal - row;
+        order[rowMajorIndex(row, col)] = t;
+        t += 1;
+      }
+    }
+  }
+
+  return order;
+}
+
+const DIAGONAL_SNAKE_ORDER: readonly number[] = buildDiagonalSnakeOrderToIndexMap();
+
+export function diagonalSnakeOrderValue(index: number): number {
+  return DIAGONAL_SNAKE_ORDER[index]!;
+}
+
+export function diagonalSnakeNormFromIndex(index: number): number {
+  return DIAGONAL_SNAKE_ORDER[index]! / (CELLS - 1);
+}
+
+function buildRowWaveSnakeOrderToIndexMap(): number[] {
+  const order = new Array<number>(CELLS);
+  const route: Array<{ col: number; dir: "up" | "down" }> = [
+    { col: 0, dir: "up" },
+    { col: 2, dir: "down" },
+    { col: 1, dir: "up" },
+    { col: 3, dir: "down" },
+    { col: 2, dir: "up" },
+    { col: 4, dir: "down" },
+  ];
+
+  let t = 0;
+  for (const step of route) {
+    if (step.dir === "up") {
+      for (let row = N - 1; row >= 0; row -= 1) {
+        order[rowMajorIndex(row, step.col)] = t;
+        t += 1;
+      }
+    } else {
+      for (let row = 0; row < N; row += 1) {
+        order[rowMajorIndex(row, step.col)] = t;
+        t += 1;
+      }
+    }
+  }
+
+  return order;
+}
+
+const ROW_WAVE_SNAKE_ORDER: readonly number[] = buildRowWaveSnakeOrderToIndexMap();
+const ROW_WAVE_SNAKE_MAX_ORDER = Math.max(...ROW_WAVE_SNAKE_ORDER);
+
+export function rowWaveOrderValue(index: number): number {
+  return ROW_WAVE_SNAKE_ORDER[index]!;
+}
+
+export function rowWaveNormFromIndex(index: number): number {
+  return ROW_WAVE_SNAKE_MAX_ORDER > 0 ? rowWaveOrderValue(index) / ROW_WAVE_SNAKE_MAX_ORDER : 0;
+}
+
+export function colWaveNormFromIndex(index: number): number {
+  const { col } = indexToCoord(index);
+  return N > 1 ? col / (N - 1) : 0;
+}
+
+export function concentricRingNormFromIndex(index: number): number {
+  const { row, col } = indexToCoord(index);
+  return Math.max(Math.abs(row - C), Math.abs(col - C)) / C;
+}
+
+const CORNER_COORDS = new Set(["0,0", "0,4", "4,0", "4,4"]);
+
+export function isWithinCircularMask(row: number, col: number): boolean {
+  return !CORNER_COORDS.has(`${row},${col}`);
+}
+
+export function stylePx(n: number): string {
+  return `${n}px`;
+}
+
+export function styleOpacity(opacity: number): number {
+  return Math.round(opacity * 1e6) / 1e6;
+}
+
+const SOURCE_BASE_OPACITY = 0.08;
+const SOURCE_MID_OPACITY = 0.34;
+const SOURCE_PEAK_OPACITY = 0.94;
+
+function lerpDmx(start: number, end: number, progress: number): number {
+  return start + (end - start) * progress;
+}
+
+function normalizeProgressDmx(value: number, start: number, end: number): number {
+  const span = end - start;
+  if (Math.abs(span) < Number.EPSILON) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, (value - start) / span));
+}
+
+function coerceOpacityDmx(value: number | undefined): number | undefined {
+  if (value == null || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+export function remapOpacityToTriplet(
+  opacity: number,
+  opacityBase: number | undefined,
+  opacityMid: number | undefined,
+  opacityPeak: number | undefined,
+): number {
+  if (!Number.isFinite(opacity)) {
+    return opacity;
+  }
+
+  const hasOverrides =
+    opacityBase !== undefined || opacityMid !== undefined || opacityPeak !== undefined;
+  const safeOpacity = Math.min(1, Math.max(0, opacity));
+  if (!hasOverrides) {
+    return safeOpacity;
+  }
+
+  const targetBase = coerceOpacityDmx(opacityBase) ?? SOURCE_BASE_OPACITY;
+  const targetMid = coerceOpacityDmx(opacityMid) ?? SOURCE_MID_OPACITY;
+  const targetPeak = coerceOpacityDmx(opacityPeak) ?? SOURCE_PEAK_OPACITY;
+
+  if (safeOpacity <= SOURCE_BASE_OPACITY) {
+    const progress = normalizeProgressDmx(safeOpacity, 0, SOURCE_BASE_OPACITY);
+    return Math.min(1, Math.max(0, lerpDmx(0, targetBase, progress)));
+  }
+
+  if (safeOpacity <= SOURCE_MID_OPACITY) {
+    const progress = normalizeProgressDmx(safeOpacity, SOURCE_BASE_OPACITY, SOURCE_MID_OPACITY);
+    return Math.min(1, Math.max(0, lerpDmx(targetBase, targetMid, progress)));
+  }
+
+  if (safeOpacity <= SOURCE_PEAK_OPACITY) {
+    const progress = normalizeProgressDmx(safeOpacity, SOURCE_MID_OPACITY, SOURCE_PEAK_OPACITY);
+    return Math.min(1, Math.max(0, lerpDmx(targetMid, targetPeak, progress)));
+  }
+
+  const progress = normalizeProgressDmx(safeOpacity, SOURCE_PEAK_OPACITY, 1);
+  return Math.min(1, Math.max(0, lerpDmx(targetPeak, 1, progress)));
+}
+
+function getMatrix5Layout(
+  size: number,
+  dotSize: number,
+  cellPadding?: number,
+): { gap: number; matrixSpan: number } {
+  const n = MATRIX_SIZE;
+  if (cellPadding != null) {
+    const g = Math.max(0, cellPadding);
+    const matrixSpan = dotSize * n + g * (n - 1);
+    return { gap: g, matrixSpan };
+  }
+  const g = Math.max(1, Math.floor((size - dotSize * n) / (n - 1)));
+  return { gap: g, matrixSpan: size };
+}
+
+function resolveDmxBoxOuterDim(
+  options: { boxSize?: number | undefined; minSize?: number | undefined } | null | undefined,
+): { outerDim: number; useWrapper: boolean } {
+  const b = options?.boxSize;
+  const hasBox = b != null && b > 0 && Number.isFinite(b);
+  if (!hasBox) {
+    return { outerDim: 0, useWrapper: false };
+  }
+  const m = options?.minSize;
+  if (m != null && m > 0 && Number.isFinite(m)) {
+    return { outerDim: Math.max(b, m), useWrapper: true };
+  }
+  return { outerDim: b, useWrapper: true };
+}
+
+function clamp01Dmx(n: number | undefined) {
+  if (n == null) {
+    return;
+  }
+  if (!Number.isFinite(n)) {
+    return;
+  }
+  return Math.min(1, Math.max(0, n));
+}
+
+interface DotMatrixBaseProps extends DotMatrixCommonProps {
+  phase: DotMatrixPhase;
+  reducedMotion?: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  animationResolver?: DotAnimationResolver;
+}
+
+export function DotMatrixBase({
+  size = 24,
+  dotSize = 3,
+  color = "currentColor",
+  speed = 1,
+  ariaLabel = "Loading",
+  className,
+  pattern = "diamond",
+  muted = false,
+  dotClassName,
+  phase,
+  reducedMotion = false,
+  onMouseEnter,
+  onMouseLeave,
+  animationResolver,
+  opacityBase,
+  opacityMid,
+  opacityPeak,
+  cellPadding,
+  boxSize,
+  minSize,
+}: DotMatrixBaseProps) {
+  const patternIndexes = new Set(getPatternIndexes(pattern));
+  const safeSpeed = speed > 0 ? speed : 1;
+  const speedScale = 1 / safeSpeed;
+  const { gap, matrixSpan } = getMatrix5Layout(size, dotSize, cellPadding);
+  const { outerDim, useWrapper } = resolveDmxBoxOuterDim({ boxSize, minSize });
+  const scale = useWrapper && matrixSpan > 0 ? outerDim / matrixSpan : 1;
+  const center = Math.floor(MATRIX_SIZE / 2);
+  const ob = clamp01Dmx(opacityBase);
+  const om = clamp01Dmx(opacityMid);
+  const op = clamp01Dmx(opacityPeak);
+  const unit = dotSize + gap;
+
+  const dmxVarStyle = {
+    width: matrixSpan,
+    height: matrixSpan,
+    "--dmx-speed": speedScale,
+    color,
+    ...(ob !== undefined && { ["--dmx-opacity-base" as const]: ob }),
+    ...(om !== undefined && { ["--dmx-opacity-mid" as const]: om }),
+    ...(op !== undefined && { ["--dmx-opacity-peak" as const]: op }),
+    ...(useWrapper
+      ? {
+          transform: `scale(${scale})`,
+          transformOrigin: "center center" as const,
+        }
+      : { minWidth: minSize, minHeight: minSize }),
+  } as unknown as CSSProperties;
+
+  const dots = Array.from({ length: MATRIX_SIZE * MATRIX_SIZE }).map((_, index) => {
+    const { row, col } = indexToCoord(index);
+    const isActive = patternIndexes.has(index);
+    const distance = distanceFromCenter(index);
+    const angle = polarAngle(index);
+    const radiusNormalizedValue = normalizedRadius(index);
+    const manhattan = manhattanDistance(index);
+    const deltaX = (col - center) * unit;
+    const deltaY = (row - center) * unit;
+
+    const animationState = animationResolver
+      ? animationResolver({
+          index,
+          row,
+          col,
+          distanceFromCenter: distance,
+          angleFromCenter: angle,
+          radiusNormalized: radiusNormalizedValue,
+          manhattanDistance: manhattan,
+          phase,
+          isActive,
+          reducedMotion,
+        })
+      : {};
+
+    const resolvedAnimationStyle = animationState.style ? { ...animationState.style } : undefined;
+    const rawOpacity = resolvedAnimationStyle?.opacity;
+    if (resolvedAnimationStyle != null && typeof rawOpacity === "number") {
+      resolvedAnimationStyle.opacity = remapOpacityToTriplet(rawOpacity, ob, om, op);
+    }
+
+    const dotStyle = {
+      width: dotSize,
+      height: dotSize,
+      "--dmx-distance": distance,
+      "--dmx-row": row,
+      "--dmx-col": col,
+      "--dmx-x": `${deltaX}px`,
+      "--dmx-y": `${deltaY}px`,
+      "--dmx-angle": angle,
+      "--dmx-radius": radiusNormalizedValue,
+      "--dmx-manhattan": manhattan,
+      ...resolvedAnimationStyle,
+      ...(!isActive
+        ? {
+            opacity: 0,
+            visibility: "hidden" as const,
+            pointerEvents: "none" as const,
+            animation: "none",
+          }
+        : {}),
+    } as CSSProperties;
+
+    return (
+      <span
+        key={index}
+        aria-hidden="true"
+        className={cx(
+          "dmx-dot",
+          !isActive && "dmx-inactive",
+          dotClassName,
+          animationState.className,
+        )}
+        style={dotStyle}
+      />
+    );
+  });
+
+  const matrix = (
+    <div
+      className={cx("dmx-root", muted && "dmx-muted", !useWrapper && className)}
+      style={dmxVarStyle}
+    >
+      <div className="dmx-grid" style={{ gap }}>
+        {dots}
+      </div>
+    </div>
+  );
+
+  if (useWrapper) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label={ariaLabel}
+        className={className}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: outerDim,
+          height: outerDim,
+          minWidth: minSize,
+          minHeight: minSize,
+          overflow: "hidden",
+        }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {matrix}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className={cx("dmx-root", muted && "dmx-muted", className)}
+      style={dmxVarStyle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="dmx-grid" style={{ gap }}>
+        {dots}
+      </div>
+    </div>
+  );
+}
+
+type NormFn = (ctx: Pick<DotAnimationContext, "row" | "col" | "index">) => number;
+
+export function createPathWaveResolver(getPathNorm: NormFn): DotAnimationResolver {
+  return ({ isActive, row, col, index, reducedMotion, phase }) => {
+    if (!isActive) {
+      return { className: "dmx-inactive" };
+    }
+
+    const path = getPathNorm({ row, col, index });
+    const style = { "--dmx-path": path } as CSSProperties;
+
+    if (reducedMotion || phase === "idle") {
+      return {
+        style: {
+          ...style,
+          opacity: 0.12 + path * 0.72,
+        },
+      };
+    }
+
+    return { className: "dmx-path", style };
+  };
+}
+
+type PathWaveComponentProps = DotMatrixCommonProps;
+
+export function createPathWaveComponent(displayName: string, getPathNorm: NormFn) {
+  const resolve = createPathWaveResolver(getPathNorm);
+
+  function PathWaveComponent({
+    pattern = "full",
+    animated = true,
+    hoverAnimated = false,
+    speed = 1,
+    ...rest
+  }: PathWaveComponentProps) {
+    const reducedMotion = usePrefersReducedMotion();
+    const {
+      phase: matrixPhase,
+      onMouseEnter,
+      onMouseLeave,
+    } = useDotMatrixPhases({
+      animated: Boolean(animated && !reducedMotion),
+      hoverAnimated: Boolean(hoverAnimated && !reducedMotion),
+      speed,
+    });
+    return (
+      <DotMatrixBase
+        {...rest}
+        speed={speed}
+        pattern={pattern}
+        animated={animated}
+        phase={matrixPhase}
+        reducedMotion={reducedMotion}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        animationResolver={resolve}
+      />
+    );
+  }
+
+  PathWaveComponent.displayName = displayName;
+  return PathWaveComponent;
+}

--- a/app/src/lib/dotmatrix-hooks.ts
+++ b/app/src/lib/dotmatrix-hooks.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { DotMatrixPhase } from "@/lib/dotmatrix-core";
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const update = () => {
+      setPrefersReducedMotion(query.matches);
+    };
+
+    update();
+    query.addEventListener("change", update);
+
+    return () => {
+      query.removeEventListener("change", update);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export interface UseCyclePhaseOptions {
+  active: boolean;
+  cycleMsBase: number;
+  speed?: number;
+}
+
+export function useCyclePhase({ active, cycleMsBase, speed = 1 }: UseCyclePhaseOptions): number {
+  const [phase, setPhase] = useState(0);
+
+  useEffect(() => {
+    if (!active) {
+      setPhase(0);
+      return;
+    }
+
+    const safeSpeed = speed > 0 ? speed : 1;
+    const raw = cycleMsBase / safeSpeed;
+    const cycleMs = raw > 0 && Number.isFinite(raw) ? raw : 1000;
+    const start = performance.now();
+    let rafId = 0;
+
+    const tick = (now: number) => {
+      const elapsed = (((now - start) % cycleMs) + cycleMs) % cycleMs;
+      setPhase(elapsed / cycleMs);
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [active, cycleMsBase, speed]);
+
+  return phase;
+}
+
+interface UseSteppedCycleOptions {
+  active: boolean;
+  cycleMsBase: number;
+  steps: number;
+  speed?: number;
+  idleStep?: number;
+}
+
+type FrameListener = (now: number) => void;
+
+const listeners = new Set<FrameListener>();
+let rafId: number | null = null;
+
+function emit(now: number) {
+  listeners.forEach((listener) => {
+    listener(now);
+  });
+}
+
+function tick(now: number) {
+  emit(now);
+  if (listeners.size > 0) {
+    rafId = window.requestAnimationFrame(tick);
+  } else {
+    rafId = null;
+  }
+}
+
+function subscribeFrame(listener: FrameListener) {
+  listeners.add(listener);
+  if (rafId === null) {
+    rafId = window.requestAnimationFrame(tick);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}
+
+export function useSteppedCycle({
+  active,
+  cycleMsBase,
+  steps,
+  speed = 1,
+  idleStep = 0,
+}: UseSteppedCycleOptions): number {
+  const safeSteps = Math.max(1, Math.floor(steps));
+  const safeSpeed = speed > 0 ? speed : 1;
+  const rawCycleMs = cycleMsBase / safeSpeed;
+  const rawStepMs = rawCycleMs / safeSteps;
+  const stepMs = rawStepMs > 0 && Number.isFinite(rawStepMs) ? rawStepMs : 1;
+  const cycleMs = stepMs * safeSteps;
+
+  const [step, setStep] = useState(() => (active ? 0 : idleStep));
+  const startMsRef = useRef<number>(0);
+  const activeRef = useRef(false);
+  const currentStepRef = useRef(idleStep);
+
+  useEffect(() => {
+    if (!active) {
+      activeRef.current = false;
+      currentStepRef.current = idleStep;
+      setStep(idleStep);
+      return;
+    }
+
+    const updateStep = (now: number) => {
+      if (!activeRef.current) {
+        startMsRef.current = now;
+        activeRef.current = true;
+      }
+
+      const elapsed = Math.max(0, now - startMsRef.current);
+      const nextStep = Math.floor((elapsed % cycleMs) / stepMs) % safeSteps;
+      if (nextStep !== currentStepRef.current) {
+        currentStepRef.current = nextStep;
+        setStep(nextStep);
+      }
+    };
+
+    updateStep(performance.now());
+    return subscribeFrame(updateStep);
+  }, [active, cycleMs, idleStep, safeSteps, stepMs]);
+
+  return active ? step : idleStep;
+}
+
+interface UseDotMatrixPhasesOptions {
+  animated?: boolean;
+  hoverAnimated?: boolean;
+  speed?: number;
+}
+
+interface DotMatrixPhasesResult {
+  phase: DotMatrixPhase;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+export function useDotMatrixPhases({
+  animated = false,
+  hoverAnimated = false,
+  speed = 1,
+}: UseDotMatrixPhasesOptions): DotMatrixPhasesResult {
+  const safeSpeed = speed > 0 ? speed : 1;
+  const autoRun = Boolean(animated && !hoverAnimated);
+  const [hoverPhase, setHoverPhase] = useState<DotMatrixPhase>("idle");
+  const timeouts = useRef<number[]>([]);
+  const hoverGen = useRef(0);
+
+  const clearTimers = useCallback(() => {
+    for (let i = 0; i < timeouts.current.length; i += 1) {
+      window.clearTimeout(timeouts.current[i]!);
+    }
+    timeouts.current = [];
+  }, []);
+
+  useEffect(() => {
+    hoverGen.current += 1;
+    clearTimers();
+    return clearTimers;
+  }, [autoRun, hoverAnimated, clearTimers]);
+
+  const onMouseEnter = useCallback(() => {
+    if (!hoverAnimated || autoRun) {
+      return;
+    }
+    clearTimers();
+    const gen = ++hoverGen.current;
+    setHoverPhase("collapse");
+    const collapseMs = Math.max(1, Math.round(300 / safeSpeed));
+    const id = window.setTimeout(() => {
+      if (hoverGen.current !== gen) {
+        return;
+      }
+      setHoverPhase("hoverRipple");
+    }, collapseMs);
+    timeouts.current.push(id);
+  }, [hoverAnimated, autoRun, safeSpeed, clearTimers]);
+
+  const onMouseLeave = useCallback(() => {
+    if (!hoverAnimated || autoRun) {
+      return;
+    }
+    hoverGen.current += 1;
+    clearTimers();
+    setHoverPhase("idle");
+  }, [hoverAnimated, autoRun, clearTimers]);
+
+  const phase: DotMatrixPhase = autoRun ? "loadingRipple" : hoverAnimated ? hoverPhase : "idle";
+
+  return useMemo(
+    () => ({
+      phase,
+      onMouseEnter,
+      onMouseLeave,
+    }),
+    [phase, onMouseEnter, onMouseLeave],
+  );
+}

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -385,6 +385,7 @@ export type SuggestedDestination = {
 
 export type ImportRankingResponse = {
   suggestions: SuggestedDestination[];
+  all_dirs: string[];
 };
 
 export type ImportRequestWire = {

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -376,6 +376,108 @@ export async function notesWrite(path: string, body: string): Promise<void> {
   }
 }
 
+// --- import ----------------------------------------------------------------
+
+export type SuggestedDestination = {
+  path: string;
+  score: number;
+};
+
+export type ImportRankingResponse = {
+  suggestions: SuggestedDestination[];
+};
+
+export type ImportRequestWire = {
+  source: string;
+  dest: string;
+  mode?: string; // "copy" (default) | "move"
+  group_id?: string | null;
+};
+
+export type ImportConflict =
+  | { kind: "dest_exists"; existing_path: string }
+  | { kind: "source_missing"; reason: string }
+  | { kind: "source_is_project"; project_path: string }
+  | {
+      kind: "placement_mismatch";
+      expected_exts: string[];
+      suggestion: string | null;
+    };
+
+export type ImportOp = {
+  source: string;
+  dest: string;
+  mode: string;
+  group_id: string | null;
+  conflicts: ImportConflict[];
+};
+
+export type ImportPreview = {
+  ops: ImportOp[];
+  clean: boolean;
+  conflict_count: number;
+};
+
+export type ImportedFile = {
+  source: string;
+  dest: string;
+  file_id: string;
+  mode: string;
+};
+
+export type ImportWarning = {
+  kind: string;
+  dest: string;
+  message: string;
+};
+
+export type ImportOutcome = {
+  batch_id: string;
+  group_id: string | null;
+  imported: ImportedFile[];
+  warnings: ImportWarning[];
+};
+
+export async function importRanking(sources: string[]): Promise<ImportRankingResponse> {
+  try {
+    return await invoke<ImportRankingResponse>("import_ranking", { sources });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function importPreview(requests: ImportRequestWire[]): Promise<ImportPreview> {
+  try {
+    return await invoke<ImportPreview>("import_preview", { requests });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function importApply(requests: ImportRequestWire[]): Promise<ImportOutcome> {
+  try {
+    return await invoke<ImportOutcome>("import_apply", { requests });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+// --- thumbnail -------------------------------------------------------------
+
+export type ThumbnailPathsResponse = {
+  paths: Record<string, string>;
+};
+
+export async function thumbnailPaths(fileIds: string[]): Promise<ThumbnailPathsResponse> {
+  try {
+    return await invoke<ThumbnailPathsResponse>("thumbnail_paths", {
+      fileIds,
+    });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- lint refresh ----------------------------------------------------------
 
 export type LintRunResponse = {

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -466,7 +466,7 @@ export async function importApply(requests: ImportRequestWire[]): Promise<Import
 // --- thumbnail -------------------------------------------------------------
 
 export type ThumbnailPathsResponse = {
-  paths: Record<string, string>;
+  urls: Record<string, string>;
 };
 
 export async function thumbnailPaths(fileIds: string[]): Promise<ThumbnailPathsResponse> {

--- a/app/src/lib/use-thumbnails.ts
+++ b/app/src/lib/use-thumbnails.ts
@@ -1,15 +1,13 @@
 import * as React from "react";
-import { convertFileSrc } from "@tauri-apps/api/core";
 
 import { thumbnailPaths } from "@/lib/ipc";
 
 /**
- * Batch-fetch thumbnail asset URLs for a list of file IDs.
+ * Batch-fetch thumbnail data URLs for a list of file IDs.
  *
- * Returns a map of `file_id → asset://` URL that can be used directly
- * as `<img src>`.  Files without a cached thumbnail are omitted.
- * Re-fetches whenever the input `fileIds` array changes (shallow
- * comparison on the joined string).
+ * Returns a map of `file_id → data:image/webp;base64,...` that can be
+ * used directly as `<img src>`.  Files without a cached thumbnail are
+ * omitted.
  */
 export function useThumbnails(fileIds: string[]): Record<string, string> {
   const [urls, setUrls] = React.useState<Record<string, string>>({});
@@ -25,12 +23,7 @@ export function useThumbnails(fileIds: string[]): Record<string, string> {
 
     thumbnailPaths(fileIds)
       .then((resp) => {
-        if (cancelled) return;
-        const map: Record<string, string> = {};
-        for (const [fid, absPath] of Object.entries(resp.paths)) {
-          map[fid] = convertFileSrc(absPath);
-        }
-        setUrls(map);
+        if (!cancelled) setUrls(resp.urls);
       })
       .catch(() => {
         if (!cancelled) setUrls({});

--- a/app/src/lib/use-thumbnails.ts
+++ b/app/src/lib/use-thumbnails.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+import { thumbnailPaths } from "@/lib/ipc";
+
+/**
+ * Batch-fetch thumbnail asset URLs for a list of file IDs.
+ *
+ * Returns a map of `file_id → asset://` URL that can be used directly
+ * as `<img src>`.  Files without a cached thumbnail are omitted.
+ * Re-fetches whenever the input `fileIds` array changes (shallow
+ * comparison on the joined string).
+ */
+export function useThumbnails(fileIds: string[]): Record<string, string> {
+  const [urls, setUrls] = React.useState<Record<string, string>>({});
+  const key = fileIds.join(",");
+
+  React.useEffect(() => {
+    if (fileIds.length === 0) {
+      setUrls({});
+      return;
+    }
+
+    let cancelled = false;
+
+    thumbnailPaths(fileIds)
+      .then((resp) => {
+        if (cancelled) return;
+        const map: Record<string, string> = {};
+        for (const [fid, absPath] of Object.entries(resp.paths)) {
+          map[fid] = convertFileSrc(absPath);
+        }
+        setUrls(map);
+      })
+      .catch(() => {
+        if (!cancelled) setUrls({});
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  return urls;
+}

--- a/crates/progest-tauri/Cargo.toml
+++ b/crates/progest-tauri/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { workspace = true, features = ["clock"] }
 dirs = "5"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tauri-plugin-drag = "2.1.0"
 
 [lints]
 workspace = true

--- a/crates/progest-tauri/Cargo.toml
+++ b/crates/progest-tauri/Cargo.toml
@@ -33,6 +33,7 @@ dirs = "5"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tauri-plugin-drag = "2.1.0"
+base64 = "0.22.1"
 
 [lints]
 workspace = true

--- a/crates/progest-tauri/capabilities/default.json
+++ b/crates/progest-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
-    "dialog:default"
+    "dialog:default",
+    "drag:default",
+    "core:event:default"
   ]
 }

--- a/crates/progest-tauri/src/import_commands.rs
+++ b/crates/progest-tauri/src/import_commands.rs
@@ -19,7 +19,7 @@ use progest_core::index::Index;
 use progest_core::meta::{StdMetaStore, load_dirmeta};
 use progest_core::thumbnail::{self, ThumbnailCache};
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{AppHandle, Manager};
 
 use crate::commands::{load_alias_catalog_for_ctx, no_project_error};
 use crate::state::{AppState, ProjectContext};
@@ -109,122 +109,136 @@ pub struct ImportOutcomeWire {
 /// Given a list of source file paths, rank project directories by how
 /// well they accept each file's extension.  The frontend shows the
 /// top suggestions in the import modal.
+///
+/// Async so the directory walk doesn't block the UI thread.
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
-pub fn import_ranking(
+pub async fn import_ranking(
     sources: Vec<String>,
-    state: State<'_, AppState>,
+    app: AppHandle,
 ) -> Result<ImportRankingResponse, String> {
-    let guard = state.project.lock().expect("project mutex poisoned");
-    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
 
-    let exts: Vec<String> = sources
-        .iter()
-        .filter_map(|s| {
-            Path::new(s)
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(str::to_lowercase)
-        })
-        .collect();
-
-    let all_dirs = collect_all_dirs(ctx);
-
-    if exts.is_empty() {
-        return Ok(ImportRankingResponse {
-            suggestions: Vec::new(),
-            all_dirs,
-        });
-    }
-
-    let catalog = load_alias_catalog_for_ctx(ctx);
-    let dirs = collect_dirmeta_effective_accepts(ctx, &catalog);
-
-    let ext = normalize_ext(&exts[0]);
-    let ranked = rank_destinations(&dirs, &ext);
-
-    Ok(ImportRankingResponse {
-        suggestions: ranked
-            .into_iter()
-            .map(|s| SuggestedDestinationWire {
-                path: s.path.as_str().to_owned(),
-                score: s.score,
+        let exts: Vec<String> = sources
+            .iter()
+            .filter_map(|s| {
+                Path::new(s)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(str::to_lowercase)
             })
-            .collect(),
-        all_dirs,
+            .collect();
+
+        let all_dirs = collect_all_dirs(ctx);
+
+        if exts.is_empty() {
+            return Ok(ImportRankingResponse {
+                suggestions: Vec::new(),
+                all_dirs,
+            });
+        }
+
+        let catalog = load_alias_catalog_for_ctx(ctx);
+        let dirs = collect_dirmeta_effective_accepts(ctx, &catalog);
+
+        let ext = normalize_ext(&exts[0]);
+        let ranked = rank_destinations(&dirs, &ext);
+
+        Ok(ImportRankingResponse {
+            suggestions: ranked
+                .into_iter()
+                .map(|s| SuggestedDestinationWire {
+                    path: s.path.as_str().to_owned(),
+                    score: s.score,
+                })
+                .collect(),
+            all_dirs,
+        })
     })
+    .await
+    .map_err(|e| format!("join: {e}"))?
 }
 
 /// Build a conflict-checked preview without mutating the filesystem.
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
-pub fn import_preview(
+pub async fn import_preview(
     requests: Vec<ImportRequestWire>,
-    state: State<'_, AppState>,
+    app: AppHandle,
 ) -> Result<ImportPreviewWire, String> {
-    let guard = state.project.lock().expect("project mutex poisoned");
-    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
-
     let reqs = wire_to_requests(&requests)?;
-    let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
-
-    Ok(preview_to_wire(&preview))
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+        let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
+        Ok(preview_to_wire(&preview))
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
 }
 
 /// Apply a clean import atomically.  Fails if any op carries
 /// conflicts — the frontend should resolve them before calling.
+///
+/// Async + `spawn_blocking` so file copies and thumbnail generation
+/// don't freeze the UI.
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
-pub fn import_apply(
+pub async fn import_apply(
     requests: Vec<ImportRequestWire>,
-    state: State<'_, AppState>,
+    app: AppHandle,
 ) -> Result<ImportOutcomeWire, String> {
-    let guard = state.project.lock().expect("project mutex poisoned");
-    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
-
     let reqs = wire_to_requests(&requests)?;
-    let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
 
-    if !preview.is_clean() {
-        return Err(format!(
-            "cannot apply: {} conflict(s) remain",
-            preview.conflicting_ops().count()
-        ));
-    }
+        let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
 
-    let meta_store = StdMetaStore::new(ctx.fs.clone());
-    let history =
-        HistoryStore::open(&ctx.root.history_db()).map_err(|e| format!("open history: {e}"))?;
+        if !preview.is_clean() {
+            return Err(format!(
+                "cannot apply: {} conflict(s) remain",
+                preview.conflicting_ops().count()
+            ));
+        }
 
-    let driver = Import::new(&ctx.fs, &meta_store, &ctx.index, &history, ctx.root.root());
-    let outcome = driver.apply(&preview).map_err(|e| format!("apply: {e}"))?;
+        let meta_store = StdMetaStore::new(ctx.fs.clone());
+        let history =
+            HistoryStore::open(&ctx.root.history_db()).map_err(|e| format!("open history: {e}"))?;
 
-    // Generate thumbnails for newly imported files.
-    let cache = ThumbnailCache::new(
-        ctx.root.root().join(".progest/thumbs"),
-        thumbnail::DEFAULT_CACHE_MAX_BYTES,
-    );
-    let thumb_requests: Vec<thumbnail::ThumbnailRequest> = outcome
-        .imported
-        .iter()
-        .filter_map(|f| {
-            let row = ctx.index.get_file(&f.file_id).ok()??;
-            let abs_path = ctx.root.root().join(row.path.as_str());
-            Some(thumbnail::ThumbnailRequest {
-                path: row.path,
-                abs_path,
-                file_id: row.file_id,
-                fingerprint: row.fingerprint,
-                size: thumbnail::DEFAULT_MAX_DIM,
+        let driver = Import::new(&ctx.fs, &meta_store, &ctx.index, &history, ctx.root.root());
+        let outcome = driver.apply(&preview).map_err(|e| format!("apply: {e}"))?;
+
+        let cache = ThumbnailCache::new(
+            ctx.root.root().join(".progest/thumbs"),
+            thumbnail::DEFAULT_CACHE_MAX_BYTES,
+        );
+        let thumb_requests: Vec<thumbnail::ThumbnailRequest> = outcome
+            .imported
+            .iter()
+            .filter_map(|f| {
+                let row = ctx.index.get_file(&f.file_id).ok()??;
+                let abs_path = ctx.root.root().join(row.path.as_str());
+                Some(thumbnail::ThumbnailRequest {
+                    path: row.path,
+                    abs_path,
+                    file_id: row.file_id,
+                    fingerprint: row.fingerprint,
+                    size: thumbnail::DEFAULT_MAX_DIM,
+                })
             })
-        })
-        .collect();
+            .collect();
 
-    if !thumb_requests.is_empty() {
-        let _ = thumbnail::generate_batch(&thumb_requests, &cache, false);
-    }
+        if !thumb_requests.is_empty() {
+            let _ = thumbnail::generate_batch(&thumb_requests, &cache, false);
+        }
 
-    Ok(outcome_to_wire(&outcome))
+        Ok(outcome_to_wire(&outcome))
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
 }
 
 // ------------------------------------------------------------------- helpers

--- a/crates/progest-tauri/src/import_commands.rs
+++ b/crates/progest-tauri/src/import_commands.rs
@@ -35,6 +35,7 @@ pub struct SuggestedDestinationWire {
 #[derive(Debug, Clone, Serialize)]
 pub struct ImportRankingResponse {
     pub suggestions: Vec<SuggestedDestinationWire>,
+    pub all_dirs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -127,18 +128,18 @@ pub fn import_ranking(
         })
         .collect();
 
+    let all_dirs = collect_all_dirs(ctx);
+
     if exts.is_empty() {
         return Ok(ImportRankingResponse {
             suggestions: Vec::new(),
+            all_dirs,
         });
     }
 
     let catalog = load_alias_catalog_for_ctx(ctx);
     let dirs = collect_dirmeta_effective_accepts(ctx, &catalog);
 
-    // Use the first file's extension for ranking (batch imports usually
-    // share the same type; multi-type imports show per-file suggestions
-    // in the preview).
     let ext = normalize_ext(&exts[0]);
     let ranked = rank_destinations(&dirs, &ext);
 
@@ -150,6 +151,7 @@ pub fn import_ranking(
                 score: s.score,
             })
             .collect(),
+        all_dirs,
     })
 }
 
@@ -418,4 +420,37 @@ fn compute_effective_for_dir(
 
     let chain_refs: Vec<_> = chain_raws.iter().collect();
     compute_effective_accepts(own.as_ref(), &chain_refs, catalog).ok()?
+}
+
+/// Recursively collect all directory paths in the project (sorted).
+fn collect_all_dirs(ctx: &ProjectContext) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut stack: Vec<(String, PathBuf)> = vec![(String::new(), ctx.root.root().to_path_buf())];
+
+    while let Some((rel, abs)) = stack.pop() {
+        if !rel.is_empty() {
+            result.push(rel.clone());
+        }
+        let Ok(entries) = std::fs::read_dir(&abs) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.') {
+                continue;
+            }
+            let child = if rel.is_empty() {
+                name
+            } else {
+                format!("{rel}/{name}")
+            };
+            stack.push((child, entry.path()));
+        }
+    }
+
+    result.sort();
+    result
 }

--- a/crates/progest-tauri/src/import_commands.rs
+++ b/crates/progest-tauri/src/import_commands.rs
@@ -1,0 +1,421 @@
+//! IPC commands for importing external files into the project.
+//!
+//! `import_ranking` walks project dirmeta to find the best destination
+//! directories for a given set of source files.  `import_preview`
+//! builds a conflict-checked preview and `import_apply` commits the
+//! import atomically.
+
+use std::path::{Path, PathBuf};
+
+use progest_core::accepts::{
+    AliasCatalog, EffectiveAccepts, compute_effective_accepts, extract_accepts, normalize_ext,
+};
+use progest_core::fs::ProjectPath;
+use progest_core::history::SqliteStore as HistoryStore;
+use progest_core::import::{
+    self, Import, ImportMode, ImportRequest, build_preview, rank_destinations,
+};
+use progest_core::index::Index;
+use progest_core::meta::{StdMetaStore, load_dirmeta};
+use progest_core::thumbnail::{self, ThumbnailCache};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::commands::{load_alias_catalog_for_ctx, no_project_error};
+use crate::state::{AppState, ProjectContext};
+
+// ------------------------------------------------------------------ wire types
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SuggestedDestinationWire {
+    pub path: String,
+    pub score: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportRankingResponse {
+    pub suggestions: Vec<SuggestedDestinationWire>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImportRequestWire {
+    pub source: String,
+    pub dest: String,
+    #[serde(default)]
+    pub mode: String,
+    pub group_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportOpWire {
+    pub source: String,
+    pub dest: String,
+    pub mode: String,
+    pub group_id: Option<String>,
+    pub conflicts: Vec<ImportConflictWire>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportConflictWire {
+    DestExists {
+        existing_path: String,
+    },
+    SourceMissing {
+        reason: String,
+    },
+    SourceIsProject {
+        project_path: String,
+    },
+    PlacementMismatch {
+        expected_exts: Vec<String>,
+        suggestion: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportPreviewWire {
+    pub ops: Vec<ImportOpWire>,
+    pub clean: bool,
+    pub conflict_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportedFileWire {
+    pub source: String,
+    pub dest: String,
+    pub file_id: String,
+    pub mode: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportWarningWire {
+    pub kind: String,
+    pub dest: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportOutcomeWire {
+    pub batch_id: String,
+    pub group_id: Option<String>,
+    pub imported: Vec<ImportedFileWire>,
+    pub warnings: Vec<ImportWarningWire>,
+}
+
+// ------------------------------------------------------------------- commands
+
+/// Given a list of source file paths, rank project directories by how
+/// well they accept each file's extension.  The frontend shows the
+/// top suggestions in the import modal.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn import_ranking(
+    sources: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<ImportRankingResponse, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+    let exts: Vec<String> = sources
+        .iter()
+        .filter_map(|s| {
+            Path::new(s)
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(str::to_lowercase)
+        })
+        .collect();
+
+    if exts.is_empty() {
+        return Ok(ImportRankingResponse {
+            suggestions: Vec::new(),
+        });
+    }
+
+    let catalog = load_alias_catalog_for_ctx(ctx);
+    let dirs = collect_dirmeta_effective_accepts(ctx, &catalog);
+
+    // Use the first file's extension for ranking (batch imports usually
+    // share the same type; multi-type imports show per-file suggestions
+    // in the preview).
+    let ext = normalize_ext(&exts[0]);
+    let ranked = rank_destinations(&dirs, &ext);
+
+    Ok(ImportRankingResponse {
+        suggestions: ranked
+            .into_iter()
+            .map(|s| SuggestedDestinationWire {
+                path: s.path.as_str().to_owned(),
+                score: s.score,
+            })
+            .collect(),
+    })
+}
+
+/// Build a conflict-checked preview without mutating the filesystem.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn import_preview(
+    requests: Vec<ImportRequestWire>,
+    state: State<'_, AppState>,
+) -> Result<ImportPreviewWire, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+    let reqs = wire_to_requests(&requests)?;
+    let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
+
+    Ok(preview_to_wire(&preview))
+}
+
+/// Apply a clean import atomically.  Fails if any op carries
+/// conflicts — the frontend should resolve them before calling.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn import_apply(
+    requests: Vec<ImportRequestWire>,
+    state: State<'_, AppState>,
+) -> Result<ImportOutcomeWire, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+    let reqs = wire_to_requests(&requests)?;
+    let preview = build_preview(&reqs, &ctx.fs, ctx.root.root());
+
+    if !preview.is_clean() {
+        return Err(format!(
+            "cannot apply: {} conflict(s) remain",
+            preview.conflicting_ops().count()
+        ));
+    }
+
+    let meta_store = StdMetaStore::new(ctx.fs.clone());
+    let history =
+        HistoryStore::open(&ctx.root.history_db()).map_err(|e| format!("open history: {e}"))?;
+
+    let driver = Import::new(&ctx.fs, &meta_store, &ctx.index, &history, ctx.root.root());
+    let outcome = driver.apply(&preview).map_err(|e| format!("apply: {e}"))?;
+
+    // Generate thumbnails for newly imported files.
+    let cache = ThumbnailCache::new(
+        ctx.root.root().join(".progest/thumbs"),
+        thumbnail::DEFAULT_CACHE_MAX_BYTES,
+    );
+    let thumb_requests: Vec<thumbnail::ThumbnailRequest> = outcome
+        .imported
+        .iter()
+        .filter_map(|f| {
+            let row = ctx.index.get_file(&f.file_id).ok()??;
+            let abs_path = ctx.root.root().join(row.path.as_str());
+            Some(thumbnail::ThumbnailRequest {
+                path: row.path,
+                abs_path,
+                file_id: row.file_id,
+                fingerprint: row.fingerprint,
+                size: thumbnail::DEFAULT_MAX_DIM,
+            })
+        })
+        .collect();
+
+    if !thumb_requests.is_empty() {
+        let _ = thumbnail::generate_batch(&thumb_requests, &cache, false);
+    }
+
+    Ok(outcome_to_wire(&outcome))
+}
+
+// ------------------------------------------------------------------- helpers
+
+fn wire_to_requests(wires: &[ImportRequestWire]) -> Result<Vec<ImportRequest>, String> {
+    wires
+        .iter()
+        .map(|w| {
+            let source = PathBuf::from(&w.source);
+            let dest =
+                ProjectPath::new(&w.dest).map_err(|e| format!("invalid dest `{}`: {e}", w.dest))?;
+            let mode = match w.mode.as_str() {
+                "move" => ImportMode::Move,
+                _ => ImportMode::Copy,
+            };
+            Ok(ImportRequest {
+                source,
+                dest,
+                mode,
+                group_id: w.group_id.clone(),
+            })
+        })
+        .collect()
+}
+
+fn preview_to_wire(preview: &import::ImportPreview) -> ImportPreviewWire {
+    ImportPreviewWire {
+        conflict_count: preview.conflicting_ops().count(),
+        clean: preview.is_clean(),
+        ops: preview.ops.iter().map(op_to_wire).collect(),
+    }
+}
+
+fn op_to_wire(op: &import::ImportOp) -> ImportOpWire {
+    ImportOpWire {
+        source: op.source.clone(),
+        dest: op.dest.as_str().to_owned(),
+        mode: match op.mode {
+            ImportMode::Copy => "copy",
+            ImportMode::Move => "move",
+        }
+        .to_owned(),
+        group_id: op.group_id.clone(),
+        conflicts: op.conflicts.iter().map(conflict_to_wire).collect(),
+    }
+}
+
+fn conflict_to_wire(c: &import::ImportConflict) -> ImportConflictWire {
+    match c {
+        import::ImportConflict::DestExists { existing_path } => ImportConflictWire::DestExists {
+            existing_path: existing_path.as_str().to_owned(),
+        },
+        import::ImportConflict::SourceMissing { reason } => ImportConflictWire::SourceMissing {
+            reason: reason.clone(),
+        },
+        import::ImportConflict::SourceIsProject { project_path } => {
+            ImportConflictWire::SourceIsProject {
+                project_path: project_path.as_str().to_owned(),
+            }
+        }
+        import::ImportConflict::PlacementMismatch {
+            expected_exts,
+            suggestion,
+        } => ImportConflictWire::PlacementMismatch {
+            expected_exts: expected_exts.clone(),
+            suggestion: suggestion.as_ref().map(|s| s.as_str().to_owned()),
+        },
+    }
+}
+
+fn outcome_to_wire(outcome: &import::ImportOutcome) -> ImportOutcomeWire {
+    ImportOutcomeWire {
+        batch_id: outcome.batch_id.clone(),
+        group_id: outcome.group_id.clone(),
+        imported: outcome
+            .imported
+            .iter()
+            .map(|f| ImportedFileWire {
+                source: f.source.clone(),
+                dest: f.dest.as_str().to_owned(),
+                file_id: f.file_id.to_string(),
+                mode: match f.mode {
+                    ImportMode::Copy => "copy",
+                    ImportMode::Move => "move",
+                }
+                .to_owned(),
+            })
+            .collect(),
+        warnings: outcome
+            .warnings
+            .iter()
+            .map(|w| match w {
+                import::ImportWarning::MetaCreate { dest, message } => ImportWarningWire {
+                    kind: "meta_create".into(),
+                    dest: dest.as_str().to_owned(),
+                    message: message.clone(),
+                },
+                import::ImportWarning::IndexInsert { dest, message } => ImportWarningWire {
+                    kind: "index_insert".into(),
+                    dest: dest.as_str().to_owned(),
+                    message: message.clone(),
+                },
+                import::ImportWarning::HistoryAppend { dest, message } => ImportWarningWire {
+                    kind: "history_append".into(),
+                    dest: dest.as_str().to_owned(),
+                    message: message.clone(),
+                },
+                import::ImportWarning::FingerprintFailed { dest, message } => ImportWarningWire {
+                    kind: "fingerprint_failed".into(),
+                    dest: dest.as_str().to_owned(),
+                    message: message.clone(),
+                },
+            })
+            .collect(),
+    }
+}
+
+/// Walk the entire project tree and collect `(dir_path,
+/// effective_accepts)` for every directory that carries an `[accepts]`
+/// block (own or inherited).  Used by `import_ranking` to feed
+/// `rank_destinations`.
+fn collect_dirmeta_effective_accepts(
+    ctx: &ProjectContext,
+    catalog: &AliasCatalog,
+) -> Vec<(ProjectPath, EffectiveAccepts)> {
+    let mut result: Vec<(ProjectPath, EffectiveAccepts)> = Vec::new();
+
+    let mut dirs_to_visit: Vec<(ProjectPath, PathBuf)> =
+        vec![(ProjectPath::root(), ctx.root.root().to_path_buf())];
+
+    while let Some((rel, abs)) = dirs_to_visit.pop() {
+        if let Some(eff) = compute_effective_for_dir(ctx, &rel, catalog) {
+            result.push((rel.clone(), eff));
+        }
+
+        let Ok(entries) = std::fs::read_dir(&abs) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            if !ft.is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.') {
+                continue;
+            }
+            let child_rel = if rel.is_root() {
+                match ProjectPath::new(&name) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                }
+            } else {
+                match rel.join(&name) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                }
+            };
+            dirs_to_visit.push((child_rel, entry.path()));
+        }
+    }
+
+    result
+}
+
+/// Compute `effective_accepts` for a single directory by loading its
+/// dirmeta + ancestor chain, mirroring the `accepts_commands` pattern.
+fn compute_effective_for_dir(
+    ctx: &ProjectContext,
+    dir: &ProjectPath,
+    catalog: &AliasCatalog,
+) -> Option<EffectiveAccepts> {
+    let own_doc = load_dirmeta(&ctx.fs, dir).ok()?;
+    let own = own_doc.and_then(|doc| {
+        extract_accepts(&doc.extra)
+            .ok()
+            .flatten()
+            .map(|e| e.accepts)
+    });
+
+    let mut chain_raws = Vec::new();
+    let mut cursor = dir.parent();
+    while let Some(ancestor) = cursor {
+        if let Ok(Some(doc)) = load_dirmeta(&ctx.fs, &ancestor)
+            && let Ok(Some(extraction)) = extract_accepts(&doc.extra)
+        {
+            chain_raws.push(extraction.accepts);
+        }
+        cursor = ancestor.parent();
+    }
+
+    let chain_refs: Vec<_> = chain_raws.iter().collect();
+    compute_effective_accepts(own.as_ref(), &chain_refs, catalog).ok()?
+}

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -7,11 +7,13 @@
 mod accepts_commands;
 mod commands;
 mod file_inspector_commands;
+mod import_commands;
 mod lint_commands;
 mod project_init_commands;
 mod recent;
 mod state;
 mod template_commands;
+mod thumbnail_commands;
 
 use state::AppState;
 
@@ -47,6 +49,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_drag::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::app_info,
@@ -76,6 +79,10 @@ pub fn run() {
             template_commands::template_export,
             template_commands::template_preview,
             template_commands::template_apply,
+            import_commands::import_ranking,
+            import_commands::import_preview,
+            import_commands::import_apply,
+            thumbnail_commands::thumbnail_paths,
         ])
         .setup(|app| {
             // We build the main window programmatically rather than via

--- a/crates/progest-tauri/src/thumbnail_commands.rs
+++ b/crates/progest-tauri/src/thumbnail_commands.rs
@@ -2,15 +2,19 @@
 //!
 //! Returns base64-encoded data URLs so the frontend can use them
 //! directly as `<img src>` without asset-protocol scope configuration.
+//!
+//! Async + `spawn_blocking` so base64 encoding of many thumbnails
+//! doesn't freeze the UI.
 
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use base64::Engine;
 use progest_core::identity::FileId;
 use progest_core::index::Index;
 use progest_core::thumbnail::{CacheKey, DEFAULT_CACHE_MAX_BYTES, DEFAULT_MAX_DIM, ThumbnailCache};
 use serde::Serialize;
-use tauri::State;
+use tauri::{AppHandle, Manager};
 
 use crate::commands::no_project_error;
 use crate::state::AppState;
@@ -20,47 +24,47 @@ pub struct ThumbnailUrlsResponse {
     pub urls: HashMap<String, String>,
 }
 
-/// Return base64 data-URL thumbnails for a batch of file IDs.
-///
-/// Files without a cached thumbnail are silently omitted from the map.
 #[tauri::command]
-#[allow(clippy::needless_pass_by_value)]
-pub fn thumbnail_paths(
+pub async fn thumbnail_paths(
     file_ids: Vec<String>,
-    state: State<'_, AppState>,
+    app: AppHandle,
 ) -> Result<ThumbnailUrlsResponse, String> {
-    let guard = state.project.lock().expect("project mutex poisoned");
-    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
 
-    let cache = ThumbnailCache::new(
-        ctx.root.root().join(".progest/thumbs"),
-        DEFAULT_CACHE_MAX_BYTES,
-    );
+        let cache = ThumbnailCache::new(
+            ctx.root.root().join(".progest/thumbs"),
+            DEFAULT_CACHE_MAX_BYTES,
+        );
 
-    let mut urls = HashMap::new();
+        let mut urls = HashMap::new();
 
-    for fid_str in &file_ids {
-        let Ok(file_id) = FileId::from_str(fid_str) else {
-            continue;
-        };
-        let Ok(Some(row)) = ctx.index.get_file(&file_id) else {
-            continue;
-        };
+        for fid_str in &file_ids {
+            let Ok(file_id) = FileId::from_str(fid_str) else {
+                continue;
+            };
+            let Ok(Some(row)) = ctx.index.get_file(&file_id) else {
+                continue;
+            };
 
-        let key = CacheKey {
-            file_id: row.file_id,
-            fingerprint: row.fingerprint,
-            size: DEFAULT_MAX_DIM,
-        };
+            let key = CacheKey {
+                file_id: row.file_id,
+                fingerprint: row.fingerprint,
+                size: DEFAULT_MAX_DIM,
+            };
 
-        if let Some(abs_path) = cache.get(&key)
-            && let Ok(bytes) = std::fs::read(&abs_path)
-        {
-            use base64::Engine;
-            let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-            urls.insert(fid_str.clone(), format!("data:image/webp;base64,{b64}"));
+            if let Some(abs_path) = cache.get(&key)
+                && let Ok(bytes) = std::fs::read(&abs_path)
+            {
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                urls.insert(fid_str.clone(), format!("data:image/webp;base64,{b64}"));
+            }
         }
-    }
 
-    Ok(ThumbnailUrlsResponse { urls })
+        Ok(ThumbnailUrlsResponse { urls })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
 }

--- a/crates/progest-tauri/src/thumbnail_commands.rs
+++ b/crates/progest-tauri/src/thumbnail_commands.rs
@@ -1,9 +1,7 @@
 //! IPC commands for thumbnail retrieval.
 //!
-//! Thumbnails are served via Tauri's asset protocol — the frontend
-//! calls `thumbnail_paths` with a batch of file IDs and receives
-//! absolute filesystem paths that can be converted to asset URLs
-//! with `convertFileSrc()`.
+//! Returns base64-encoded data URLs so the frontend can use them
+//! directly as `<img src>` without asset-protocol scope configuration.
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -18,21 +16,19 @@ use crate::commands::no_project_error;
 use crate::state::AppState;
 
 #[derive(Debug, Clone, Serialize)]
-pub struct ThumbnailPathsResponse {
-    pub paths: HashMap<String, String>,
+pub struct ThumbnailUrlsResponse {
+    pub urls: HashMap<String, String>,
 }
 
-/// Return absolute thumbnail paths for a batch of file IDs.
+/// Return base64 data-URL thumbnails for a batch of file IDs.
 ///
-/// The frontend converts these to asset-protocol URLs via
-/// `convertFileSrc()` and uses them as `<img src>`.  Files without
-/// a cached thumbnail are silently omitted from the map.
+/// Files without a cached thumbnail are silently omitted from the map.
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
 pub fn thumbnail_paths(
     file_ids: Vec<String>,
     state: State<'_, AppState>,
-) -> Result<ThumbnailPathsResponse, String> {
+) -> Result<ThumbnailUrlsResponse, String> {
     let guard = state.project.lock().expect("project mutex poisoned");
     let ctx = guard.as_ref().ok_or_else(no_project_error)?;
 
@@ -41,7 +37,7 @@ pub fn thumbnail_paths(
         DEFAULT_CACHE_MAX_BYTES,
     );
 
-    let mut paths = HashMap::new();
+    let mut urls = HashMap::new();
 
     for fid_str in &file_ids {
         let Ok(file_id) = FileId::from_str(fid_str) else {
@@ -58,11 +54,13 @@ pub fn thumbnail_paths(
         };
 
         if let Some(abs_path) = cache.get(&key)
-            && let Some(s) = abs_path.to_str()
+            && let Ok(bytes) = std::fs::read(&abs_path)
         {
-            paths.insert(fid_str.clone(), s.to_owned());
+            use base64::Engine;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            urls.insert(fid_str.clone(), format!("data:image/webp;base64,{b64}"));
         }
     }
 
-    Ok(ThumbnailPathsResponse { paths })
+    Ok(ThumbnailUrlsResponse { urls })
 }

--- a/crates/progest-tauri/src/thumbnail_commands.rs
+++ b/crates/progest-tauri/src/thumbnail_commands.rs
@@ -1,0 +1,68 @@
+//! IPC commands for thumbnail retrieval.
+//!
+//! Thumbnails are served via Tauri's asset protocol — the frontend
+//! calls `thumbnail_paths` with a batch of file IDs and receives
+//! absolute filesystem paths that can be converted to asset URLs
+//! with `convertFileSrc()`.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use progest_core::identity::FileId;
+use progest_core::index::Index;
+use progest_core::thumbnail::{CacheKey, DEFAULT_CACHE_MAX_BYTES, DEFAULT_MAX_DIM, ThumbnailCache};
+use serde::Serialize;
+use tauri::State;
+
+use crate::commands::no_project_error;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ThumbnailPathsResponse {
+    pub paths: HashMap<String, String>,
+}
+
+/// Return absolute thumbnail paths for a batch of file IDs.
+///
+/// The frontend converts these to asset-protocol URLs via
+/// `convertFileSrc()` and uses them as `<img src>`.  Files without
+/// a cached thumbnail are silently omitted from the map.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn thumbnail_paths(
+    file_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<ThumbnailPathsResponse, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+    let cache = ThumbnailCache::new(
+        ctx.root.root().join(".progest/thumbs"),
+        DEFAULT_CACHE_MAX_BYTES,
+    );
+
+    let mut paths = HashMap::new();
+
+    for fid_str in &file_ids {
+        let Ok(file_id) = FileId::from_str(fid_str) else {
+            continue;
+        };
+        let Ok(Some(row)) = ctx.index.get_file(&file_id) else {
+            continue;
+        };
+
+        let key = CacheKey {
+            file_id: row.file_id,
+            fingerprint: row.fingerprint,
+            size: DEFAULT_MAX_DIM,
+        };
+
+        if let Some(abs_path) = cache.get(&key)
+            && let Some(s) = abs_path.to_str()
+        {
+            paths.insert(fid_str.clone(), s.to_owned());
+        }
+    }
+
+    Ok(ThumbnailPathsResponse { paths })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
 
   app:
     dependencies:
+      '@crabnebula/tauri-plugin-drag':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -234,6 +237,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@crabnebula/tauri-plugin-drag@2.1.0':
+    resolution: {integrity: sha512-LnUXAZwQt1cdMoGDLJ6ogW9wFCYServCZXlGadS7CA+CZ9eXS7L+Q7QyQW6g/zGw9YI2MwKFqf1aSNBGyWw+OA==}
 
   '@dotenvx/dotenvx@1.63.0':
     resolution: {integrity: sha512-jjkmzIRu19uH78AjFInqfcALehbDCZZ7M09hurVawyqNxtOXEg2LR73L59y4QnzfYDEzjbhVzGAd2uDHu0D1aQ==}
@@ -3560,6 +3566,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@crabnebula/tauri-plugin-drag@2.1.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@dotenvx/dotenvx@1.63.0':
     dependencies:


### PR DESCRIPTION
## Summary

- **Tauri IPC**: `import_ranking` / `import_preview` / `import_apply` (async + `spawn_blocking`) + `thumbnail_paths` (base64 data URL) — UI thread non-blocking
- **Grid view thumbnails**: `useThumbnails` hook fetches base64 data URLs in batch, `HitGrid` renders `<img>` with WebP thumbnails (fallback to FileIcon)
- **D&D import**: `DragDropProvider` listens to Tauri `onDragDropEvent` with DPR-corrected positions; FlatView shows `DropOverlay`, TreeView highlights hovered folder via `data-dir-path` + `elementFromPoint`
- **Import modal**: Popover+Command combobox for destination (suggested dirs scored by accepts ranking + all project dirs with fuzzy search), copy/move toggle, conflict preview, DotmSquare8 spinner during apply
- **tauri-plugin-drag** added as dependency for future drag-out support

## Test plan

- [x] Drop files from Finder onto FlatView → import modal opens with accepts-ranked suggestions
- [x] Drop files onto a TreeView folder → modal pre-selects that folder as destination
- [x] Switch to grid view → thumbnails display for supported formats (PNG/JPEG/WebP/PSD)
- [x] Import large files → UI stays responsive, spinner animates during apply
- [x] Import with conflicts (existing dest) → conflict badges shown, Import button disabled
- [x] Copy vs Move toggle → Move shows warning, applies correctly
- [x] Destination combobox → fuzzy search works across all project directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)