### PR TITLE
feat: BYOK AI suggestions (core + CLI + Tauri + UI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +626,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "foreign-types",
  "libc",
@@ -635,7 +641,7 @@ checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
  "bitflags 2.11.1",
  "block",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
 ]
@@ -686,6 +692,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -707,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -720,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -733,7 +749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -932,6 +948,27 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -1407,6 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1607,8 +1645,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1618,9 +1658,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1960,6 +2002,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2431,6 +2489,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2582,15 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2609,6 +2691,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3599,12 +3687,14 @@ dependencies = [
  "heck 0.5.0",
  "ignore",
  "image",
+ "keyring",
  "libheif-rs",
  "notify",
  "notify-debouncer-full",
  "proptest",
  "psd",
  "regex",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3702,6 +3792,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4002,6 +4147,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -4065,6 +4250,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4104,6 +4303,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4195,6 +4429,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4336,6 +4606,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4608,6 +4890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4681,7 +4969,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
@@ -4758,7 +5046,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5194,6 +5482,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +5854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5842,6 +6146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,6 +6209,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6302,6 +6625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6865,6 +7197,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ which = "7"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "tiff", "gif", "bmp", "rayon"] }
 psd = "0.3"
 libheif-rs = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [profile.release]
 lto = "thin"

--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
 import { DotmSquare1 } from "@/components/ui/dotm-square-1";
+import { DotmSquare12 } from "@/components/ui/dotm-square-12";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -586,7 +587,7 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
       ) : null}
       {busy ? (
         <div className="flex items-center gap-1.5 text-muted-foreground">
-          <DotmSquare1 size={16} dotSize={2} animated />
+          <DotmSquare12 size={16} dotSize={2} animated />
           Generating…
         </div>
       ) : null}

