### PR TITLE
fix: case-insensitive path uniqueness in SQLite index

### DIFF
--- a/crates/progest-core/src/index/migration.rs
+++ b/crates/progest-core/src/index/migration.rs
@@ -45,6 +45,11 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "search",
         sql: include_str!("migrations/0002_search.sql"),
     },
+    Migration {
+        version: 3,
+        name: "case_insensitive_path",
+        sql: include_str!("migrations/0003_case_insensitive_path.sql"),
+    },
 ];
 
 /// Errors surfaced by [`apply`].

--- a/crates/progest-core/src/index/migrations/0003_case_insensitive_path.sql
+++ b/crates/progest-core/src/index/migrations/0003_case_insensitive_path.sql
@@ -1,0 +1,69 @@
+-- Case-insensitive path uniqueness for Windows and default macOS.
+--
+-- On case-insensitive filesystems (Windows NTFS, default macOS HFS+)
+-- the same file can be indexed with different casing, producing
+-- duplicate rows. This migration:
+--
+--  1. Deduplicates existing rows (keeps the first inserted per
+--     case-folded path).
+--  2. Rebuilds `files` with `COLLATE NOCASE` on the `path` column
+--     so future INSERTs and lookups are case-insensitive.
+--  3. Recreates indexes and FTS5 triggers dropped by the table
+--     rebuild.
+
+-- 1. Deduplicate: keep first row per case-folded path.
+DELETE FROM files WHERE rowid NOT IN (
+    SELECT MIN(rowid) FROM files GROUP BY path COLLATE NOCASE
+);
+
+-- 2. Rebuild table with COLLATE NOCASE on path.
+CREATE TABLE files_new (
+    file_id          TEXT PRIMARY KEY,
+    path             TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    fingerprint      TEXT NOT NULL,
+    source_file_id   TEXT,
+    kind             TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    size             INTEGER,
+    mtime            INTEGER,
+    created_at       TEXT,
+    last_seen_at     TEXT,
+    name             TEXT,
+    ext              TEXT,
+    notes            TEXT,
+    updated_at       TEXT,
+    is_orphan        INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO files_new SELECT * FROM files;
+DROP TABLE files;
+ALTER TABLE files_new RENAME TO files;
+
+-- 3. Recreate indexes (from 0001 + 0002).
+CREATE INDEX idx_files_path        ON files(path COLLATE NOCASE);
+CREATE INDEX idx_files_fingerprint ON files(fingerprint);
+CREATE INDEX idx_files_ext         ON files(ext);
+CREATE INDEX idx_files_updated_at  ON files(updated_at);
+
+-- 4. Recreate FTS5 triggers (from 0002).
+--    The virtual table `files_fts` survives (it has its own storage)
+--    but the triggers reference `files` which was rebuilt.
+CREATE TRIGGER files_fts_after_insert
+AFTER INSERT ON files
+BEGIN
+    INSERT INTO files_fts (file_id, name, notes)
+    VALUES (NEW.file_id, COALESCE(NEW.name, ''), COALESCE(NEW.notes, ''));
+END;
+
+CREATE TRIGGER files_fts_after_update
+AFTER UPDATE OF name, notes ON files
+BEGIN
+    DELETE FROM files_fts WHERE file_id = OLD.file_id;
+    INSERT INTO files_fts (file_id, name, notes)
+    VALUES (NEW.file_id, COALESCE(NEW.name, ''), COALESCE(NEW.notes, ''));
+END;
+
+CREATE TRIGGER files_fts_after_delete
+AFTER DELETE ON files
+BEGIN
+    DELETE FROM files_fts WHERE file_id = OLD.file_id;
+END;

--- a/crates/progest-core/src/index/store.rs
+++ b/crates/progest-core/src/index/store.rs
@@ -892,4 +892,38 @@ mod tests {
         let err = idx.get_file_by_path(&p).unwrap_err();
         assert!(matches!(err, IndexError::InvalidKind(_)));
     }
+
+    #[test]
+    fn get_file_by_path_is_case_insensitive() {
+        let idx = SqliteIndex::open_in_memory().unwrap();
+        let row = sample_row();
+        idx.upsert_file(&row).unwrap();
+
+        let upper = ProjectPath::new("ASSETS/HERO.PSD").unwrap();
+        let found = idx.get_file_by_path(&upper).unwrap();
+        assert!(
+            found.is_some(),
+            "case-insensitive lookup should find the row"
+        );
+        assert_eq!(found.unwrap().file_id, row.file_id);
+    }
+
+    #[test]
+    fn upsert_with_different_case_produces_one_row() {
+        let idx = SqliteIndex::open_in_memory().unwrap();
+        let row = sample_row();
+        idx.upsert_file(&row).unwrap();
+
+        let mut row2 = sample_row();
+        row2.path = ProjectPath::new("Assets/Hero.PSD").unwrap();
+        row2.file_id = FileId::new_v7();
+        idx.upsert_file(&row2).unwrap();
+
+        let all = idx.list_files().unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "different-case path should collapse to one row"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add migration 0003: rebuild `files` table with `COLLATE NOCASE` on the `path` column
- Deduplicates existing rows that differ only in case (keeps first inserted per case-folded path)
- Recreates indexes and FTS5 triggers dropped by the table rebuild
- Benefits both Windows (NTFS) and macOS (default HFS+), where filesystems are case-insensitive

Part of the Windows support initiative (W2). The index is a rebuildable cache, so the migration is safe.

## Test plan

- [x] `mise run check` green
- [x] `cargo test --workspace` all pass
- [x] New test: case-insensitive lookup finds existing row
- [x] New test: upsert with different casing produces exactly one row
- [ ] Verify on Windows: `progest scan` does not create duplicate index entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)