### PR TITLE
fix: LIKE fallback for short free-text search queries

### DIFF
--- a/crates/progest-core/src/search/execute.rs
+++ b/crates/progest-core/src/search/execute.rs
@@ -1068,4 +1068,68 @@ mod tests {
         let after = run(&conn, "forest", &CustomFields::new());
         assert!(after.is_empty());
     }
+
+    #[test]
+    fn freetext_short_query_matches_via_like() {
+        let conn = open();
+        insert_file(
+            &conn,
+            "f1",
+            "./ch_bg_v10.psd",
+            "ch_bg_v10.psd",
+            Some("psd"),
+            None,
+            None,
+            None,
+            false,
+            "fp1",
+        );
+        insert_file(
+            &conn,
+            "f2",
+            "./forest_night.psd",
+            "forest_night.psd",
+            Some("psd"),
+            None,
+            None,
+            None,
+            false,
+            "fp2",
+        );
+
+        let hits = run(&conn, "bg", &CustomFields::new());
+        assert_eq!(paths(&hits), vec!["./ch_bg_v10.psd"]);
+    }
+
+    #[test]
+    fn freetext_short_query_matches_notes() {
+        let conn = open();
+        insert_file(
+            &conn,
+            "f1",
+            "./a.psd",
+            "a.psd",
+            Some("psd"),
+            Some("BG reference shot"),
+            None,
+            None,
+            false,
+            "fp1",
+        );
+        insert_file(
+            &conn,
+            "f2",
+            "./b.psd",
+            "b.psd",
+            Some("psd"),
+            None,
+            None,
+            None,
+            false,
+            "fp2",
+        );
+
+        let hits = run(&conn, "BG", &CustomFields::new());
+        assert_eq!(paths(&hits), vec!["./a.psd"]);
+    }
 }

--- a/crates/progest-core/src/search/plan.rs
+++ b/crates/progest-core/src/search/plan.rs
@@ -182,6 +182,19 @@ impl SqlBuilder {
     }
 
     fn build_freetext(&mut self, term: &FreeTextTerm) -> String {
+        let raw = match term {
+            FreeTextTerm::Bareword(s) | FreeTextTerm::Phrase(s) => s.as_str(),
+        };
+
+        // FTS5 trigram needs >= 3 characters to produce any trigrams.
+        // For shorter queries, fall back to LIKE on the same columns.
+        if raw.chars().count() < 3 {
+            let pattern = like_escape_wrap(raw);
+            self.push_text(pattern.clone());
+            self.push_text(pattern);
+            return "(f.name LIKE ? ESCAPE '\\' OR f.notes LIKE ? ESCAPE '\\')".into();
+        }
+
         let q = match term {
             FreeTextTerm::Bareword(s) => fts_escape_bareword(s),
             FreeTextTerm::Phrase(s) => fts_escape_phrase(s),
@@ -240,6 +253,20 @@ fn fts_escape_bareword(s: &str) -> String {
 
 fn fts_escape_phrase(s: &str) -> String {
     fts_escape_bareword(s)
+}
+
+/// Wrap a short query in `%…%` for LIKE, escaping LIKE meta-chars.
+fn like_escape_wrap(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    out.push('%');
+    for ch in s.chars() {
+        if ch == '%' || ch == '_' || ch == '\\' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out.push('%');
+    out
 }
 
 // ---------------------------------------------------------------- tests
@@ -407,6 +434,34 @@ mod tests {
         assert!(p.sql.contains("files_fts"));
         assert!(p.sql.contains("MATCH ?"));
         assert_eq!(texts(&p), vec![r#""forest""#]);
+    }
+
+    #[test]
+    fn freetext_short_query_falls_back_to_like() {
+        let p = planned("bg");
+        assert!(
+            !p.sql.contains("files_fts"),
+            "short query should not use FTS5"
+        );
+        assert!(p.sql.contains("f.name LIKE ?"), "{}", p.sql);
+        assert!(p.sql.contains("f.notes LIKE ?"), "{}", p.sql);
+        assert_eq!(texts(&p), vec!["%bg%", "%bg%"]);
+    }
+
+    #[test]
+    fn freetext_single_char_falls_back_to_like() {
+        let p = planned("a");
+        assert!(!p.sql.contains("files_fts"));
+        assert!(p.sql.contains("f.name LIKE ?"));
+        assert_eq!(texts(&p), vec!["%a%", "%a%"]);
+    }
+
+    #[test]
+    fn freetext_three_chars_uses_fts5() {
+        let p = planned("bgv");
+        assert!(p.sql.contains("files_fts"));
+        assert!(p.sql.contains("MATCH ?"));
+        assert_eq!(texts(&p), vec![r#""bgv""#]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- FTS5 trigram は 3 文字未満のクエリでトリグラムを生成できず何もマッチしない問題を修正
- planner の `build_freetext()` で `chars().count() < 3` の場合、FTS5 MATCH の代わりに `f.name LIKE ? OR f.notes LIKE ?` にフォールバック
- LIKE メタ文字 (`%`, `_`, `\`) のエスケープ処理付き
- `SEARCH_DSL.md §3.2` に記載されていた未実装のフォールバック仕様を実装
- planner 3 テスト + executor 2 integration テスト追加

## 例

- `bg` → `ch_bg_v10.psd` にマッチするようになった（以前は `bg_` まで入力が必要だった）
- `BG` → notes に "BG reference shot" を含むファイルにもマッチ（LIKE のデフォルト case-insensitive）

## Test plan

- [x] planner: 2 文字クエリが LIKE SQL を生成することを確認
- [x] planner: 1 文字クエリも LIKE フォールバック
- [x] planner: 3 文字以上は従来通り FTS5 MATCH
- [x] executor: "bg" が "ch_bg_v10.psd" にマッチ
- [x] executor: "BG" が notes 内の "BG reference shot" にマッチ
- [x] 既存テスト全 pass（708 test）

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)