### PR TITLE
ci: add Windows CI runner and NSIS installer config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,16 @@ jobs:
         run: mise run check
 
   test:
-    name: Cargo test
-    runs-on: ubuntu-latest
+    name: Cargo test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Tauri build dependencies
+      - name: Install Tauri build dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -82,7 +86,25 @@ jobs:
   build-macos:
     name: Build (macOS)
     runs-on: macos-latest
-    # Only run on main pushes to keep macOS minutes manageable.
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: jdx/mise-action@v3
+        with:
+          install: true
+          cache: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build workspace and frontend
+        run: mise run build
+
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v5

--- a/crates/progest-tauri/tauri.conf.json
+++ b/crates/progest-tauri/tauri.conf.json
@@ -29,6 +29,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "displayLanguageSelector": false
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add `windows-latest` to the cargo test matrix — core tests now run on both Linux and Windows
- Add a `build-windows` job (main pushes only) mirroring the existing `build-macos` job
- Configure NSIS installer settings in `tauri.conf.json` for Windows distribution
- Note: `bundle.active` remains `false` — CI build commands should use `--bundles nsis`/`--bundles dmg` flags when actual packaging is needed

Part of the Windows support initiative (W6).

## Test plan

- [x] `mise run check` green locally
- [ ] Verify `windows-latest` runner installs dependencies and passes tests in CI
- [ ] Verify NSIS config is picked up by `cargo tauri build` on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)