### PR TITLE
feat: reserved filenames, OneDrive placeholders, and UNC path support

### DIFF
--- a/crates/progest-core/src/fs/mod.rs
+++ b/crates/progest-core/src/fs/mod.rs
@@ -15,6 +15,7 @@ pub mod filesystem;
 pub mod ignore;
 pub mod mem;
 pub mod path;
+pub mod placeholder;
 pub mod scanner;
 
 pub use fault::{FaultKind, FaultyFileSystem, Op as FaultOp};
@@ -22,4 +23,5 @@ pub use filesystem::{FileSystem, FsError, Metadata, StdFileSystem};
 pub use ignore::{DEFAULT_PATTERNS, IgnoreError, IgnoreRules, USER_IGNORE_PATH};
 pub use mem::MemFileSystem;
 pub use path::{ProjectPath, ProjectPathError};
+pub use placeholder::is_cloud_placeholder;
 pub use scanner::{EntryKind, ScanEntry, ScanError, ScanIter, Scanner};

--- a/crates/progest-core/src/fs/placeholder.rs
+++ b/crates/progest-core/src/fs/placeholder.rs
@@ -1,0 +1,35 @@
+//! Cloud storage placeholder detection.
+//!
+//! On Windows, `OneDrive` (and similar cloud sync providers) create
+//! "placeholder" files that appear in directory listings but whose
+//! content has not been downloaded. Reading or fingerprinting them
+//! triggers a potentially slow and unwanted download.
+//!
+//! [`is_cloud_placeholder`] detects these files via the
+//! `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS` and
+//! `FILE_ATTRIBUTE_RECALL_ON_OPEN` file attributes so that the
+//! scanner and reconciler can skip them.
+
+use std::path::Path;
+
+/// Returns `true` if `path` is a cloud storage placeholder file
+/// that has not been fully downloaded.
+///
+/// On non-Windows platforms this always returns `false`.
+#[cfg(windows)]
+pub fn is_cloud_placeholder(path: &Path) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    std::fs::metadata(path)
+        .map(|m| {
+            let attrs = m.file_attributes();
+            // FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000
+            // FILE_ATTRIBUTE_RECALL_ON_OPEN        = 0x00200000
+            (attrs & 0x0040_0000 != 0) || (attrs & 0x0020_0000 != 0)
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(not(windows))]
+pub fn is_cloud_placeholder(_path: &Path) -> bool {
+    false
+}

--- a/crates/progest-core/src/fs/scanner.rs
+++ b/crates/progest-core/src/fs/scanner.rs
@@ -118,6 +118,11 @@ impl Iterator for ScanIter {
                 continue;
             };
 
+            if file_type.is_file() && super::placeholder::is_cloud_placeholder(entry.path()) {
+                tracing::info!("skipping cloud placeholder: {}", entry.path().display());
+                continue;
+            }
+
             let kind = if file_type.is_symlink() {
                 EntryKind::Symlink
             } else if file_type.is_dir() {

--- a/crates/progest-core/src/rules/constraint.rs
+++ b/crates/progest-core/src/rules/constraint.rs
@@ -42,6 +42,15 @@ pub struct CompiledConstraint {
     pub required_suffix: String,
 }
 
+/// Windows reserved device names (case-insensitive, with or without
+/// extension). Files with these names cannot be created on NTFS and
+/// will break cross-platform projects. Checked unconditionally so
+/// macOS/Linux users also get warnings for Windows compatibility.
+const WINDOWS_RESERVED_NAMES: &[&str] = &[
+    "CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+    "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
 /// Builtin compound extension tokens recognized by Progest v1 (§4.8).
 ///
 /// Users may extend this via `.progest/schema.toml [extension_compounds]`
@@ -61,6 +70,7 @@ pub enum ConstraintFailure {
     TooShort { length: u32, min: u32 },
     MissingPrefix { required: String },
     MissingSuffix { required: String },
+    WindowsReservedName { name: String },
 }
 
 impl fmt::Display for ConstraintFailure {
@@ -90,6 +100,9 @@ impl fmt::Display for ConstraintFailure {
             }
             Self::MissingPrefix { required } => write!(f, "required prefix `{required}` missing"),
             Self::MissingSuffix { required } => write!(f, "required suffix `{required}` missing"),
+            Self::WindowsReservedName { name } => {
+                write!(f, "`{name}` is a Windows reserved filename")
+            }
         }
     }
 }
@@ -268,6 +281,16 @@ pub fn evaluate_constraint(
         if c.reserved_words.iter().any(|w| w == &lower) {
             failures.push(ConstraintFailure::ReservedWord {
                 word: token.to_owned(),
+            });
+        }
+    }
+
+    // Windows reserved names (stem only, cross-platform lint)
+    {
+        let stem_upper = stem.to_ascii_uppercase();
+        if WINDOWS_RESERVED_NAMES.iter().any(|r| r == &stem_upper) {
+            failures.push(ConstraintFailure::WindowsReservedName {
+                name: stem.to_owned(),
             });
         }
     }
@@ -827,6 +850,41 @@ mod tests {
             f.iter()
                 .any(|v| matches!(v, ConstraintFailure::MissingSuffix { .. }))
         );
+    }
+
+    // --- Windows reserved names ---------------------------------------------
+
+    #[test]
+    fn windows_reserved_name_is_flagged() {
+        let c = compile_constraint(&default_raw()).unwrap();
+        for name in [
+            "CON.txt", "prn.log", "AUX.psd", "NUL.dat", "com1.tmp", "LPT3.out",
+        ] {
+            let f = evaluate_constraint(&c, name, &[]);
+            assert!(
+                f.iter()
+                    .any(|v| matches!(v, ConstraintFailure::WindowsReservedName { .. })),
+                "{name} should be flagged as Windows reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_reserved_name_does_not_false_positive() {
+        let c = compile_constraint(&default_raw()).unwrap();
+        for name in [
+            "console.txt",
+            "auxiliary.psd",
+            "component.rs",
+            "null_value.json",
+        ] {
+            let f = evaluate_constraint(&c, name, &[]);
+            assert!(
+                f.iter()
+                    .all(|v| !matches!(v, ConstraintFailure::WindowsReservedName { .. })),
+                "{name} should NOT be flagged as Windows reserved"
+            );
+        }
     }
 
     // --- AND composition ---------------------------------------------------


### PR DESCRIPTION
## Summary

- **Windows reserved filenames**: Add `ConstraintFailure::WindowsReservedName` that flags `CON`, `PRN`, `AUX`, `NUL`, `COM0-9`, `LPT0-9` as naming violations. Runs on all platforms for cross-platform lint compatibility.
- **OneDrive placeholder detection**: New `fs::placeholder` module detects cloud placeholder files (not yet downloaded) via Windows file attributes. Scanner skips these to avoid triggering unwanted downloads. No-op on non-Windows.
- **UNC paths**: Already handled by `dunce::canonicalize` (W1) + `ProjectPath::from_absolute` using `strip_prefix`. No additional code needed.

Part of the Windows support initiative (W4).

## Test plan

- [x] `mise run check` green
- [x] `cargo test --workspace` all pass
- [x] New test: `CON.txt`, `prn.log`, etc. flagged as reserved
- [x] New test: `console.txt`, `auxiliary.psd` NOT flagged (no false positives)
- [ ] Verify on Windows: `progest lint` flags `CON.txt`; OneDrive placeholders skipped during scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)