### PR TITLE
feat: add accepts suggest mode (default, no violations)

### DIFF
--- a/app/src/components/directory-inspector.tsx
+++ b/app/src/components/directory-inspector.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
-const MODES: AcceptsMode[] = ["strict", "warn", "hint", "off"];
+const MODES: AcceptsMode[] = ["strict", "warn", "suggest", "hint", "off"];
 
 export function DirectoryInspector(props: { dir: string }) {
   const { project, bumpRefresh } = useProject();
@@ -121,7 +121,7 @@ export function DirectoryInspector(props: { dir: string }) {
   }
 
   function onDeclareEmpty() {
-    setDraft({ inherit: false, exts: [], mode: "warn" });
+    setDraft({ inherit: false, exts: [], mode: "suggest" });
   }
 
   function onClearAccepts() {

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -314,7 +314,7 @@ export function isAlreadyInitialized(e: unknown): boolean {
 // with `#[serde(tag = "type", rename_all = "lowercase")]`.
 export type AcceptsToken = { type: "alias"; name: string } | { type: "ext"; value: string };
 
-export type AcceptsMode = "strict" | "warn" | "hint" | "off";
+export type AcceptsMode = "strict" | "warn" | "suggest" | "hint" | "off";
 
 export type RawAccepts = {
   inherit: boolean;

--- a/crates/progest-core/src/accepts/loader.rs
+++ b/crates/progest-core/src/accepts/loader.rs
@@ -87,7 +87,7 @@ pub fn extract_accepts(extra: &Table) -> Result<Option<AcceptsExtraction>, Accep
     let mut warnings = Vec::new();
     let mut inherit = false;
     let mut exts: Vec<AcceptsToken> = Vec::new();
-    let mut mode = Mode::Warn;
+    let mut mode = Mode::Suggest;
 
     for (key, value) in accepts_table {
         match key.as_str() {
@@ -129,13 +129,14 @@ pub fn extract_accepts(extra: &Table) -> Result<Option<AcceptsExtraction>, Accep
                 mode = match raw {
                     "strict" => Mode::Strict,
                     "warn" => Mode::Warn,
+                    "suggest" => Mode::Suggest,
                     "hint" => Mode::Hint,
                     "off" => Mode::Off,
                     other => {
                         return Err(AcceptsLoadError::InvalidField {
                             field: "mode",
                             message: format!(
-                                "unknown mode `{other}` (expected strict/warn/hint/off)"
+                                "unknown mode `{other}` (expected strict/warn/suggest/hint/off)"
                             ),
                         });
                     }
@@ -235,7 +236,7 @@ exts = [".psd"]
         );
         let got = extract_accepts(&t).unwrap().unwrap();
         assert!(!got.accepts.inherit);
-        assert_eq!(got.accepts.mode, Mode::Warn);
+        assert_eq!(got.accepts.mode, Mode::Suggest);
     }
 
     // --- Warnings -----------------------------------------------------------

--- a/crates/progest-core/src/accepts/resolve.rs
+++ b/crates/progest-core/src/accepts/resolve.rs
@@ -35,8 +35,7 @@ pub struct EffectiveAccepts {
     /// dir itself and via inheritance, `Own` wins.
     pub exts: BTreeMap<Ext, AcceptsSource>,
     /// Severity for placement lint (from the dir's own `[accepts]`,
-    /// or [`Mode::Warn`] if the dir has no declaration — matching
-    /// REQUIREMENTS.md §3.13.6 default).
+    /// or [`Mode::Suggest`] if the dir has no declaration).
     pub mode: Mode,
 }
 

--- a/crates/progest-core/src/accepts/types.rs
+++ b/crates/progest-core/src/accepts/types.rs
@@ -100,7 +100,8 @@ pub struct RawAccepts {
     /// unknown-alias errors with the original text.
     pub exts: Vec<AcceptsToken>,
     /// Severity mode for placement violations. Defaults to
-    /// [`Mode::Warn`] per REQUIREMENTS.md §3.13.1.
+    /// [`Mode::Suggest`] — no violation, but import / UI will still
+    /// suggest appropriate directories.
     pub mode: Mode,
 }
 
@@ -109,7 +110,7 @@ impl Default for RawAccepts {
         Self {
             inherit: false,
             exts: Vec::new(),
-            mode: Mode::Warn,
+            mode: Mode::Suggest,
         }
     }
 }
@@ -337,9 +338,9 @@ mod tests {
     }
 
     #[test]
-    fn default_raw_accepts_is_warn_mode_no_inherit_empty() {
+    fn default_raw_accepts_is_suggest_mode_no_inherit_empty() {
         let r = RawAccepts::default();
-        assert_eq!(r.mode, Mode::Warn);
+        assert_eq!(r.mode, Mode::Suggest);
         assert!(!r.inherit);
         assert!(r.exts.is_empty());
     }

--- a/crates/progest-core/src/accepts/writer.rs
+++ b/crates/progest-core/src/accepts/writer.rs
@@ -55,6 +55,7 @@ fn mode_str(mode: Mode) -> &'static str {
     match mode {
         Mode::Strict => "strict",
         Mode::Warn => "warn",
+        Mode::Suggest => "suggest",
         Mode::Hint => "hint",
         Mode::Off => "off",
     }
@@ -89,12 +90,12 @@ mod tests {
     }
 
     #[test]
-    fn defaults_round_trip_with_warn_mode() {
+    fn defaults_round_trip_with_suggest_mode() {
         let original = RawAccepts::default();
         let mut extra = Table::new();
         inject_accepts(&mut extra, &original);
         let parsed = extract_accepts(&extra).unwrap().unwrap();
-        assert_eq!(parsed.accepts.mode, Mode::Warn);
+        assert_eq!(parsed.accepts.mode, Mode::Suggest);
         assert!(!parsed.accepts.inherit);
         assert!(parsed.accepts.exts.is_empty());
     }

--- a/crates/progest-core/src/rules/types.rs
+++ b/crates/progest-core/src/rules/types.rs
@@ -100,28 +100,30 @@ impl fmt::Display for RuleKind {
 /// User-configured mode determining lint / rename behavior (§8.2).
 ///
 /// `Mode::Warn` is the default when callers leave the field unset in
-/// `rules.toml`.
+/// `rules.toml`. For accepts placement, `Mode::Suggest` is used as the
+/// default — see `RawAccepts::default()`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Mode {
     Strict,
     #[default]
     Warn,
+    Suggest,
     Hint,
     Off,
 }
 
 impl Mode {
     /// The severity that should be attached to violations emitted under
-    /// this mode. `Off` produces no violations and is therefore modeled
-    /// as `None` — callers should short-circuit before reaching here.
+    /// this mode. `Off` and `Suggest` produce no violations and are
+    /// therefore modeled as `None` — callers should short-circuit.
     #[must_use]
     pub fn violation_severity(self) -> Option<Severity> {
         match self {
             Self::Strict => Some(Severity::Strict),
             Self::Warn => Some(Severity::Warn),
             Self::Hint => Some(Severity::Hint),
-            Self::Off => None,
+            Self::Suggest | Self::Off => None,
         }
     }
 }

--- a/crates/progest-tauri/src/accepts_commands.rs
+++ b/crates/progest-tauri/src/accepts_commands.rs
@@ -253,11 +253,12 @@ fn raw_from_wire(w: RawAcceptsWire) -> Result<RawAccepts, String> {
     let mode = match w.mode.as_str() {
         "strict" => Mode::Strict,
         "warn" => Mode::Warn,
+        "suggest" => Mode::Suggest,
         "hint" => Mode::Hint,
         "off" => Mode::Off,
         other => {
             return Err(format!(
-                "invalid mode `{other}` (expected strict/warn/hint/off)"
+                "invalid mode `{other}` (expected strict/warn/suggest/hint/off)"
             ));
         }
     };
@@ -309,6 +310,7 @@ fn mode_str(mode: Mode) -> &'static str {
     match mode {
         Mode::Strict => "strict",
         Mode::Warn => "warn",
+        Mode::Suggest => "suggest",
         Mode::Hint => "hint",
         Mode::Off => "off",
     }


### PR DESCRIPTION
## Summary

- \`Mode::Suggest\` を追加 — \`violation_severity()\` が \`None\` を返すため placement violation を生成しない
- accepts のデフォルトを \`Mode::Warn\` → \`Mode::Suggest\` に変更
- 既存の \`.dirmeta.toml\` で明示的に \`mode = "warn"\` / \`mode = "strict"\` を設定しているプロジェクトは影響なし
- core（Mode enum + accepts loader/writer/resolver）、Tauri IPC（wire format）、frontend（型定義 + mode ドロップダウン + 新規 accepts のデフォルト）を一括変更

## モード一覧（変更後）

| Mode | Violation | 用途 |
|------|-----------|------|
| strict | Strict severity | 厳格な配置制限 |
| warn | Warn severity | violation バッジ表示、操作は許可 |
| **suggest** | **なし** | **配置提案のみ（新デフォルト）** |
| hint | Hint severity | 新規ファイルにのみ提案 |
| off | なし | 制約なし |

## Test plan

- [x] \`RawAccepts::default().mode == Mode::Suggest\` テスト通過
- [x] loader: \`mode\` 未指定時のデフォルトが \`Suggest\`
- [x] writer: suggest mode の round-trip
- [x] 全テスト 806 passed, 0 failed
- [ ] Tauri dev で新規 accepts 作成時に suggest がデフォルト選択されることを確認
- [ ] suggest モードのディレクトリに配置ルール外のファイルがあっても violation バッジが出ないことを確認

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)