### PR TITLE
feat: platform-aware titlebar and keyboard shortcuts

### DIFF
--- a/app/src/components/title-bar.tsx
+++ b/app/src/components/title-bar.tsx
@@ -29,7 +29,10 @@ export function TitleBar(props: {
   panels: PanelVisibility;
   onTogglePanel: (key: PanelKey) => void;
 }) {
-  const { project, openPicker } = useProject();
+  const { project, platform, openPicker } = useProject();
+  const isMac = platform === "macos";
+  const modKey = isMac ? "⌘" : "Ctrl+";
+  const titlebarPadding = isMac ? "pl-[80px]" : "pl-2";
   const { panels, onTogglePanel } = props;
 
   const visibleKeys = React.useMemo(
@@ -68,10 +71,7 @@ export function TitleBar(props: {
         // column is `auto` (sized by the search button); the side
         // columns are equal-width via `1fr` so the search stays put.
         "grid-cols-[1fr_auto_1fr]",
-        // Reserve room for macOS traffic lights. Other platforms get a
-        // benign extra 80 px gutter — fine for v1.0 (macOS-first); a
-        // platform-aware variant lands when Windows ships in v1.1.
-        "pl-[80px]",
+        titlebarPadding,
       )}
     >
       {/* Left cluster — project chip + separator + panel toggles.
@@ -151,12 +151,12 @@ export function TitleBar(props: {
         size="sm"
         onClick={() => window.dispatchEvent(new CustomEvent("progest:toggle-palette"))}
         className="h-7 w-64 justify-start gap-2 text-muted-foreground"
-        title="Open command palette (⌘K)"
+        title={`Open command palette (${modKey}K)`}
       >
         <Search className="size-3.5" />
         <span className="flex-1 text-left text-xs">Search…</span>
         <kbd className="rounded bg-muted px-1.5 py-0.5 text-[0.625rem] text-muted-foreground">
-          ⌘K
+          {modKey}K
         </kbd>
       </Button>
 

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -25,6 +25,7 @@ export type ProjectInfo = {
 
 export type AppInfo = {
   project: ProjectInfo | null;
+  platform: string;
 };
 
 export type RichViolationCounts = {

--- a/app/src/lib/project-context.tsx
+++ b/app/src/lib/project-context.tsx
@@ -17,6 +17,7 @@ import {
 
 type ProjectContextValue = {
   project: ProjectInfo | null;
+  platform: string;
   recent: RecentProject[];
   error: string | null;
   /** Re-probe the backend for the currently attached project. */
@@ -80,6 +81,7 @@ const Ctx = React.createContext<ProjectContextValue | null>(null);
 
 export function ProjectProvider({ children }: { children: React.ReactNode }) {
   const [project, setProject] = React.useState<ProjectInfo | null>(null);
+  const [platform, setPlatform] = React.useState("macos");
   const [recent, setRecent] = React.useState<RecentProject[]>([]);
   const [error, setError] = React.useState<string | null>(null);
   const [refreshTick, setRefreshTick] = React.useState(0);
@@ -91,6 +93,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
     try {
       const info = await appInfo();
       setProject(info.project);
+      setPlatform(info.platform);
       setError(null);
     } catch (e) {
       setProject(null);
@@ -116,6 +119,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
       try {
         const info = await projectOpen(path);
         setProject(info.project);
+        setPlatform(info.platform);
         setError(null);
         await refreshRecent();
       } catch (e) {
@@ -212,6 +216,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
   const value = React.useMemo<ProjectContextValue>(
     () => ({
       project,
+      platform,
       recent,
       error,
       refresh,
@@ -231,6 +236,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
     }),
     [
       project,
+      platform,
       recent,
       error,
       refresh,

--- a/crates/progest-tauri/src/commands.rs
+++ b/crates/progest-tauri/src/commands.rs
@@ -50,6 +50,7 @@ const VIEWS_TOML_PATH: &str = ".progest/views.toml";
 #[derive(Debug, Clone, Serialize)]
 pub struct AppInfo {
     pub project: Option<ProjectInfo>,
+    pub platform: String,
 }
 
 /// Response shape for `search_execute`.
@@ -133,6 +134,7 @@ pub fn project_open(path: String, state: State<'_, AppState>) -> Result<AppInfo,
     *guard = Some(ctx);
     Ok(AppInfo {
         project: Some(info),
+        platform: std::env::consts::OS.to_owned(),
     })
 }
 
@@ -155,6 +157,7 @@ pub fn app_info(state: State<'_, AppState>) -> AppInfo {
     let guard = state.project.lock().expect("project mutex poisoned");
     AppInfo {
         project: guard.as_ref().map(ProjectInfo::from_context),
+        platform: std::env::consts::OS.to_owned(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Expose `platform` field (`macos`/`windows`/`linux`) in `AppInfo` IPC response
- Titlebar left padding: `80px` for macOS (traffic lights), `8px` for Windows/Linux
- Keyboard shortcut labels: `⌘K` on macOS, `Ctrl+K` on Windows/Linux
- Windows uses standard OS system chrome (no code changes needed — already correct via `#[cfg(target_os = "macos")]`)

Part of the Windows support initiative (W5).

## Test plan

- [x] `mise run check` green
- [x] `cargo test --workspace` all pass
- [ ] Verify on Windows: `Ctrl+K` label shown, no 80px gap on left
- [ ] Verify on macOS: `⌘K` label shown, traffic light padding preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)