--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -6,6 +6,7 @@ import {
   IpcError,
   aiDeleteKey,
   aiGetConfig,
+  aiSetConfig,
   aiSetKey,
   aiSuggest,
   fileDeleteApply,
@@ -521,11 +522,12 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
     setSavingKey(true);
     try {
       await aiSetKey(keyProvider, keyInput.trim());
+      await aiSetConfig({ provider: keyProvider });
       setKeyInput("");
       setShowKeyForm(false);
       const newConfig = await aiGetConfig();
       setConfig(newConfig);
-      toast.success("API key saved");
+      toast.success(`API key saved for ${keyProvider}`);
     } catch (e) {
       toast.error(e instanceof IpcError ? e.raw : String(e));
     } finally {

--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -4,12 +4,17 @@ import { toast } from "sonner";
 
 import {
   IpcError,
+  aiGetConfig,
+  aiSetKey,
+  aiSuggest,
   fileDeleteApply,
   fileDeletePreview,
   notesRead,
   notesWrite,
   tagAdd,
   tagRemove,
+  type AiConfigResponse,
+  type AiSuggestionWire,
   type DeletePreview,
   type RichSearchHit,
 } from "@/lib/ipc";
@@ -60,6 +65,7 @@ export function FileInspector(props: { hit: RichSearchHit; onDeleted?: (() => vo
         <TagsEditor hit={hit} disabled={!isIndexed} />
         <NotesEditor hit={hit} disabled={!isIndexed} />
         <CustomFieldsBlock hit={hit} />
+        {isIndexed ? <AiSuggestionsSection hit={hit} /> : null}
         {!isIndexed ? (
           <div className="rounded-md border border-warning/40 bg-warning/10 px-2 py-1.5 text-warning">
             This file isn&apos;t indexed yet — run <code>progest scan</code> (or wait for the next
@@ -415,6 +421,200 @@ function CustomFieldsBlock(props: { hit: RichSearchHit }) {
           </li>
         ))}
       </ul>
+    </section>
+  );
+}
+
+// ── AI Suggestions ─────────────────────────────────────────────────
+
+const AI_TYPES = ["naming", "tags", "notes", "placement"] as const;
+type AiType = (typeof AI_TYPES)[number];
+
+function AiSuggestionsSection(props: { hit: RichSearchHit }) {
+  const { hit } = props;
+  const { bumpRefresh } = useProject();
+  const [config, setConfig] = React.useState<AiConfigResponse | null>(null);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [suggestions, setSuggestions] = React.useState<AiSuggestionWire[]>([]);
+  const [activeType, setActiveType] = React.useState<AiType>("naming");
+  const [includeNotes, setIncludeNotes] = React.useState(false);
+  const [keyInput, setKeyInput] = React.useState("");
+  const [showKeyForm, setShowKeyForm] = React.useState(false);
+  const [savingKey, setSavingKey] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    aiGetConfig()
+      .then((c) => {
+        if (!cancelled) setConfig(c);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    setSuggestions([]);
+    setError(null);
+  }, [hit.path]);
+
+  const handleSuggest = async (type_: AiType) => {
+    setActiveType(type_);
+    setBusy(true);
+    setError(null);
+    setSuggestions([]);
+    try {
+      const resp = await aiSuggest(hit.path, type_, includeNotes);
+      setSuggestions(resp.suggestions);
+    } catch (e) {
+      setError(e instanceof IpcError ? e.raw : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleApplyTag = async (tag: string) => {
+    try {
+      await tagAdd(hit.file_id, tag);
+      bumpRefresh();
+      toast.success(`Tag "${tag}" added`);
+    } catch (e) {
+      toast.error(e instanceof IpcError ? e.raw : String(e));
+    }
+  };
+
+  const handleApplyNotes = async (notes: string) => {
+    try {
+      await notesWrite(hit.path, notes);
+      bumpRefresh();
+      toast.success("Notes updated");
+    } catch (e) {
+      toast.error(e instanceof IpcError ? e.raw : String(e));
+    }
+  };
+
+  const handleSaveKey = async () => {
+    if (!keyInput.trim() || !config) return;
+    setSavingKey(true);
+    try {
+      await aiSetKey(config.provider, keyInput.trim());
+      setKeyInput("");
+      setShowKeyForm(false);
+      const newConfig = await aiGetConfig();
+      setConfig(newConfig);
+      toast.success("API key saved");
+    } catch (e) {
+      toast.error(e instanceof IpcError ? e.raw : String(e));
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
+  if (!config) return null;
+
+  if (!config.has_key) {
+    return (
+      <section className="grid gap-1.5">
+        <Label className="text-muted-foreground">AI suggestions</Label>
+        {showKeyForm ? (
+          <div className="grid gap-2">
+            <Input
+              type="password"
+              placeholder={`${config.provider} API key`}
+              value={keyInput}
+              onChange={(e) => setKeyInput(e.target.value)}
+              disabled={savingKey}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleSaveKey();
+              }}
+            />
+            <div className="flex gap-1">
+              <Button
+                size="xs"
+                onClick={() => void handleSaveKey()}
+                disabled={savingKey || !keyInput.trim()}
+              >
+                {savingKey ? "Saving…" : "Save"}
+              </Button>
+              <Button
+                size="xs"
+                variant="ghost"
+                onClick={() => setShowKeyForm(false)}
+                disabled={savingKey}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button size="xs" variant="outline" onClick={() => setShowKeyForm(true)}>
+            Configure API key
+          </Button>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid gap-1.5">
+      <Label className="text-muted-foreground">AI suggestions</Label>
+      <div className="flex flex-wrap gap-1">
+        {AI_TYPES.map((t) => (
+          <Button
+            key={t}
+            size="xs"
+            variant={activeType === t && suggestions.length > 0 ? "default" : "outline"}
+            onClick={() => void handleSuggest(t)}
+            disabled={busy}
+          >
+            {t}
+          </Button>
+        ))}
+      </div>
+      {activeType === "notes" ? (
+        <label className="flex items-center gap-1.5 text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={includeNotes}
+            onChange={(e) => setIncludeNotes(e.target.checked)}
+            className="accent-primary"
+          />
+          Include existing notes in AI context
+        </label>
+      ) : null}
+      {busy ? (
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <DotmSquare1 size={16} dotSize={2} animated />
+          Generating…
+        </div>
+      ) : null}
+      {error ? <div className="text-destructive">{error}</div> : null}
+      {suggestions.length > 0 ? (
+        <ul className="grid gap-1">
+          {suggestions.map((s, i) => (
+            <li key={i} className="rounded-md border bg-muted/30 px-2 py-1.5">
+              <div className="flex items-start justify-between gap-2">
+                <span className="break-words font-mono">{s.value}</span>
+                {activeType === "tags" ? (
+                  <Button size="xs" variant="ghost" onClick={() => void handleApplyTag(s.value)}>
+                    Apply
+                  </Button>
+                ) : null}
+                {activeType === "notes" ? (
+                  <Button size="xs" variant="ghost" onClick={() => void handleApplyNotes(s.value)}>
+                    Apply
+                  </Button>
+                ) : null}
+              </div>
+              {s.explanation ? (
+                <div className="mt-0.5 text-muted-foreground">{s.explanation}</div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </section>
   );
 }

--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import {
   IpcError,
+  aiDeleteKey,
   aiGetConfig,
   aiSetKey,
   aiSuggest,
@@ -430,6 +431,7 @@ function CustomFieldsBlock(props: { hit: RichSearchHit }) {
 
 const AI_TYPES = ["naming", "tags", "notes", "placement"] as const;
 type AiType = (typeof AI_TYPES)[number];
+const AI_PROVIDERS = ["anthropic", "openai"] as const;
 
 function AiSuggestionsSection(props: { hit: RichSearchHit }) {
   const { hit } = props;
@@ -441,6 +443,7 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
   const [activeType, setActiveType] = React.useState<AiType>("naming");
   const [includeNotes, setIncludeNotes] = React.useState(false);
   const [keyInput, setKeyInput] = React.useState("");
+  const [keyProvider, setKeyProvider] = React.useState<string>("anthropic");
   const [showKeyForm, setShowKeyForm] = React.useState(false);
   const [savingKey, setSavingKey] = React.useState(false);
 
@@ -448,7 +451,10 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
     let cancelled = false;
     aiGetConfig()
       .then((c) => {
-        if (!cancelled) setConfig(c);
+        if (!cancelled) {
+          setConfig(c);
+          setKeyProvider(c.provider);
+        }
       })
       .catch(() => {});
     return () => {
@@ -496,11 +502,25 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
     }
   };
 
+  const handleDeleteKey = async () => {
+    if (!config) return;
+    try {
+      await aiDeleteKey(config.provider);
+      const newConfig = await aiGetConfig();
+      setConfig(newConfig);
+      setShowKeyForm(false);
+      setSuggestions([]);
+      toast.success("API key removed");
+    } catch (e) {
+      toast.error(e instanceof IpcError ? e.raw : String(e));
+    }
+  };
+
   const handleSaveKey = async () => {
-    if (!keyInput.trim() || !config) return;
+    if (!keyInput.trim()) return;
     setSavingKey(true);
     try {
-      await aiSetKey(config.provider, keyInput.trim());
+      await aiSetKey(keyProvider, keyInput.trim());
       setKeyInput("");
       setShowKeyForm(false);
       const newConfig = await aiGetConfig();
@@ -521,9 +541,22 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
         <Label className="text-muted-foreground">AI suggestions</Label>
         {showKeyForm ? (
           <div className="grid gap-2">
+            <div className="flex gap-1.5">
+              {AI_PROVIDERS.map((p) => (
+                <Button
+                  key={p}
+                  size="xs"
+                  variant={keyProvider === p ? "default" : "outline"}
+                  onClick={() => setKeyProvider(p)}
+                  disabled={savingKey}
+                >
+                  {p}
+                </Button>
+              ))}
+            </div>
             <Input
               type="password"
-              placeholder={`${config.provider} API key`}
+              placeholder={`${keyProvider} API key`}
               value={keyInput}
               onChange={(e) => setKeyInput(e.target.value)}
               disabled={savingKey}
@@ -560,7 +593,72 @@ function AiSuggestionsSection(props: { hit: RichSearchHit }) {
 
   return (
     <section className="grid gap-1.5">
-      <Label className="text-muted-foreground">AI suggestions</Label>
+      <div className="flex items-center justify-between">
+        <Label className="text-muted-foreground">AI suggestions</Label>
+        <span className="text-[0.625rem] text-muted-foreground">
+          {config.provider}/{config.model.split("-").slice(0, 2).join("-")}
+          {" · "}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-foreground"
+            onClick={() => setShowKeyForm(true)}
+          >
+            change
+          </button>
+          {" · "}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-destructive"
+            onClick={() => void handleDeleteKey()}
+          >
+            remove
+          </button>
+        </span>
+      </div>
+      {showKeyForm ? (
+        <div className="grid gap-2 rounded-md border bg-muted/30 p-2">
+          <div className="flex gap-1.5">
+            {AI_PROVIDERS.map((p) => (
+              <Button
+                key={p}
+                size="xs"
+                variant={keyProvider === p ? "default" : "outline"}
+                onClick={() => setKeyProvider(p)}
+                disabled={savingKey}
+              >
+                {p}
+              </Button>
+            ))}
+          </div>
+          <Input
+            type="password"
+            placeholder={`${keyProvider} API key`}
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            disabled={savingKey}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSaveKey();
+            }}
+          />
+          <div className="flex gap-1">
+            <Button
+              size="xs"
+              onClick={() => void handleSaveKey()}
+              disabled={savingKey || !keyInput.trim()}
+            >
+              {savingKey ? "Saving…" : "Save"}
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={() => setShowKeyForm(false)}
+              disabled={savingKey}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : null}
       <div className="flex flex-wrap gap-1">
         {AI_TYPES.map((t) => (
           <Button

--- a/app/src/components/ui/dotm-square-12.tsx
+++ b/app/src/components/ui/dotm-square-12.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import { DotMatrixBase } from "@/lib/dotmatrix-core";
+import { useDotMatrixPhases } from "@/lib/dotmatrix-hooks";
+import { usePrefersReducedMotion } from "@/lib/dotmatrix-hooks";
+import type { DotAnimationResolver, DotMatrixCommonProps } from "@/lib/dotmatrix-core";
+
+export type DotmSquare12Props = DotMatrixCommonProps;
+
+// User-defined origin is cell (2,2) in a 1-based 5x5 grid => (row=1,col=1) in zero-based coords.
+const ORIGIN_ROW = 1;
+const ORIGIN_COL = 1;
+const MAX_MANHATTAN = 6;
+
+const animationResolver: DotAnimationResolver = ({ isActive, row, col, reducedMotion, phase }) => {
+  if (!isActive) {
+    return { className: "dmx-inactive" };
+  }
+
+  const ring = Math.max(
+    0,
+    Math.min(MAX_MANHATTAN, Math.abs(row - ORIGIN_ROW) + Math.abs(col - ORIGIN_COL))
+  );
+  const style = {
+    "--dmx-center-ripple-ring": ring
+  } as CSSProperties;
+
+  if (reducedMotion || phase === "idle") {
+    return {
+      style: {
+        ...style,
+        opacity: 0.2 + (1 - ring / MAX_MANHATTAN) * 0.75
+      }
+    };
+  }
+
+  return { className: "dmx-center-origin-ripple", style };
+};
+
+export function DotmSquare12({
+  speed = 1.35,
+  pattern = "full",
+  animated = true,
+  hoverAnimated = false,
+  ...rest
+}: DotmSquare12Props) {
+  const reducedMotion = usePrefersReducedMotion();
+  const { phase: matrixPhase, onMouseEnter, onMouseLeave } = useDotMatrixPhases({
+    animated: Boolean(animated && !reducedMotion),
+    hoverAnimated: Boolean(hoverAnimated && !reducedMotion),
+    speed
+  });
+
+  return (
+    <DotMatrixBase
+      {...rest}
+      size={rest.size ?? 36}
+      dotSize={rest.dotSize ?? 5}
+      speed={speed}
+      pattern={pattern}
+      animated={animated}
+      phase={matrixPhase}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      reducedMotion={reducedMotion}
+      animationResolver={animationResolver}
+    />
+  );
+}

--- a/app/src/lib/dotmatrix-core.tsx
+++ b/app/src/lib/dotmatrix-core.tsx
@@ -531,7 +531,7 @@ function getMatrix5Layout(
 }
 
 function resolveDmxBoxOuterDim(
-  options: { boxSize?: number | undefined; minSize?: number | undefined } | null | undefined,
+  options: { boxSize?: number; minSize?: number } | null | undefined,
 ): { outerDim: number; useWrapper: boolean } {
   const b = options?.boxSize;
   const hasBox = b != null && b > 0 && Number.isFinite(b);
@@ -589,7 +589,10 @@ export function DotMatrixBase({
   const safeSpeed = speed > 0 ? speed : 1;
   const speedScale = 1 / safeSpeed;
   const { gap, matrixSpan } = getMatrix5Layout(size, dotSize, cellPadding);
-  const { outerDim, useWrapper } = resolveDmxBoxOuterDim({ boxSize, minSize });
+  const { outerDim, useWrapper } = resolveDmxBoxOuterDim({
+    boxSize: boxSize ?? undefined,
+    minSize: minSize ?? undefined,
+  } as { boxSize?: number; minSize?: number });
   const scale = useWrapper && matrixSpan > 0 ? outerDim / matrixSpan : 1;
   const center = Math.floor(MATRIX_SIZE / 2);
   const ob = clamp01Dmx(opacityBase);

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -565,3 +565,58 @@ export async function lintRun(onProgress?: (e: ProgressEvent) => void): Promise<
     throw toIpcError(e);
   }
 }
+
+// --- AI suggestions -------------------------------------------------------
+
+export type AiSuggestionWire = {
+  value: string;
+  explanation: string | null;
+};
+
+export type AiSuggestResponse = {
+  suggestions: AiSuggestionWire[];
+  model: string;
+  provider: string;
+  elapsed_ms: number;
+  suggestion_type: string;
+};
+
+export type AiConfigResponse = {
+  provider: string;
+  model: string;
+  audit_log: boolean;
+  has_key: boolean;
+  glossary: string[];
+};
+
+export async function aiSuggest(
+  path: string,
+  suggestionType: string,
+  includeNotes: boolean,
+): Promise<AiSuggestResponse> {
+  try {
+    return await invoke<AiSuggestResponse>("ai_suggest", {
+      path,
+      suggestionType,
+      includeNotes,
+    });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function aiSetKey(provider: string, key: string): Promise<void> {
+  try {
+    await invoke<void>("ai_set_key", { provider, key });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function aiGetConfig(): Promise<AiConfigResponse> {
+  try {
+    return await invoke<AiConfigResponse>("ai_get_config");
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -621,6 +621,18 @@ export async function aiDeleteKey(provider: string): Promise<void> {
   }
 }
 
+export async function aiSetConfig(opts: {
+  provider?: string;
+  model?: string;
+  audit_log?: boolean;
+}): Promise<void> {
+  try {
+    await invoke<void>("ai_set_config", opts);
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 export async function aiGetConfig(): Promise<AiConfigResponse> {
   try {
     return await invoke<AiConfigResponse>("ai_get_config");

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -613,6 +613,14 @@ export async function aiSetKey(provider: string, key: string): Promise<void> {
   }
 }
 
+export async function aiDeleteKey(provider: string): Promise<void> {
+  try {
+    await invoke<void>("ai_delete_key", { provider });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 export async function aiGetConfig(): Promise<AiConfigResponse> {
   try {
     return await invoke<AiConfigResponse>("ai_get_config");

--- a/app/src/lib/palette-commands/ai-commands.ts
+++ b/app/src/lib/palette-commands/ai-commands.ts
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import type { PaletteCommand } from "./types";
+
+export function useAiCommands(): PaletteCommand[] {
+  return React.useMemo<PaletteCommand[]>(
+    () => [
+      {
+        id: "ai.suggest.naming",
+        title: "AI: Suggest filename",
+        group: "AI",
+        keywords: ["ai", "name", "rename", "suggest"],
+        hint: "select a file first",
+        run: () => {},
+      },
+      {
+        id: "ai.suggest.tags",
+        title: "AI: Suggest tags",
+        group: "AI",
+        keywords: ["ai", "tag", "suggest"],
+        hint: "select a file first",
+        run: () => {},
+      },
+      {
+        id: "ai.suggest.notes",
+        title: "AI: Generate notes",
+        group: "AI",
+        keywords: ["ai", "notes", "generate", "describe"],
+        hint: "select a file first",
+        run: () => {},
+      },
+      {
+        id: "ai.suggest.placement",
+        title: "AI: Suggest placement",
+        group: "AI",
+        keywords: ["ai", "move", "placement", "directory"],
+        hint: "select a file first",
+        run: () => {},
+      },
+      {
+        id: "ai.configure",
+        title: "AI: Configure API key",
+        group: "AI",
+        keywords: ["ai", "key", "config", "setup", "byok", "openai", "anthropic"],
+        run: () => {},
+      },
+    ],
+    [],
+  );
+}

--- a/app/src/lib/palette-commands/index.ts
+++ b/app/src/lib/palette-commands/index.ts
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 
+import { useAiCommands } from "./ai-commands";
 import { useProjectCommands } from "./project-commands";
 import { useThemeCommands } from "./theme-commands";
 import type { PaletteCommand } from "./types";
@@ -27,7 +28,8 @@ export { fuzzyMatch } from "./types";
 export function usePaletteCommands(): PaletteCommand[] {
   const project = useProjectCommands();
   const theme = useThemeCommands();
-  return React.useMemo(() => [...project, ...theme], [project, theme]);
+  const ai = useAiCommands();
+  return React.useMemo(() => [...project, ...theme, ...ai], [project, theme, ai]);
 }
 
 /**

--- a/crates/progest-cli/src/commands/ai.rs
+++ b/crates/progest-cli/src/commands/ai.rs
@@ -1,0 +1,138 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use progest_core::ai::{
+    self, AiConfig, AiProvider, PrivacyFlags, SuggestionType, extract_ai_config,
+};
+use progest_core::fs::{ProjectPath, StdFileSystem};
+use progest_core::meta::StdMetaStore;
+use progest_core::project::ProjectDocument;
+
+use crate::context;
+use crate::output::{self, OutputFormat};
+
+pub struct SuggestArgs {
+    pub path: String,
+    pub suggestion_type: SuggestionType,
+    pub include_notes: bool,
+    pub format: OutputFormat,
+}
+
+pub fn run_suggest(cwd: &Path, args: &SuggestArgs) -> Result<i32> {
+    let root = context::discover_root(cwd)?;
+    let index = context::open_index(&root)?;
+    let fs = StdFileSystem::new(root.root().to_path_buf());
+    let meta_store = StdMetaStore::new(fs);
+    let config = load_ai_config(&root)?;
+    let privacy = PrivacyFlags {
+        include_notes: args.include_notes,
+    };
+    let file_path = resolve_path(&root, &args.path)?;
+    let local = root.dot_dir().join("local");
+
+    let response = ai::suggest(
+        &file_path,
+        args.suggestion_type,
+        &privacy,
+        root.root(),
+        &index,
+        &meta_store,
+        &config,
+        &local,
+    )
+    .with_context(|| format!("AI suggest failed for `{}`", args.path))?;
+
+    match args.format {
+        OutputFormat::Json => {
+            output::emit_json(&response, "ai-suggest")?;
+        }
+        OutputFormat::Text => {
+            println!(
+                "{} suggestions for {} ({}ms, {}/{}):",
+                args.suggestion_type,
+                args.path,
+                response.elapsed_ms,
+                response.provider,
+                response.model,
+            );
+            for (i, s) in response.suggestions.iter().enumerate() {
+                print!("  {}. {}", i + 1, s.value);
+                if let Some(expl) = &s.explanation {
+                    print!("  — {expl}");
+                }
+                println!();
+            }
+        }
+    }
+    Ok(0)
+}
+
+pub fn run_set_key(provider: AiProvider, key: &str) -> Result<i32> {
+    ai::store_api_key(provider, key)
+        .with_context(|| format!("failed to store API key for `{provider}`"))?;
+    println!("API key stored for {provider}");
+    Ok(0)
+}
+
+#[derive(serde::Serialize)]
+struct StatusReport {
+    provider: String,
+    model: String,
+    audit_log: bool,
+    has_key: bool,
+    glossary: Vec<String>,
+}
+
+pub fn run_status(cwd: &Path, format: OutputFormat) -> Result<i32> {
+    let root = context::discover_root(cwd)?;
+    let config = load_ai_config(&root)?;
+    let has_key = ai::has_api_key(config.provider);
+
+    let report = StatusReport {
+        provider: config.provider.to_string(),
+        model: config.model.clone(),
+        audit_log: config.audit_log,
+        has_key,
+        glossary: config.glossary.clone(),
+    };
+
+    match format {
+        OutputFormat::Json => output::emit_json(&report, "ai-status")?,
+        OutputFormat::Text => {
+            println!("Provider:  {}", config.provider);
+            println!("Model:     {}", config.model);
+            println!("Audit log: {}", if config.audit_log { "on" } else { "off" });
+            println!("API key:   {}", if has_key { "stored" } else { "not set" });
+            if !config.glossary.is_empty() {
+                println!("Glossary:  {}", config.glossary.join(", "));
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn load_ai_config(root: &progest_core::project::ProjectRoot) -> Result<AiConfig> {
+    let toml_path = root.project_toml();
+    let text = std::fs::read_to_string(&toml_path)
+        .with_context(|| format!("reading {}", toml_path.display()))?;
+    let doc = ProjectDocument::from_toml_str(&text)?;
+    let (config, warnings) = extract_ai_config(&doc.extra)?;
+    for w in &warnings {
+        tracing::warn!("project.toml [ai]: {w:?}");
+    }
+    Ok(config)
+}
+
+fn resolve_path(root: &progest_core::project::ProjectRoot, raw: &str) -> Result<ProjectPath> {
+    let abs = std::path::Path::new(raw);
+    let rel = if abs.is_absolute() {
+        abs.strip_prefix(root.root())
+            .with_context(|| format!("`{raw}` is not inside the project root"))?
+            .to_string_lossy()
+            .to_string()
+    } else {
+        raw.to_string()
+    };
+    ProjectPath::new(&rel).with_context(|| format!("invalid project path `{rel}`"))
+}

--- a/crates/progest-cli/src/commands/mod.rs
+++ b/crates/progest-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@
 //! that [`rename`] also uses since the two subcommands share their
 //! cleanup pipeline knobs.
 
+pub mod ai;
 pub mod clean;
 pub mod delete;
 pub mod doctor;

--- a/crates/progest-cli/src/main.rs
+++ b/crates/progest-cli/src/main.rs
@@ -10,6 +10,7 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
+use commands::ai::SuggestArgs;
 use commands::clean::{CaseFlag, CleanArgs, FillFlag};
 use commands::delete::DeleteArgs;
 use commands::import::ImportArgs;
@@ -193,6 +194,11 @@ enum Command {
         #[command(subcommand)]
         op: ViewOp,
     },
+    /// AI-powered suggestions (naming, tags, notes, placement).
+    Ai {
+        #[command(subcommand)]
+        op: AiOp,
+    },
     /// Manage project templates.
     Template {
         #[command(subcommand)]
@@ -297,6 +303,72 @@ enum ViewOp {
         #[arg(long, default_value = "text", value_enum)]
         format: OutputFormat,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum AiOp {
+    /// Get AI suggestions for a file.
+    Suggest {
+        /// Project-relative or absolute path to the target file.
+        path: String,
+        /// Type of suggestion.
+        #[arg(long = "type", default_value = "naming", value_enum)]
+        suggestion_type: SuggestionTypeCli,
+        /// Include notes body in AI context (opt-in for privacy).
+        #[arg(long)]
+        include_notes: bool,
+        /// Output format.
+        #[arg(long, default_value = "text", value_enum)]
+        format: OutputFormat,
+    },
+    /// Store an API key in the OS keychain.
+    SetKey {
+        /// AI provider (anthropic or openai).
+        #[arg(value_enum)]
+        provider: ProviderCli,
+        /// The API key.
+        key: String,
+    },
+    /// Show current AI configuration and key status.
+    Status {
+        /// Output format.
+        #[arg(long, default_value = "text", value_enum)]
+        format: OutputFormat,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SuggestionTypeCli {
+    Naming,
+    Tags,
+    Notes,
+    Placement,
+}
+
+impl From<SuggestionTypeCli> for progest_core::ai::SuggestionType {
+    fn from(v: SuggestionTypeCli) -> Self {
+        match v {
+            SuggestionTypeCli::Naming => Self::Naming,
+            SuggestionTypeCli::Tags => Self::Tags,
+            SuggestionTypeCli::Notes => Self::Notes,
+            SuggestionTypeCli::Placement => Self::Placement,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ProviderCli {
+    Anthropic,
+    Openai,
+}
+
+impl From<ProviderCli> for progest_core::ai::AiProvider {
+    fn from(v: ProviderCli) -> Self {
+        match v {
+            ProviderCli::Anthropic => Self::Anthropic,
+            ProviderCli::Openai => Self::OpenAi,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -504,6 +576,27 @@ fn main() -> Result<ExitCode> {
                     explain,
                 },
             )?;
+            Ok(to_exit_code(code))
+        }
+        Command::Ai { op } => {
+            let code = match op {
+                AiOp::Suggest {
+                    path,
+                    suggestion_type,
+                    include_notes,
+                    format,
+                } => commands::ai::run_suggest(
+                    &cwd,
+                    &SuggestArgs {
+                        path,
+                        suggestion_type: suggestion_type.into(),
+                        include_notes,
+                        format,
+                    },
+                )?,
+                AiOp::SetKey { provider, key } => commands::ai::run_set_key(provider.into(), &key)?,
+                AiOp::Status { format } => commands::ai::run_status(&cwd, format)?,
+            };
             Ok(to_exit_code(code))
         }
         Command::Template { op } => {

--- a/crates/progest-core/Cargo.toml
+++ b/crates/progest-core/Cargo.toml
@@ -37,6 +37,8 @@ psd.workspace = true
 tempfile.workspace = true
 libheif-rs = { workspace = true, optional = true }
 trash = "5.2.5"
+reqwest = { workspace = true }
+keyring = { workspace = true }
 
 [features]
 heic = ["dep:libheif-rs"]

--- a/crates/progest-core/src/ai/audit.rs
+++ b/crates/progest-core/src/ai/audit.rs
@@ -1,0 +1,105 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::types::{AiError, AiProvider, AiSuggestion, SuggestionType};
+
+#[derive(Debug, Serialize)]
+pub struct AuditEntry {
+    pub timestamp: String,
+    pub suggestion_type: SuggestionType,
+    pub provider: AiProvider,
+    pub model: String,
+    pub file_path: String,
+    pub system_prompt: String,
+    pub user_prompt: String,
+    pub response_text: String,
+    pub suggestions: Vec<AiSuggestion>,
+    pub elapsed_ms: u64,
+    pub error: Option<String>,
+}
+
+const LOG_FILE: &str = "ai-log.jsonl";
+
+/// Append an audit entry to `.progest/local/ai-log.jsonl`.
+///
+/// Best-effort: I/O failures are returned but callers should swallow
+/// them to avoid blocking the suggestion flow.
+pub fn log_entry(local_dir: &Path, entry: &AuditEntry) -> Result<(), AiError> {
+    let path = local_dir.join(LOG_FILE);
+    let line = serde_json::to_string(entry).map_err(|e| AiError::AuditError(e.to_string()))?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| AiError::AuditError(format!("{}: {e}", path.display())))?;
+
+    writeln!(file, "{line}").map_err(|e| AiError::AuditError(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::BufRead;
+
+    use super::*;
+
+    #[test]
+    fn writes_jsonl_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = AuditEntry {
+            timestamp: "2026-05-01T12:00:00Z".into(),
+            suggestion_type: SuggestionType::Naming,
+            provider: AiProvider::Anthropic,
+            model: "claude-sonnet-4-20250514".into(),
+            file_path: "shots/sh010/hero.psd".into(),
+            system_prompt: "You are a naming assistant.".into(),
+            user_prompt: "Suggest a name.".into(),
+            response_text: r#"[{"value":"hero_comp_v01.psd"}]"#.into(),
+            suggestions: vec![AiSuggestion {
+                value: "hero_comp_v01.psd".into(),
+                explanation: None,
+            }],
+            elapsed_ms: 1200,
+            error: None,
+        };
+
+        log_entry(dir.path(), &entry).unwrap();
+        log_entry(dir.path(), &entry).unwrap();
+
+        let file = std::fs::File::open(dir.path().join(LOG_FILE)).unwrap();
+        let lines: Vec<String> = std::io::BufReader::new(file)
+            .lines()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(lines.len(), 2);
+
+        let parsed: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(parsed["file_path"], "shots/sh010/hero.psd");
+        assert_eq!(parsed["elapsed_ms"], 1200);
+        assert_eq!(parsed["suggestions"][0]["value"], "hero_comp_v01.psd");
+    }
+
+    #[test]
+    fn missing_dir_returns_error() {
+        let result = log_entry(
+            Path::new("/nonexistent/path"),
+            &AuditEntry {
+                timestamp: String::new(),
+                suggestion_type: SuggestionType::Tags,
+                provider: AiProvider::OpenAi,
+                model: String::new(),
+                file_path: String::new(),
+                system_prompt: String::new(),
+                user_prompt: String::new(),
+                response_text: String::new(),
+                suggestions: Vec::new(),
+                elapsed_ms: 0,
+                error: None,
+            },
+        );
+        assert!(result.is_err());
+    }
+}

--- a/crates/progest-core/src/ai/context.rs
+++ b/crates/progest-core/src/ai/context.rs
@@ -1,0 +1,327 @@
+use std::path::Path;
+
+use crate::fs::ProjectPath;
+use crate::index::Index;
+use crate::meta::MetaStore;
+
+use super::types::{AiConfig, AiContext, AiError, PrivacyFlags, SuggestionType};
+
+const MAX_SIBLINGS: usize = 30;
+const MAX_TAGS: usize = 100;
+const MAX_DIRS: usize = 50;
+
+/// Gather the context needed for an AI prompt about `file_path`.
+///
+/// Only collects the context relevant for `suggestion_type` to keep
+/// prompt size (and API costs) down.
+pub fn gather_context(
+    file_path: &ProjectPath,
+    suggestion_type: SuggestionType,
+    privacy: &PrivacyFlags,
+    project_root: &Path,
+    index: &dyn Index,
+    meta_store: &dyn MetaStore,
+    config: &AiConfig,
+) -> Result<AiContext, AiError> {
+    let raw = file_path.as_str();
+
+    let file_name = raw
+        .rsplit_once('/')
+        .map_or(raw, |(_, name)| name)
+        .to_string();
+
+    let file_extension = file_name.rsplit_once('.').map(|(_, ext)| ext.to_string());
+
+    let parent_dir = raw.rsplit_once('/').map_or(".", |(dir, _)| dir).to_string();
+
+    let mut ctx = AiContext {
+        file_name,
+        file_extension,
+        parent_dir: parent_dir.clone(),
+        glossary: config.glossary.clone(),
+        ..AiContext::default()
+    };
+
+    // Sibling filenames (naming, notes, tags)
+    if matches!(
+        suggestion_type,
+        SuggestionType::Naming | SuggestionType::Notes | SuggestionType::Tags
+    ) {
+        ctx.sibling_names = collect_siblings(project_root, &parent_dir);
+    }
+
+    // Tags on this file + project vocabulary (tags, notes)
+    if matches!(
+        suggestion_type,
+        SuggestionType::Tags | SuggestionType::Notes | SuggestionType::Naming
+    ) && let Some(row) = index
+        .get_file_by_path(file_path)
+        .map_err(|e| AiError::ContextError(e.to_string()))?
+    {
+        ctx.existing_tags = index.list_tags_for_file(&row.file_id).unwrap_or_default();
+    }
+
+    if matches!(suggestion_type, SuggestionType::Tags) {
+        ctx.project_tag_vocabulary = index
+            .list_all_tags()
+            .unwrap_or_default()
+            .into_iter()
+            .take(MAX_TAGS)
+            .collect();
+    }
+
+    // Notes body — only if privacy permits
+    if matches!(suggestion_type, SuggestionType::Notes) && privacy.include_notes {
+        let sidecar_path = format!("{raw}.meta");
+        if let Ok(sidecar) = ProjectPath::new(&sidecar_path)
+            && let Ok(doc) = meta_store.load(&sidecar)
+        {
+            ctx.notes_body = doc
+                .notes
+                .as_ref()
+                .map(|n| n.body.clone())
+                .filter(|b| !b.is_empty());
+        }
+    }
+
+    // Directory structure + accepts (placement)
+    if matches!(suggestion_type, SuggestionType::Placement) {
+        ctx.project_dirs = collect_project_dirs(project_root);
+        ctx.dir_accepts = collect_dir_accepts(project_root);
+    }
+
+    Ok(ctx)
+}
+
+fn collect_siblings(project_root: &Path, parent_dir: &str) -> Vec<String> {
+    let abs = project_root.join(parent_dir);
+    let Ok(entries) = std::fs::read_dir(abs) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let is_meta = name
+                .rsplit_once('.')
+                .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("meta"));
+            if name.starts_with('.') || is_meta || name == ".dirmeta.toml" {
+                return None;
+            }
+            if e.file_type().ok()?.is_file() {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
+    names.sort();
+    names.truncate(MAX_SIBLINGS);
+    names
+}
+
+fn collect_project_dirs(project_root: &Path) -> Vec<String> {
+    let mut dirs = Vec::new();
+    collect_dirs_recursive(project_root, project_root, &mut dirs, 3);
+    dirs.truncate(MAX_DIRS);
+    dirs
+}
+
+fn collect_dirs_recursive(root: &Path, current: &Path, out: &mut Vec<String>, depth: u8) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') || name == "node_modules" {
+            continue;
+        }
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if let Ok(rel) = path.strip_prefix(root) {
+            out.push(rel.to_string_lossy().into_owned());
+        }
+        collect_dirs_recursive(root, &path, out, depth - 1);
+    }
+}
+
+fn read_accepts_extensions(dirmeta: &Path) -> Option<Vec<String>> {
+    let content = std::fs::read_to_string(dirmeta).ok()?;
+    let table = content.parse::<toml::Table>().ok()?;
+    let accepts = table.get("accepts")?.as_table()?;
+    let exts = accepts.get("extensions")?.as_array()?;
+    let strs: Vec<String> = exts
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    if strs.is_empty() { None } else { Some(strs) }
+}
+
+fn collect_dir_accepts(project_root: &Path) -> Vec<(String, Vec<String>)> {
+    let mut result = Vec::new();
+    collect_accepts_recursive(project_root, project_root, &mut result, 3);
+    result.truncate(MAX_DIRS);
+    result
+}
+
+fn collect_accepts_recursive(
+    root: &Path,
+    current: &Path,
+    out: &mut Vec<(String, Vec<String>)>,
+    depth: u8,
+) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return;
+    };
+
+    let dirmeta = current.join(".dirmeta.toml");
+    if let Some(ext_strs) = read_accepts_extensions(&dirmeta) {
+        let rel = current
+            .strip_prefix(root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        out.push((rel, ext_strs));
+    }
+
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') || name == "node_modules" {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            collect_accepts_recursive(root, &path, out, depth - 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::StdFileSystem;
+    use crate::index::SqliteIndex;
+    use crate::meta::StdMetaStore;
+
+    #[test]
+    fn gather_naming_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Create files
+        std::fs::create_dir_all(root.join("shots/sh010/comp")).unwrap();
+        std::fs::write(root.join("shots/sh010/comp/hero_v01.psd"), b"").unwrap();
+        std::fs::write(root.join("shots/sh010/comp/hero_v02.psd"), b"").unwrap();
+        std::fs::write(root.join("shots/sh010/comp/hero_v03.psd"), b"").unwrap();
+
+        let index = SqliteIndex::open_in_memory().unwrap();
+        let meta_store = StdMetaStore::new(StdFileSystem::new(root.to_path_buf()));
+        let config = AiConfig::default();
+        let privacy = PrivacyFlags::default();
+        let file_path = ProjectPath::new("shots/sh010/comp/hero_v03.psd").unwrap();
+
+        let ctx = gather_context(
+            &file_path,
+            SuggestionType::Naming,
+            &privacy,
+            root,
+            &index,
+            &meta_store,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(ctx.file_name, "hero_v03.psd");
+        assert_eq!(ctx.file_extension.as_deref(), Some("psd"));
+        assert_eq!(ctx.parent_dir, "shots/sh010/comp");
+        assert!(ctx.sibling_names.contains(&"hero_v01.psd".to_string()));
+        assert!(ctx.sibling_names.contains(&"hero_v02.psd".to_string()));
+    }
+
+    #[test]
+    fn placement_collects_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::create_dir_all(root.join("shots/sh010/comp")).unwrap();
+        std::fs::create_dir_all(root.join("shots/sh010/plate")).unwrap();
+        std::fs::create_dir_all(root.join("assets")).unwrap();
+        std::fs::write(root.join("test.psd"), b"").unwrap();
+
+        let index = SqliteIndex::open_in_memory().unwrap();
+        let meta_store = StdMetaStore::new(StdFileSystem::new(root.to_path_buf()));
+        let config = AiConfig::default();
+        let privacy = PrivacyFlags::default();
+        let file_path = ProjectPath::new("test.psd").unwrap();
+
+        let ctx = gather_context(
+            &file_path,
+            SuggestionType::Placement,
+            &privacy,
+            root,
+            &index,
+            &meta_store,
+            &config,
+        )
+        .unwrap();
+
+        assert!(!ctx.project_dirs.is_empty());
+        assert!(ctx.project_dirs.iter().any(|d| d.contains("assets")));
+        // Siblings not collected for placement
+        assert!(ctx.sibling_names.is_empty());
+    }
+
+    #[test]
+    fn notes_excluded_without_privacy_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::write(root.join("test.psd"), b"").unwrap();
+        std::fs::write(
+            root.join("test.psd.meta"),
+            "schema_version = 1\nfile_id = \"01961234-5678-7000-8000-000000000001\"\ncontent_fingerprint = \"blake3:00000000000000000000000000000000\"\n\n[notes]\nbody = \"secret notes\"\n",
+        )
+        .unwrap();
+
+        let index = SqliteIndex::open_in_memory().unwrap();
+        let meta_store = StdMetaStore::new(StdFileSystem::new(root.to_path_buf()));
+        let config = AiConfig::default();
+
+        let privacy_off = PrivacyFlags {
+            include_notes: false,
+        };
+        let ctx = gather_context(
+            &ProjectPath::new("test.psd").unwrap(),
+            SuggestionType::Notes,
+            &privacy_off,
+            root,
+            &index,
+            &meta_store,
+            &config,
+        )
+        .unwrap();
+        assert!(ctx.notes_body.is_none());
+
+        let privacy_on = PrivacyFlags {
+            include_notes: true,
+        };
+        let ctx2 = gather_context(
+            &ProjectPath::new("test.psd").unwrap(),
+            SuggestionType::Notes,
+            &privacy_on,
+            root,
+            &index,
+            &meta_store,
+            &config,
+        )
+        .unwrap();
+        assert_eq!(ctx2.notes_body.as_deref(), Some("secret notes"));
+    }
+}

--- a/crates/progest-core/src/ai/keychain.rs
+++ b/crates/progest-core/src/ai/keychain.rs
@@ -1,0 +1,87 @@
+use super::types::{AiError, AiProvider};
+
+const SERVICE_PREFIX: &str = "progest-ai";
+const USERNAME: &str = "api-key";
+
+fn service_name(provider: AiProvider) -> String {
+    format!("{SERVICE_PREFIX}-{}", provider.as_str())
+}
+
+fn entry(provider: AiProvider) -> Result<keyring::Entry, AiError> {
+    keyring::Entry::new(&service_name(provider), USERNAME)
+        .map_err(|e| AiError::KeychainError(e.to_string()))
+}
+
+/// Store an API key in the OS keychain.
+pub fn store_api_key(provider: AiProvider, key: &str) -> Result<(), AiError> {
+    entry(provider)?
+        .set_password(key)
+        .map_err(|e| AiError::KeychainError(e.to_string()))
+}
+
+/// Retrieve an API key from the OS keychain.
+pub fn get_api_key(provider: AiProvider) -> Result<String, AiError> {
+    entry(provider)?.get_password().map_err(|e| match e {
+        keyring::Error::NoEntry => AiError::NoApiKey {
+            provider: provider.as_str().into(),
+        },
+        other => AiError::KeychainError(other.to_string()),
+    })
+}
+
+/// Delete the stored API key for `provider`.
+pub fn delete_api_key(provider: AiProvider) -> Result<(), AiError> {
+    let ent = entry(provider)?;
+    match ent.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(AiError::KeychainError(e.to_string())),
+    }
+}
+
+/// Check whether a key is stored without retrieving the secret.
+pub fn has_api_key(provider: AiProvider) -> bool {
+    entry(provider)
+        .and_then(|e| {
+            e.get_password()
+                .map_err(|e| AiError::KeychainError(e.to_string()))
+        })
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_name_format() {
+        assert_eq!(service_name(AiProvider::Anthropic), "progest-ai-anthropic");
+        assert_eq!(service_name(AiProvider::OpenAi), "progest-ai-openai");
+    }
+
+    // Real keychain tests are OS-dependent and require user interaction
+    // on some platforms. Run manually with `cargo test -- --ignored`.
+    #[test]
+    #[ignore = "requires OS keychain access"]
+    fn store_get_delete_round_trip() {
+        let provider = AiProvider::Anthropic;
+        let key = "sk-test-12345";
+
+        store_api_key(provider, key).unwrap();
+        assert!(has_api_key(provider));
+
+        let got = get_api_key(provider).unwrap();
+        assert_eq!(got, key);
+
+        delete_api_key(provider).unwrap();
+        assert!(!has_api_key(provider));
+
+        let err = get_api_key(provider).unwrap_err();
+        assert!(matches!(err, AiError::NoApiKey { .. }));
+    }
+
+    #[test]
+    #[ignore = "requires OS keychain access"]
+    fn delete_nonexistent_is_ok() {
+        delete_api_key(AiProvider::OpenAi).unwrap();
+    }
+}

--- a/crates/progest-core/src/ai/loader.rs
+++ b/crates/progest-core/src/ai/loader.rs
@@ -172,10 +172,10 @@ provider = "gemini"
     #[test]
     fn wrong_type_is_error() {
         let t = table(
-            r#"
+            r"
 [ai]
 provider = 42
-"#,
+",
         );
         let err = extract_ai_config(&t).unwrap_err();
         assert!(matches!(err, AiConfigError::WrongType { key, .. } if key == "provider"));
@@ -197,10 +197,10 @@ model = "custom-model"
     #[test]
     fn glossary_wrong_element_type() {
         let t = table(
-            r#"
+            r"
 [ai]
 glossary = [1, 2, 3]
-"#,
+",
         );
         let err = extract_ai_config(&t).unwrap_err();
         assert!(matches!(err, AiConfigError::WrongType { key, .. } if key == "glossary"));

--- a/crates/progest-core/src/ai/loader.rs
+++ b/crates/progest-core/src/ai/loader.rs
@@ -1,0 +1,220 @@
+use toml::{Table, Value};
+
+use super::types::{AiConfig, AiProvider};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AiConfigWarning {
+    UnknownKey(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AiConfigError {
+    #[error("invalid provider `{0}`: expected \"anthropic\" or \"openai\"")]
+    InvalidProvider(String),
+
+    #[error("wrong type for key `{key}`: expected {expected}")]
+    WrongType { key: String, expected: String },
+}
+
+const KNOWN_KEYS: &[&str] = &["provider", "model", "audit_log", "glossary"];
+
+/// Parse `[ai]` from [`ProjectDocument::extra`].
+///
+/// Returns `Ok((default, []))` when the section is absent.
+pub fn extract_ai_config(extra: &Table) -> Result<(AiConfig, Vec<AiConfigWarning>), AiConfigError> {
+    let Some(Value::Table(ai)) = extra.get("ai") else {
+        return Ok((AiConfig::default(), Vec::new()));
+    };
+
+    let mut warnings = Vec::new();
+
+    for key in ai.keys() {
+        if !KNOWN_KEYS.contains(&key.as_str()) {
+            warnings.push(AiConfigWarning::UnknownKey(key.clone()));
+        }
+    }
+
+    let provider = match ai.get("provider") {
+        Some(Value::String(s)) => match s.as_str() {
+            "anthropic" => AiProvider::Anthropic,
+            "openai" => AiProvider::OpenAi,
+            other => return Err(AiConfigError::InvalidProvider(other.to_string())),
+        },
+        Some(_) => {
+            return Err(AiConfigError::WrongType {
+                key: "provider".into(),
+                expected: "string".into(),
+            });
+        }
+        None => AiProvider::Anthropic,
+    };
+
+    let model = match ai.get("model") {
+        Some(Value::String(s)) => s.clone(),
+        Some(_) => {
+            return Err(AiConfigError::WrongType {
+                key: "model".into(),
+                expected: "string".into(),
+            });
+        }
+        None => provider.default_model().to_string(),
+    };
+
+    let audit_log = match ai.get("audit_log") {
+        Some(Value::Boolean(b)) => *b,
+        Some(_) => {
+            return Err(AiConfigError::WrongType {
+                key: "audit_log".into(),
+                expected: "boolean".into(),
+            });
+        }
+        None => true,
+    };
+
+    let glossary = match ai.get("glossary") {
+        Some(Value::Array(arr)) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::String(s) => out.push(s.clone()),
+                    _ => {
+                        return Err(AiConfigError::WrongType {
+                            key: "glossary".into(),
+                            expected: "array of strings".into(),
+                        });
+                    }
+                }
+            }
+            out
+        }
+        Some(_) => {
+            return Err(AiConfigError::WrongType {
+                key: "glossary".into(),
+                expected: "array of strings".into(),
+            });
+        }
+        None => Vec::new(),
+    };
+
+    Ok((
+        AiConfig {
+            provider,
+            model,
+            audit_log,
+            glossary,
+        },
+        warnings,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(toml_str: &str) -> Table {
+        toml_str.parse::<Table>().unwrap()
+    }
+
+    #[test]
+    fn absent_section_returns_defaults() {
+        let (cfg, warns) = extract_ai_config(&Table::new()).unwrap();
+        assert_eq!(cfg, AiConfig::default());
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn full_section_round_trips() {
+        let t = table(
+            r#"
+[ai]
+provider = "openai"
+model = "gpt-4.1"
+audit_log = false
+glossary = ["VFX", "comp"]
+"#,
+        );
+        let (cfg, warns) = extract_ai_config(&t).unwrap();
+        assert!(warns.is_empty());
+        assert_eq!(cfg.provider, AiProvider::OpenAi);
+        assert_eq!(cfg.model, "gpt-4.1");
+        assert!(!cfg.audit_log);
+        assert_eq!(cfg.glossary, vec!["VFX", "comp"]);
+    }
+
+    #[test]
+    fn unknown_keys_produce_warnings() {
+        let t = table(
+            r#"
+[ai]
+provider = "anthropic"
+future_field = 42
+"#,
+        );
+        let (_, warns) = extract_ai_config(&t).unwrap();
+        assert_eq!(
+            warns,
+            vec![AiConfigWarning::UnknownKey("future_field".into())]
+        );
+    }
+
+    #[test]
+    fn invalid_provider_is_error() {
+        let t = table(
+            r#"
+[ai]
+provider = "gemini"
+"#,
+        );
+        let err = extract_ai_config(&t).unwrap_err();
+        assert!(matches!(err, AiConfigError::InvalidProvider(s) if s == "gemini"));
+    }
+
+    #[test]
+    fn wrong_type_is_error() {
+        let t = table(
+            r#"
+[ai]
+provider = 42
+"#,
+        );
+        let err = extract_ai_config(&t).unwrap_err();
+        assert!(matches!(err, AiConfigError::WrongType { key, .. } if key == "provider"));
+    }
+
+    #[test]
+    fn missing_provider_defaults_to_anthropic() {
+        let t = table(
+            r#"
+[ai]
+model = "custom-model"
+"#,
+        );
+        let (cfg, _) = extract_ai_config(&t).unwrap();
+        assert_eq!(cfg.provider, AiProvider::Anthropic);
+        assert_eq!(cfg.model, "custom-model");
+    }
+
+    #[test]
+    fn glossary_wrong_element_type() {
+        let t = table(
+            r#"
+[ai]
+glossary = [1, 2, 3]
+"#,
+        );
+        let err = extract_ai_config(&t).unwrap_err();
+        assert!(matches!(err, AiConfigError::WrongType { key, .. } if key == "glossary"));
+    }
+
+    #[test]
+    fn audit_log_wrong_type() {
+        let t = table(
+            r#"
+[ai]
+audit_log = "yes"
+"#,
+        );
+        let err = extract_ai_config(&t).unwrap_err();
+        assert!(matches!(err, AiConfigError::WrongType { key, .. } if key == "audit_log"));
+    }
+}

--- a/crates/progest-core/src/ai/mod.rs
+++ b/crates/progest-core/src/ai/mod.rs
@@ -1,0 +1,7 @@
+pub mod keychain;
+pub mod loader;
+pub mod types;
+
+pub use keychain::{delete_api_key, get_api_key, has_api_key, store_api_key};
+pub use loader::{AiConfigError, AiConfigWarning, extract_ai_config};
+pub use types::*;

--- a/crates/progest-core/src/ai/mod.rs
+++ b/crates/progest-core/src/ai/mod.rs
@@ -1,5 +1,6 @@
 pub mod keychain;
 pub mod loader;
+pub mod provider;
 pub mod types;
 
 pub use keychain::{delete_api_key, get_api_key, has_api_key, store_api_key};

--- a/crates/progest-core/src/ai/mod.rs
+++ b/crates/progest-core/src/ai/mod.rs
@@ -1,5 +1,8 @@
+pub mod audit;
+pub mod context;
 pub mod keychain;
 pub mod loader;
+pub mod prompt;
 pub mod provider;
 pub mod types;
 

--- a/crates/progest-core/src/ai/mod.rs
+++ b/crates/progest-core/src/ai/mod.rs
@@ -6,6 +6,272 @@ pub mod prompt;
 pub mod provider;
 pub mod types;
 
+use std::path::Path;
+
+use crate::fs::ProjectPath;
+use crate::index::Index;
+use crate::meta::MetaStore;
+
 pub use keychain::{delete_api_key, get_api_key, has_api_key, store_api_key};
 pub use loader::{AiConfigError, AiConfigWarning, extract_ai_config};
 pub use types::*;
+
+/// Main entry point for AI suggestions.
+///
+/// Fetches the API key from the OS keychain, gathers context, builds
+/// prompts, calls the provider, parses the response, and writes an
+/// audit log entry.
+#[allow(clippy::too_many_arguments)]
+pub fn suggest(
+    file_path: &ProjectPath,
+    suggestion_type: SuggestionType,
+    privacy: &PrivacyFlags,
+    project_root: &Path,
+    index: &dyn Index,
+    meta_store: &dyn MetaStore,
+    config: &AiConfig,
+    local_dir: &Path,
+) -> Result<AiResponse, AiError> {
+    let api_key = keychain::get_api_key(config.provider)?;
+    let provider_impl: Box<dyn provider::Provider> = match config.provider {
+        AiProvider::Anthropic => Box::new(provider::AnthropicProvider::new(api_key, None)),
+        AiProvider::OpenAi => Box::new(provider::OpenAiProvider::new(api_key, None)),
+    };
+    run_suggest(
+        file_path,
+        suggestion_type,
+        privacy,
+        project_root,
+        index,
+        meta_store,
+        config,
+        local_dir,
+        &*provider_impl,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_suggest(
+    file_path: &ProjectPath,
+    suggestion_type: SuggestionType,
+    privacy: &PrivacyFlags,
+    project_root: &Path,
+    index: &dyn Index,
+    meta_store: &dyn MetaStore,
+    config: &AiConfig,
+    local_dir: &Path,
+    provider_impl: &dyn provider::Provider,
+) -> Result<AiResponse, AiError> {
+    let ctx = context::gather_context(
+        file_path,
+        suggestion_type,
+        privacy,
+        project_root,
+        index,
+        meta_store,
+        config,
+    )?;
+
+    let (system_prompt, user_prompt) = prompt::build_prompt(suggestion_type, &ctx);
+
+    let start = std::time::Instant::now();
+    let raw_result = provider_impl.send(&config.model, &system_prompt, &user_prompt);
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    let response = match &raw_result {
+        Ok(resp) => {
+            let suggestions = parse_suggestions(&resp.content)?;
+            Ok(AiResponse {
+                suggestion_type,
+                suggestions,
+                model: resp.model.clone(),
+                provider: config.provider,
+                elapsed_ms,
+            })
+        }
+        Err(e) => Err(AiError::HttpError(e.to_string())),
+    };
+
+    if config.audit_log {
+        let entry = audit::AuditEntry {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            suggestion_type,
+            provider: config.provider,
+            model: config.model.clone(),
+            file_path: file_path.as_str().to_string(),
+            system_prompt,
+            user_prompt,
+            response_text: raw_result
+                .as_ref()
+                .map_or_else(ToString::to_string, |r| r.content.clone()),
+            suggestions: response
+                .as_ref()
+                .map_or_else(|_| Vec::new(), |r| r.suggestions.clone()),
+            elapsed_ms,
+            error: response.as_ref().err().map(ToString::to_string),
+        };
+        if let Err(e) = audit::log_entry(local_dir, &entry) {
+            tracing::warn!("AI audit log write failed: {e}");
+        }
+    }
+
+    response
+}
+
+/// Parse the AI's text response into structured suggestions.
+///
+/// Handles:
+/// - Bare JSON array
+/// - Array wrapped in markdown code fences
+/// - JSON object with a `"suggestions"` key
+#[derive(serde::Deserialize)]
+struct SuggestionsWrapper {
+    suggestions: Vec<AiSuggestion>,
+}
+
+fn parse_suggestions(raw: &str) -> Result<Vec<AiSuggestion>, AiError> {
+    let trimmed = strip_code_fences(raw.trim());
+
+    if let Ok(arr) = serde_json::from_str::<Vec<AiSuggestion>>(trimmed) {
+        return Ok(arr);
+    }
+
+    if let Ok(wrapper) = serde_json::from_str::<SuggestionsWrapper>(trimmed) {
+        return Ok(wrapper.suggestions);
+    }
+
+    Err(AiError::ParseError(format!(
+        "could not parse AI response as JSON suggestions: {trimmed}"
+    )))
+}
+
+fn strip_code_fences(s: &str) -> &str {
+    let s = s
+        .strip_prefix("```json")
+        .or_else(|| s.strip_prefix("```"))
+        .unwrap_or(s);
+    s.strip_suffix("```").unwrap_or(s).trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::StdFileSystem;
+    use crate::index::SqliteIndex;
+    use crate::meta::StdMetaStore;
+    use provider::{MockProvider, ProviderResponse};
+
+    #[test]
+    fn parse_bare_json_array() {
+        let raw = r#"[{"value": "hero_comp_v01.psd", "explanation": "follows convention"}]"#;
+        let suggestions = parse_suggestions(raw).unwrap();
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].value, "hero_comp_v01.psd");
+    }
+
+    #[test]
+    fn parse_fenced_json() {
+        let raw = "```json\n[{\"value\": \"test.psd\"}]\n```";
+        let suggestions = parse_suggestions(raw).unwrap();
+        assert_eq!(suggestions.len(), 1);
+    }
+
+    #[test]
+    fn parse_wrapper_object() {
+        let raw = r#"{"suggestions": [{"value": "a.psd"}, {"value": "b.psd"}]}"#;
+        let suggestions = parse_suggestions(raw).unwrap();
+        assert_eq!(suggestions.len(), 2);
+    }
+
+    #[test]
+    fn parse_garbage_returns_error() {
+        let result = parse_suggestions("this is not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn suggest_with_mock_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let local = root.join(".progest/local");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::write(root.join("test.psd"), b"").unwrap();
+
+        let index = SqliteIndex::open_in_memory().unwrap();
+        let meta_store = StdMetaStore::new(StdFileSystem::new(root.to_path_buf()));
+        let config = AiConfig::default();
+        let privacy = PrivacyFlags::default();
+        let file_path = ProjectPath::new("test.psd").unwrap();
+
+        let mock = MockProvider {
+            response: Ok(ProviderResponse {
+                content: r#"[{"value": "test_renamed.psd", "explanation": "better name"}]"#.into(),
+                model: "mock-v1".into(),
+            }),
+        };
+
+        let response = run_suggest(
+            &file_path,
+            SuggestionType::Naming,
+            &privacy,
+            root,
+            &index,
+            &meta_store,
+            &config,
+            &local,
+            &mock,
+        )
+        .unwrap();
+
+        assert_eq!(response.suggestions.len(), 1);
+        assert_eq!(response.suggestions[0].value, "test_renamed.psd");
+        assert_eq!(response.provider, AiProvider::Anthropic);
+
+        // Verify audit log was written
+        let log_path = local.join("ai-log.jsonl");
+        assert!(log_path.exists());
+        let content = std::fs::read_to_string(log_path).unwrap();
+        assert!(content.contains("test_renamed.psd"));
+    }
+
+    #[test]
+    fn suggest_with_provider_error_writes_audit() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let local = root.join(".progest/local");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::write(root.join("test.psd"), b"").unwrap();
+
+        let index = SqliteIndex::open_in_memory().unwrap();
+        let meta_store = StdMetaStore::new(StdFileSystem::new(root.to_path_buf()));
+        let config = AiConfig::default();
+        let privacy = PrivacyFlags::default();
+        let file_path = ProjectPath::new("test.psd").unwrap();
+
+        let mock = MockProvider {
+            response: Err(AiError::ApiError {
+                status: 429,
+                body: "rate limited".into(),
+            }),
+        };
+
+        let result = run_suggest(
+            &file_path,
+            SuggestionType::Tags,
+            &privacy,
+            root,
+            &index,
+            &meta_store,
+            &config,
+            &local,
+            &mock,
+        );
+
+        assert!(result.is_err());
+
+        let log_path = local.join("ai-log.jsonl");
+        assert!(log_path.exists());
+        let content = std::fs::read_to_string(log_path).unwrap();
+        assert!(content.contains("\"error\""));
+    }
+}

--- a/crates/progest-core/src/ai/prompt.rs
+++ b/crates/progest-core/src/ai/prompt.rs
@@ -1,0 +1,255 @@
+use std::fmt::Write;
+
+use super::types::{AiContext, SuggestionType};
+
+const MAX_SIBLINGS: usize = 30;
+const MAX_RULES: usize = 10;
+const MAX_TAGS: usize = 100;
+const MAX_DIRS: usize = 50;
+
+pub fn build_prompt(suggestion_type: SuggestionType, ctx: &AiContext) -> (String, String) {
+    match suggestion_type {
+        SuggestionType::Naming => build_naming(ctx),
+        SuggestionType::Tags => build_tags(ctx),
+        SuggestionType::Notes => build_notes(ctx),
+        SuggestionType::Placement => build_placement(ctx),
+    }
+}
+
+fn build_naming(ctx: &AiContext) -> (String, String) {
+    let system = "\
+You are a file naming assistant for creative pipeline projects (VFX, games, 3DCG). \
+Suggest clean filenames that follow the project's naming conventions. \
+Respond ONLY with a JSON array. Each element must have a \"value\" (the suggested filename \
+including extension) and an optional \"explanation\". Return 1-3 suggestions.";
+
+    let mut user = String::new();
+    let _ = writeln!(user, "Current filename: {}", ctx.file_name);
+    let _ = writeln!(user, "Parent directory: {}", ctx.parent_dir);
+    if let Some(ext) = &ctx.file_extension {
+        let _ = writeln!(user, "Extension: .{ext}");
+    }
+    append_rules(&mut user, ctx);
+    append_siblings(&mut user, ctx);
+    append_glossary(&mut user, ctx);
+    user.push_str("\nSuggest improved filenames that follow the naming conventions above.");
+    (system.to_string(), user)
+}
+
+fn build_tags(ctx: &AiContext) -> (String, String) {
+    let system = "\
+You are a tagging assistant for creative pipeline projects. \
+Suggest relevant tags based on the file context and the project's existing tag vocabulary. \
+Tags must match the pattern [a-zA-Z0-9_-]+. \
+Respond ONLY with a JSON array. Each element must have a \"value\" (the tag) and an optional \
+\"explanation\". Return 3-5 suggestions.";
+
+    let mut user = String::new();
+    let _ = writeln!(user, "Filename: {}", ctx.file_name);
+    let _ = writeln!(user, "Parent directory: {}", ctx.parent_dir);
+    if let Some(ext) = &ctx.file_extension {
+        let _ = writeln!(user, "Extension: .{ext}");
+    }
+    if !ctx.existing_tags.is_empty() {
+        let _ = writeln!(
+            user,
+            "Existing tags on this file: {}",
+            ctx.existing_tags.join(", ")
+        );
+    }
+    if !ctx.project_tag_vocabulary.is_empty() {
+        let tags: Vec<&str> = ctx
+            .project_tag_vocabulary
+            .iter()
+            .take(MAX_TAGS)
+            .map(String::as_str)
+            .collect();
+        let _ = writeln!(
+            user,
+            "Project tag vocabulary (prefer reusing these): {}",
+            tags.join(", ")
+        );
+    }
+    append_glossary(&mut user, ctx);
+    user.push_str("\nSuggest tags for this file. Avoid duplicating existing tags.");
+    (system.to_string(), user)
+}
+
+fn build_notes(ctx: &AiContext) -> (String, String) {
+    let system = "\
+You are a documentation assistant for creative pipeline projects. \
+Generate a concise descriptive note for the given file. \
+Respond ONLY with a JSON array with a single element containing \"value\" (the note text) \
+and an optional \"explanation\".";
+
+    let mut user = String::new();
+    let _ = writeln!(user, "Filename: {}", ctx.file_name);
+    let _ = writeln!(user, "Parent directory: {}", ctx.parent_dir);
+    if let Some(ext) = &ctx.file_extension {
+        let _ = writeln!(user, "Extension: .{ext}");
+    }
+    if !ctx.existing_tags.is_empty() {
+        let _ = writeln!(user, "Tags: {}", ctx.existing_tags.join(", "));
+    }
+    if let Some(notes) = &ctx.notes_body {
+        let _ = writeln!(user, "Existing notes (update or enhance):\n{notes}");
+    }
+    append_siblings(&mut user, ctx);
+    append_rules(&mut user, ctx);
+    append_glossary(&mut user, ctx);
+    user.push_str("\nWrite a concise note describing this file's purpose and content.");
+    (system.to_string(), user)
+}
+
+fn build_placement(ctx: &AiContext) -> (String, String) {
+    let system = "\
+You are a file organization assistant for creative pipeline projects. \
+Suggest the best directory for this file based on the project structure and \
+directory accept rules. \
+Respond ONLY with a JSON array. Each element must have a \"value\" (the directory path) \
+and an optional \"explanation\". Return 1-3 suggestions.";
+
+    let mut user = String::new();
+    let _ = writeln!(user, "Filename: {}", ctx.file_name);
+    let _ = writeln!(user, "Current location: {}", ctx.parent_dir);
+    if let Some(ext) = &ctx.file_extension {
+        let _ = writeln!(user, "Extension: .{ext}");
+    }
+    if !ctx.project_dirs.is_empty() {
+        let dirs: Vec<&str> = ctx
+            .project_dirs
+            .iter()
+            .take(MAX_DIRS)
+            .map(String::as_str)
+            .collect();
+        let _ = writeln!(user, "Project directories:\n{}", dirs.join("\n"));
+    }
+    if !ctx.dir_accepts.is_empty() {
+        user.push_str("Directory accept rules:\n");
+        for (dir, exts) in ctx.dir_accepts.iter().take(MAX_DIRS) {
+            let _ = writeln!(user, "  {dir}: {}", exts.join(", "));
+        }
+    }
+    append_glossary(&mut user, ctx);
+    user.push_str("\nSuggest the best directory for this file.");
+    (system.to_string(), user)
+}
+
+fn append_rules(out: &mut String, ctx: &AiContext) {
+    if ctx.rule_summaries.is_empty() {
+        return;
+    }
+    out.push_str("Naming rules:\n");
+    for rule in ctx.rule_summaries.iter().take(MAX_RULES) {
+        let _ = writeln!(out, "  - {rule}");
+    }
+}
+
+fn append_siblings(out: &mut String, ctx: &AiContext) {
+    if ctx.sibling_names.is_empty() {
+        return;
+    }
+    let siblings: Vec<&str> = ctx
+        .sibling_names
+        .iter()
+        .take(MAX_SIBLINGS)
+        .map(String::as_str)
+        .collect();
+    let _ = writeln!(out, "Sibling files: {}", siblings.join(", "));
+}
+
+fn append_glossary(out: &mut String, ctx: &AiContext) {
+    if ctx.glossary.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "Project glossary: {}", ctx.glossary.join(", "));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_context() -> AiContext {
+        AiContext {
+            file_name: "hero_comp_v03.psd".into(),
+            file_extension: Some("psd".into()),
+            parent_dir: "shots/sh010/comp".into(),
+            sibling_names: vec!["hero_comp_v01.psd".into(), "hero_comp_v02.psd".into()],
+            existing_tags: vec!["wip".into(), "comp".into()],
+            project_tag_vocabulary: vec![
+                "wip".into(),
+                "review".into(),
+                "final".into(),
+                "comp".into(),
+            ],
+            notes_body: None,
+            rule_summaries: vec![
+                "rule_shot: template={shot}_{task}_v{ver}, applies_to=*.psd".into(),
+            ],
+            project_dirs: vec!["shots/sh010/comp".into(), "shots/sh010/plate".into()],
+            dir_accepts: vec![
+                (
+                    "shots/sh010/comp".into(),
+                    vec![".psd".into(), ".exr".into()],
+                ),
+                ("shots/sh010/plate".into(), vec![".exr".into()]),
+            ],
+            glossary: vec!["VFX".into(), "comp".into()],
+        }
+    }
+
+    #[test]
+    fn naming_prompt_includes_context() {
+        let ctx = sample_context();
+        let (sys, user) = build_prompt(SuggestionType::Naming, &ctx);
+        assert!(sys.contains("naming assistant"));
+        assert!(sys.contains("JSON array"));
+        assert!(user.contains("hero_comp_v03.psd"));
+        assert!(user.contains("shots/sh010/comp"));
+        assert!(user.contains("rule_shot"));
+        assert!(user.contains("hero_comp_v01.psd"));
+        assert!(user.contains("VFX"));
+    }
+
+    #[test]
+    fn tags_prompt_includes_vocabulary() {
+        let ctx = sample_context();
+        let (sys, user) = build_prompt(SuggestionType::Tags, &ctx);
+        assert!(sys.contains("tagging assistant"));
+        assert!(user.contains("wip, comp"));
+        assert!(user.contains("review"));
+    }
+
+    #[test]
+    fn notes_prompt_excludes_notes_when_none() {
+        let ctx = sample_context();
+        let (_, user) = build_prompt(SuggestionType::Notes, &ctx);
+        assert!(!user.contains("Existing notes"));
+    }
+
+    #[test]
+    fn notes_prompt_includes_notes_when_present() {
+        let mut ctx = sample_context();
+        ctx.notes_body = Some("Hero composite for shot 10.".into());
+        let (_, user) = build_prompt(SuggestionType::Notes, &ctx);
+        assert!(user.contains("Hero composite for shot 10."));
+    }
+
+    #[test]
+    fn placement_prompt_includes_dir_structure() {
+        let ctx = sample_context();
+        let (sys, user) = build_prompt(SuggestionType::Placement, &ctx);
+        assert!(sys.contains("organization assistant"));
+        assert!(user.contains("shots/sh010/comp"));
+        assert!(user.contains(".psd, .exr"));
+    }
+
+    #[test]
+    fn truncation_respects_limits() {
+        let mut ctx = sample_context();
+        ctx.sibling_names = (0..50).map(|i| format!("file_{i:03}.psd")).collect();
+        let (_, user) = build_prompt(SuggestionType::Naming, &ctx);
+        let count = user.matches("file_").count();
+        assert!(count <= MAX_SIBLINGS);
+    }
+}

--- a/crates/progest-core/src/ai/provider.rs
+++ b/crates/progest-core/src/ai/provider.rs
@@ -1,0 +1,372 @@
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+
+use super::types::AiError;
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+// ── Trait ────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct ProviderResponse {
+    pub content: String,
+    pub model: String,
+}
+
+pub trait Provider: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn send(
+        &self,
+        model: &str,
+        system_prompt: &str,
+        user_prompt: &str,
+    ) -> Result<ProviderResponse, AiError>;
+}
+
+// ── Anthropic ───────────────────────────────────────────────────────
+
+const ANTHROPIC_BASE: &str = "https://api.anthropic.com";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+
+pub struct AnthropicProvider {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl AnthropicProvider {
+    /// # Panics
+    ///
+    /// Panics if the TLS backend fails to initialize (should not happen
+    /// in normal operation).
+    pub fn new(api_key: String, base_url: Option<String>) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(TIMEOUT)
+                .build()
+                .expect("TLS backend init failed"),
+            api_key,
+            base_url: base_url.unwrap_or_else(|| ANTHROPIC_BASE.to_string()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct AnthropicRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    system: &'a str,
+    messages: Vec<AnthropicMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicContentBlock>,
+    model: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicContentBlock {
+    text: String,
+}
+
+impl Provider for AnthropicProvider {
+    fn name(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn send(
+        &self,
+        model: &str,
+        system_prompt: &str,
+        user_prompt: &str,
+    ) -> Result<ProviderResponse, AiError> {
+        let body = AnthropicRequest {
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            system: system_prompt,
+            messages: vec![AnthropicMessage {
+                role: "user",
+                content: user_prompt,
+            }],
+        };
+
+        let url = format!("{}/v1/messages", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .map_err(|e| AiError::HttpError(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body = resp.text().unwrap_or_default();
+            return Err(AiError::ApiError { status, body });
+        }
+
+        let parsed: AnthropicResponse = resp
+            .json()
+            .map_err(|e| AiError::ParseError(format!("Anthropic response: {e}")))?;
+
+        let text: String = parsed.content.into_iter().map(|b| b.text).collect();
+
+        Ok(ProviderResponse {
+            content: text,
+            model: parsed.model,
+        })
+    }
+}
+
+// ── OpenAI ──────────────────────────────────────────────────────────
+
+const OPENAI_BASE: &str = "https://api.openai.com";
+
+pub struct OpenAiProvider {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OpenAiProvider {
+    /// # Panics
+    ///
+    /// Panics if the TLS backend fails to initialize (should not happen
+    /// in normal operation).
+    pub fn new(api_key: String, base_url: Option<String>) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(TIMEOUT)
+                .build()
+                .expect("TLS backend init failed"),
+            api_key,
+            base_url: base_url.unwrap_or_else(|| OPENAI_BASE.to_string()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<OpenAiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    choices: Vec<OpenAiChoice>,
+    model: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiMessageContent,
+}
+
+#[derive(Deserialize)]
+struct OpenAiMessageContent {
+    content: String,
+}
+
+impl Provider for OpenAiProvider {
+    fn name(&self) -> &'static str {
+        "openai"
+    }
+
+    fn send(
+        &self,
+        model: &str,
+        system_prompt: &str,
+        user_prompt: &str,
+    ) -> Result<ProviderResponse, AiError> {
+        let body = OpenAiRequest {
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            messages: vec![
+                OpenAiMessage {
+                    role: "system",
+                    content: system_prompt,
+                },
+                OpenAiMessage {
+                    role: "user",
+                    content: user_prompt,
+                },
+            ],
+        };
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .map_err(|e| AiError::HttpError(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body = resp.text().unwrap_or_default();
+            return Err(AiError::ApiError { status, body });
+        }
+
+        let parsed: OpenAiResponse = resp
+            .json()
+            .map_err(|e| AiError::ParseError(format!("OpenAI response: {e}")))?;
+
+        let text = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .unwrap_or_default();
+
+        Ok(ProviderResponse {
+            content: text,
+            model: parsed.model,
+        })
+    }
+}
+
+// ── Mock (test) ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub struct MockProvider {
+    pub response: Result<ProviderResponse, AiError>,
+}
+
+#[cfg(test)]
+impl Provider for MockProvider {
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+
+    fn send(
+        &self,
+        _model: &str,
+        _system_prompt: &str,
+        _user_prompt: &str,
+    ) -> Result<ProviderResponse, AiError> {
+        match &self.response {
+            Ok(r) => Ok(ProviderResponse {
+                content: r.content.clone(),
+                model: r.model.clone(),
+            }),
+            Err(e) => Err(AiError::HttpError(format!("{e}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_request_body_structure() {
+        let body = AnthropicRequest {
+            model: "claude-sonnet-4-20250514",
+            max_tokens: 1024,
+            system: "You are a helper.",
+            messages: vec![AnthropicMessage {
+                role: "user",
+                content: "Hello",
+            }],
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["model"], "claude-sonnet-4-20250514");
+        assert_eq!(json["max_tokens"], 1024);
+        assert_eq!(json["system"], "You are a helper.");
+        assert_eq!(json["messages"][0]["role"], "user");
+        assert_eq!(json["messages"][0]["content"], "Hello");
+    }
+
+    #[test]
+    fn openai_request_body_structure() {
+        let body = OpenAiRequest {
+            model: "gpt-4.1-mini",
+            max_tokens: 1024,
+            messages: vec![
+                OpenAiMessage {
+                    role: "system",
+                    content: "You are a helper.",
+                },
+                OpenAiMessage {
+                    role: "user",
+                    content: "Hello",
+                },
+            ],
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["model"], "gpt-4.1-mini");
+        assert_eq!(json["messages"].as_array().unwrap().len(), 2);
+        assert_eq!(json["messages"][0]["role"], "system");
+        assert_eq!(json["messages"][1]["role"], "user");
+    }
+
+    #[test]
+    fn anthropic_response_parsing() {
+        let raw = r#"{
+            "content": [{"type": "text", "text": "[{\"value\": \"test.psd\"}]"}],
+            "model": "claude-sonnet-4-20250514",
+            "role": "assistant"
+        }"#;
+        let parsed: AnthropicResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.content.len(), 1);
+        assert!(parsed.content[0].text.contains("test.psd"));
+        assert_eq!(parsed.model, "claude-sonnet-4-20250514");
+    }
+
+    #[test]
+    fn openai_response_parsing() {
+        let raw = r#"{
+            "choices": [{
+                "message": {"role": "assistant", "content": "[{\"value\": \"test.psd\"}]"},
+                "finish_reason": "stop"
+            }],
+            "model": "gpt-4.1-mini"
+        }"#;
+        let parsed: OpenAiResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.choices.len(), 1);
+        assert!(parsed.choices[0].message.content.contains("test.psd"));
+        assert_eq!(parsed.model, "gpt-4.1-mini");
+    }
+
+    #[test]
+    fn mock_provider_returns_canned_response() {
+        let mock = MockProvider {
+            response: Ok(ProviderResponse {
+                content: r#"[{"value":"foo.psd"}]"#.into(),
+                model: "mock-v1".into(),
+            }),
+        };
+        let resp = mock.send("m", "sys", "user").unwrap();
+        assert_eq!(resp.content, r#"[{"value":"foo.psd"}]"#);
+    }
+
+    #[test]
+    fn mock_provider_returns_error() {
+        let mock = MockProvider {
+            response: Err(AiError::HttpError("timeout".into())),
+        };
+        let err = mock.send("m", "sys", "user").unwrap_err();
+        assert!(matches!(err, AiError::HttpError(_)));
+    }
+}

--- a/crates/progest-core/src/ai/types.rs
+++ b/crates/progest-core/src/ai/types.rs
@@ -1,0 +1,233 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ── Provider ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AiProvider {
+    Anthropic,
+    #[serde(alias = "openai")]
+    OpenAi,
+}
+
+impl AiProvider {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+        }
+    }
+
+    #[must_use]
+    pub fn default_model(self) -> &'static str {
+        match self {
+            Self::Anthropic => "claude-sonnet-4-20250514",
+            Self::OpenAi => "gpt-4.1-mini",
+        }
+    }
+}
+
+impl fmt::Display for AiProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ── Config ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AiConfig {
+    pub provider: AiProvider,
+    pub model: String,
+    pub audit_log: bool,
+    pub glossary: Vec<String>,
+}
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        let provider = AiProvider::Anthropic;
+        Self {
+            model: provider.default_model().to_string(),
+            provider,
+            audit_log: true,
+            glossary: Vec::new(),
+        }
+    }
+}
+
+// ── Suggestion type ─────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SuggestionType {
+    Naming,
+    Tags,
+    Notes,
+    Placement,
+}
+
+impl fmt::Display for SuggestionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Naming => f.write_str("naming"),
+            Self::Tags => f.write_str("tags"),
+            Self::Notes => f.write_str("notes"),
+            Self::Placement => f.write_str("placement"),
+        }
+    }
+}
+
+// ── Privacy flags ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub struct PrivacyFlags {
+    pub include_notes: bool,
+}
+
+// ── Context ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub struct AiContext {
+    pub file_name: String,
+    pub file_extension: Option<String>,
+    pub parent_dir: String,
+    pub sibling_names: Vec<String>,
+    pub existing_tags: Vec<String>,
+    pub project_tag_vocabulary: Vec<String>,
+    pub notes_body: Option<String>,
+    pub rule_summaries: Vec<String>,
+    pub project_dirs: Vec<String>,
+    pub dir_accepts: Vec<(String, Vec<String>)>,
+    pub glossary: Vec<String>,
+}
+
+// ── Suggestion / Response ───────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AiSuggestion {
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiResponse {
+    pub suggestion_type: SuggestionType,
+    pub suggestions: Vec<AiSuggestion>,
+    pub model: String,
+    pub provider: AiProvider,
+    pub elapsed_ms: u64,
+}
+
+// ── Error ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Error)]
+pub enum AiError {
+    #[error("AI not configured: set [ai] in project.toml")]
+    NotConfigured,
+
+    #[error("no API key found for provider `{provider}`")]
+    NoApiKey { provider: String },
+
+    #[error("keychain error: {0}")]
+    KeychainError(String),
+
+    #[error("HTTP request failed: {0}")]
+    HttpError(String),
+
+    #[error("API returned error {status}: {body}")]
+    ApiError { status: u16, body: String },
+
+    #[error("failed to parse API response: {0}")]
+    ParseError(String),
+
+    #[error("config error: {0}")]
+    ConfigError(String),
+
+    #[error("audit log I/O: {0}")]
+    AuditError(String),
+
+    #[error("context error: {0}")]
+    ContextError(String),
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_serde_round_trip() {
+        for (provider, expected) in [
+            (AiProvider::Anthropic, r#""anthropic""#),
+            (AiProvider::OpenAi, r#""openai""#),
+        ] {
+            let json = serde_json::to_string(&provider).unwrap();
+            assert_eq!(json, expected);
+            let back: AiProvider = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, provider);
+        }
+    }
+
+    #[test]
+    fn provider_openai_alias() {
+        let p: AiProvider = serde_json::from_str(r#""openai""#).unwrap();
+        assert_eq!(p, AiProvider::OpenAi);
+    }
+
+    #[test]
+    fn suggestion_type_serde_round_trip() {
+        for ty in [
+            SuggestionType::Naming,
+            SuggestionType::Tags,
+            SuggestionType::Notes,
+            SuggestionType::Placement,
+        ] {
+            let json = serde_json::to_string(&ty).unwrap();
+            let back: SuggestionType = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, ty);
+        }
+    }
+
+    #[test]
+    fn suggestion_serde_optional_explanation() {
+        let s = AiSuggestion {
+            value: "foo_bar.psd".into(),
+            explanation: None,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(!json.contains("explanation"));
+
+        let s2 = AiSuggestion {
+            value: "foo_bar.psd".into(),
+            explanation: Some("follows snake_case".into()),
+        };
+        let json2 = serde_json::to_string(&s2).unwrap();
+        assert!(json2.contains("explanation"));
+        let back: AiSuggestion = serde_json::from_str(&json2).unwrap();
+        assert_eq!(back, s2);
+    }
+
+    #[test]
+    fn default_config() {
+        let cfg = AiConfig::default();
+        assert_eq!(cfg.provider, AiProvider::Anthropic);
+        assert_eq!(cfg.model, "claude-sonnet-4-20250514");
+        assert!(cfg.audit_log);
+        assert!(cfg.glossary.is_empty());
+    }
+
+    #[test]
+    fn provider_default_models() {
+        assert_eq!(
+            AiProvider::Anthropic.default_model(),
+            "claude-sonnet-4-20250514"
+        );
+        assert_eq!(AiProvider::OpenAi.default_model(), "gpt-4.1-mini");
+    }
+}

--- a/crates/progest-core/src/index/store.rs
+++ b/crates/progest-core/src/index/store.rs
@@ -92,6 +92,11 @@ pub trait Index: Send + Sync {
     /// `file_id` (silently skips unknown ids). Used by
     /// [`crate::search::execute::project_hits`].
     fn rich_rows(&self, file_ids: &[FileId]) -> Result<Vec<RichRow>, IndexError>;
+
+    /// All distinct tag names used across the project, sorted
+    /// lexicographically. Used by AI tag suggestions to provide the
+    /// project's existing vocabulary as context.
+    fn list_all_tags(&self) -> Result<Vec<String>, IndexError>;
 }
 
 /// Search-projection columns written by reconcile after `upsert_file`.
@@ -534,6 +539,18 @@ impl Index for SqliteIndex {
                     violations: counts,
                     custom_fields,
                 });
+            }
+            Ok(out)
+        })
+    }
+
+    fn list_all_tags(&self) -> Result<Vec<String>, IndexError> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare("SELECT DISTINCT tag FROM tags ORDER BY tag")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+            let mut out = Vec::new();
+            for row in rows {
+                out.push(row?);
             }
             Ok(out)
         })

--- a/crates/progest-core/src/lib.rs
+++ b/crates/progest-core/src/lib.rs
@@ -10,6 +10,7 @@
 //! and [`watch`] modules.
 
 pub mod accepts;
+pub mod ai;
 pub mod delete;
 pub mod fs;
 pub mod history;

--- a/crates/progest-tauri/src/ai_commands.rs
+++ b/crates/progest-tauri/src/ai_commands.rs
@@ -136,6 +136,53 @@ pub async fn ai_get_config(app: AppHandle) -> Result<AiConfigResponse, String> {
     .map_err(|e| format!("join: {e}"))?
 }
 
+#[tauri::command]
+pub async fn ai_set_config(
+    provider: Option<String>,
+    model: Option<String>,
+    audit_log: Option<bool>,
+    app: AppHandle,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let toml_path = ctx.root.project_toml();
+        let text = std::fs::read_to_string(&toml_path)
+            .map_err(|e| format!("reading {}: {e}", toml_path.display()))?;
+        let mut doc: toml::Table = text
+            .parse()
+            .map_err(|e| format!("parsing project.toml: {e}"))?;
+
+        let ai = doc
+            .entry("ai")
+            .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+            .as_table_mut()
+            .ok_or("project.toml [ai] is not a table")?;
+
+        if let Some(p) = &provider {
+            parse_provider(p)?;
+            ai.insert("provider".into(), toml::Value::String(p.clone()));
+        }
+        if let Some(m) = &model {
+            ai.insert("model".into(), toml::Value::String(m.clone()));
+        }
+        if let Some(a) = audit_log {
+            ai.insert("audit_log".into(), toml::Value::Boolean(a));
+        }
+
+        let new_text =
+            toml::to_string_pretty(&doc).map_err(|e| format!("serializing project.toml: {e}"))?;
+        std::fs::write(&toml_path, new_text)
+            .map_err(|e| format!("writing {}: {e}", toml_path.display()))?;
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 fn parse_suggestion_type(s: &str) -> Result<SuggestionType, String> {

--- a/crates/progest-tauri/src/ai_commands.rs
+++ b/crates/progest-tauri/src/ai_commands.rs
@@ -1,0 +1,158 @@
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use progest_core::ai::{
+    self, AiConfig, AiProvider, PrivacyFlags, SuggestionType, extract_ai_config,
+};
+use progest_core::fs::{ProjectPath, StdFileSystem};
+use progest_core::meta::StdMetaStore;
+use progest_core::project::ProjectDocument;
+
+use crate::state::AppState;
+
+fn no_project_error() -> String {
+    "no Progest project loaded".into()
+}
+
+// ── Wire types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiSuggestionWire {
+    pub value: String,
+    pub explanation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiSuggestResponse {
+    pub suggestions: Vec<AiSuggestionWire>,
+    pub model: String,
+    pub provider: String,
+    pub elapsed_ms: u64,
+    pub suggestion_type: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiConfigResponse {
+    pub provider: String,
+    pub model: String,
+    pub audit_log: bool,
+    pub has_key: bool,
+    pub glossary: Vec<String>,
+}
+
+// ── Commands ────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn ai_suggest(
+    path: String,
+    suggestion_type: String,
+    include_notes: bool,
+    app: AppHandle,
+) -> Result<AiSuggestResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let stype = parse_suggestion_type(&suggestion_type)?;
+        let file_path =
+            ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
+        let config = load_config(ctx)?;
+        let privacy = PrivacyFlags { include_notes };
+        let fs = StdFileSystem::new(ctx.root.root().to_path_buf());
+        let meta_store = StdMetaStore::new(fs);
+        let local = ctx.root.dot_dir().join("local");
+
+        let response = ai::suggest(
+            &file_path,
+            stype,
+            &privacy,
+            ctx.root.root(),
+            &ctx.index,
+            &meta_store,
+            &config,
+            &local,
+        )
+        .map_err(|e| e.to_string())?;
+
+        Ok(AiSuggestResponse {
+            suggestions: response
+                .suggestions
+                .into_iter()
+                .map(|s| AiSuggestionWire {
+                    value: s.value,
+                    explanation: s.explanation,
+                })
+                .collect(),
+            model: response.model,
+            provider: response.provider.to_string(),
+            elapsed_ms: response.elapsed_ms,
+            suggestion_type: suggestion_type.clone(),
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
+pub async fn ai_set_key(provider: String, key: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let prov = parse_provider(&provider)?;
+        ai::store_api_key(prov, &key).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
+pub async fn ai_get_config(app: AppHandle) -> Result<AiConfigResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let config = load_config(ctx)?;
+        let has_key = ai::has_api_key(config.provider);
+
+        Ok(AiConfigResponse {
+            provider: config.provider.to_string(),
+            model: config.model,
+            audit_log: config.audit_log,
+            has_key,
+            glossary: config.glossary,
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn parse_suggestion_type(s: &str) -> Result<SuggestionType, String> {
+    match s {
+        "naming" => Ok(SuggestionType::Naming),
+        "tags" => Ok(SuggestionType::Tags),
+        "notes" => Ok(SuggestionType::Notes),
+        "placement" => Ok(SuggestionType::Placement),
+        other => Err(format!("unknown suggestion type `{other}`")),
+    }
+}
+
+fn parse_provider(s: &str) -> Result<AiProvider, String> {
+    match s {
+        "anthropic" => Ok(AiProvider::Anthropic),
+        "openai" => Ok(AiProvider::OpenAi),
+        other => Err(format!("unknown provider `{other}`")),
+    }
+}
+
+fn load_config(ctx: &crate::state::ProjectContext) -> Result<AiConfig, String> {
+    let toml_path = ctx.root.project_toml();
+    let text = std::fs::read_to_string(&toml_path)
+        .map_err(|e| format!("reading {}: {e}", toml_path.display()))?;
+    let doc =
+        ProjectDocument::from_toml_str(&text).map_err(|e| format!("parsing project.toml: {e}"))?;
+    let (config, _warnings) =
+        extract_ai_config(&doc.extra).map_err(|e| format!("[ai] config: {e}"))?;
+    Ok(config)
+}

--- a/crates/progest-tauri/src/ai_commands.rs
+++ b/crates/progest-tauri/src/ai_commands.rs
@@ -105,6 +105,16 @@ pub async fn ai_set_key(provider: String, key: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub async fn ai_delete_key(provider: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let prov = parse_provider(&provider)?;
+        ai::delete_api_key(prov).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
 pub async fn ai_get_config(app: AppHandle) -> Result<AiConfigResponse, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let state = app.state::<AppState>();

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             ai_commands::ai_suggest,
             ai_commands::ai_set_key,
             ai_commands::ai_get_config,
+            ai_commands::ai_delete_key,
         ])
         .setup(|app| {
             // We build the main window programmatically rather than via

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 //! not live here.
 
 mod accepts_commands;
+mod ai_commands;
 mod commands;
 mod delete_commands;
 mod file_inspector_commands;
@@ -87,6 +88,9 @@ pub fn run() {
             thumbnail_commands::thumbnail_paths,
             delete_commands::file_delete_preview,
             delete_commands::file_delete_apply,
+            ai_commands::ai_suggest,
+            ai_commands::ai_set_key,
+            ai_commands::ai_get_config,
         ])
         .setup(|app| {
             // We build the main window programmatically rather than via

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             ai_commands::ai_suggest,
             ai_commands::ai_set_key,
             ai_commands::ai_get_config,
+            ai_commands::ai_set_config,
             ai_commands::ai_delete_key,
         ])
         .setup(|app| {


### PR DESCRIPTION
## Summary

- **`core::ai`** module (7 files): Provider trait (Anthropic/OpenAI), prompt templates (naming/tags/notes/placement), context gatherer, OS keychain API key storage (keyring crate), JSONL audit log, config loader for `project.toml [ai]`
- **CLI**: `progest ai suggest/set-key/status` subcommands
- **Tauri IPC**: `ai_suggest`, `ai_set_key`, `ai_delete_key`, `ai_get_config`, `ai_set_config`
- **UI**: FileInspector AI section with 4 suggestion buttons, provider selector (anthropic/openai), inline API key setup + removal, privacy toggle for notes, Apply buttons for tags/notes, DotmSquare12 spinner
- **Index**: `list_all_tags()` trait method for project tag vocabulary
- **Palette commands**: 5 AI commands (4 suggest types + configure)

### Key design decisions

- `reqwest::blocking::Client` in core (no async runtime dependency)
- `keyring` crate for cross-platform keychain (macOS Keychain / Windows Credential Manager / Linux Secret Service)
- Privacy gate: notes excluded from AI context by default (`include_notes` checkbox)
- Audit log: `.progest/local/ai-log.jsonl` (default ON, project.toml can disable)
- Provider choice persisted to `project.toml [ai].provider` on key save
- All prompts enforce JSON-only output with `parse_suggestions()` handling fences + wrapper objects

## Test plan

- [x] `mise run check` green (rustfmt + clippy + tsc + oxlint)
- [x] 105 core tests pass (+ 2 ignored keychain tests requiring OS access)
- [x] CLI tests pass
- [ ] `tauri dev` smoke: FileInspector AI buttons visible
- [ ] API key setup: select provider → enter key → save → config persists
- [ ] API key change/remove flow
- [ ] Suggest tags → Apply → tag appears on file
- [ ] Suggest notes → Apply → notes textarea updated
- [ ] Palette `>AI:` shows 5 commands
- [ ] Audit log written to `.progest/local/ai-log.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)