### PR TITLE
feat(app): add toast notifications for import and delete

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^19.2.0",
     "react-resizable-panels": "^4.10.0",
     "shadcn": "^4.5.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,7 @@ import { FlatViewSummaryProvider } from "@/lib/flat-view-context";
 import { ProjectProvider, useProject } from "@/lib/project-context";
 import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
+import { Toaster } from "@/components/ui/sonner";
 
 import "./App.css";
 
@@ -67,6 +68,7 @@ export function App() {
             <Shell />
           </FlatViewSummaryProvider>
         </ProjectProvider>
+        <Toaster position="bottom-right" />
       </TooltipProvider>
     </ThemeProvider>
   );

--- a/app/src/components/file-context-menu.tsx
+++ b/app/src/components/file-context-menu.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { fileDeleteApply, fileDeletePreview, type DeletePreview } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
@@ -51,6 +52,7 @@ export function FileContextMenu(props: FileContextMenuProps) {
       await fileDeleteApply(props.path);
       setConfirmOpen(false);
       bumpRefresh();
+      toast.success("Moved to Trash", { description: filename });
       props.onDeleted?.();
     } catch (e) {
       setError(String(e));

--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Plus, Trash2, X } from "lucide-react";
+import { toast } from "sonner";
 
 import {
   IpcError,
@@ -96,6 +97,7 @@ function DeleteSection(props: { path: string; onDeleted?: (() => void) | undefin
       await fileDeleteApply(props.path);
       setConfirmOpen(false);
       bumpRefresh();
+      toast.success("Moved to Trash", { description: filename });
       props.onDeleted?.();
     } catch (e) {
       setError(String(e));

--- a/app/src/components/import-modal.tsx
+++ b/app/src/components/import-modal.tsx
@@ -11,6 +11,8 @@ import {
   Star,
 } from "lucide-react";
 
+import { toast } from "sonner";
+
 import { DotmSquare8 } from "@/components/ui/dotm-square-8";
 
 import {
@@ -19,7 +21,6 @@ import {
   importRanking,
   type ImportConflict,
   type ImportOp,
-  type ImportOutcome,
   type ImportPreview,
   type ImportRequestWire,
   type SuggestedDestination,
@@ -60,7 +61,6 @@ export function ImportModal(props: ImportModalProps) {
   const [suggestions, setSuggestions] = React.useState<SuggestedDestination[]>([]);
   const [allDirs, setAllDirs] = React.useState<string[]>([]);
   const [preview, setPreview] = React.useState<ImportPreview | null>(null);
-  const [outcome, setOutcome] = React.useState<ImportOutcome | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [busy, setBusy] = React.useState(false);
   const [dirPickerOpen, setDirPickerOpen] = React.useState(false);
@@ -69,7 +69,6 @@ export function ImportModal(props: ImportModalProps) {
     if (!open || sources.length === 0) return;
     setDest(initialDest ?? "");
     setPreview(null);
-    setOutcome(null);
     setError(null);
     setMode("copy");
     setSuggestions([]);
@@ -126,8 +125,17 @@ export function ImportModal(props: ImportModalProps) {
         return { source: src, dest: destPath, mode };
       });
       const result = await importApply(requests);
-      setOutcome(result);
       bumpRefresh();
+      onOpenChange(false);
+      const count = result.imported.length;
+      const warnCount = result.warnings.length;
+      if (warnCount > 0) {
+        toast.warning(
+          `Imported ${count} file${count === 1 ? "" : "s"} with ${warnCount} warning${warnCount === 1 ? "" : "s"}`,
+        );
+      } else {
+        toast.success(`Imported ${count} file${count === 1 ? "" : "s"}`);
+      }
     } catch (e) {
       setError(String(e));
     } finally {
@@ -141,49 +149,6 @@ export function ImportModal(props: ImportModalProps) {
     () => new Set(suggestions.map((s) => s.path)),
     [suggestions],
   );
-
-  if (outcome) {
-    return (
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Check className="size-5 text-green-500" />
-              Import complete
-            </DialogTitle>
-            <DialogDescription>
-              {outcome.imported.length} file{outcome.imported.length === 1 ? "" : "s"} imported
-              {outcome.warnings.length > 0 ? ` with ${outcome.warnings.length} warning(s)` : ""}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-48 overflow-auto text-xs font-mono space-y-0.5">
-            {outcome.imported.map((f) => (
-              <div key={f.dest} className="flex items-center gap-1.5 text-muted-foreground">
-                {f.mode === "move" ? (
-                  <Scissors className="size-3 shrink-0" />
-                ) : (
-                  <Copy className="size-3 shrink-0" />
-                )}
-                <span className="truncate">{f.dest}</span>
-              </div>
-            ))}
-          </div>
-          {outcome.warnings.length > 0 ? (
-            <div className="rounded border border-warning/30 bg-warning/5 p-2 text-xs space-y-0.5">
-              {outcome.warnings.map((w, i) => (
-                <div key={`${w.dest}-${i}`} className="text-warning">
-                  {w.kind}: {w.message}
-                </div>
-              ))}
-            </div>
-          ) : null}
-          <DialogFooter>
-            <Button onClick={() => onOpenChange(false)}>Done</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
-  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/app/src/components/ui/sonner.tsx
+++ b/app/src/components/ui/sonner.tsx
@@ -1,0 +1,47 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme } = useTheme()
+
+  return (
+    <Sonner
+      theme={(theme as ToasterProps["theme"]) ?? "system"}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       shadcn:
         specifier: ^4.5.0
         version: 4.5.0(@types/node@24.12.2)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3110,6 +3113,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6187,6 +6196,11 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- Add shadcn Sonner toast component and wire `<Toaster>` into `App.tsx`
- Replace the import completion dialog with a success/warning toast after apply
- Add "Moved to Trash" toast after file deletion (both context-menu and inspector paths)
- Fix `exactOptionalPropertyTypes` type error in generated `sonner.tsx`

## Test plan
- [ ] D&D import files → confirm → toast appears with file count
- [ ] Import with placement warnings → warning toast
- [ ] Right-click file → Move to Trash → "Moved to Trash" toast with filename
- [ ] Inspector delete button → Move to Trash → same toast
- [ ] Light/dark theme — toast inherits theme correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)