### PR TITLE
feat: file/directory create, rename, context menu (CRUD phase 1)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -159,6 +159,17 @@ function Shell() {
     setSelection(null);
   }, []);
 
+  // Clear file selection when any rename happens so the inspector
+  // doesn't show stale data. bumpRefresh (fired by the rename caller)
+  // will update the tree/flat views.
+  React.useEffect(() => {
+    function onRenamed() {
+      setSelection(null);
+    }
+    window.addEventListener("progest:renamed", onRenamed);
+    return () => window.removeEventListener("progest:renamed", onRenamed);
+  }, []);
+
   const onSelectionUpdate = React.useCallback((updatedHit: RichSearchHit) => {
     setSelection({ kind: "file", hit: updatedHit });
   }, []);

--- a/app/src/components/file-context-menu.tsx
+++ b/app/src/components/file-context-menu.tsx
@@ -63,7 +63,10 @@ export function FileContextMenu(props: FileContextMenuProps) {
     setRenameBusy(true);
     setRenameError(null);
     try {
-      await fsRename(props.path, trimmed);
+      const result = await fsRename(props.path, trimmed);
+      window.dispatchEvent(
+        new CustomEvent("progest:renamed", { detail: { from: props.path, to: result.to } }),
+      );
       setRenameOpen(false);
       bumpRefresh();
       toast.success(`Renamed to ${trimmed}`);

--- a/app/src/components/file-context-menu.tsx
+++ b/app/src/components/file-context-menu.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
-import { Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
-import { fileDeleteApply, fileDeletePreview, type DeletePreview } from "@/lib/ipc";
+import { fileDeleteApply, fileDeletePreview, fsRename, type DeletePreview } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
 import { DotmSquare1 } from "@/components/ui/dotm-square-1";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import {
@@ -29,6 +31,50 @@ type FileContextMenuProps = {
 
 export function FileContextMenu(props: FileContextMenuProps) {
   const { bumpRefresh } = useProject();
+
+  // ── Rename ──────────────────────────────────────────────────────
+  const [renameOpen, setRenameOpen] = React.useState(false);
+  const [renameBusy, setRenameBusy] = React.useState(false);
+  const [renameError, setRenameError] = React.useState<string | null>(null);
+  const [newName, setNewName] = React.useState("");
+  const renameInputRef = React.useRef<HTMLInputElement>(null);
+
+  const filename = props.path.split("/").pop() ?? props.path;
+
+  const openRename = () => {
+    setNewName(filename);
+    setRenameError(null);
+    setRenameOpen(true);
+    setTimeout(() => {
+      const input = renameInputRef.current;
+      if (!input) return;
+      input.focus();
+      const dot = filename.lastIndexOf(".");
+      input.setSelectionRange(0, dot > 0 ? dot : filename.length);
+    }, 50);
+  };
+
+  const handleRename = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === filename) {
+      setRenameOpen(false);
+      return;
+    }
+    setRenameBusy(true);
+    setRenameError(null);
+    try {
+      await fsRename(props.path, trimmed);
+      setRenameOpen(false);
+      bumpRefresh();
+      toast.success(`Renamed to ${trimmed}`);
+    } catch (e) {
+      setRenameError(String(e));
+    } finally {
+      setRenameBusy(false);
+    }
+  };
+
+  // ── Delete ──────────────────────────────────────────────────────
   const [confirmOpen, setConfirmOpen] = React.useState(false);
   const [preview, setPreview] = React.useState<DeletePreview | null>(null);
   const [busy, setBusy] = React.useState(false);
@@ -61,23 +107,65 @@ export function FileContextMenu(props: FileContextMenuProps) {
     }
   };
 
-  const filename = props.path.split("/").pop() ?? props.path;
-
   return (
     <>
       <ContextMenu>
         <ContextMenuTrigger asChild>{props.children}</ContextMenuTrigger>
         <ContextMenuContent>
+          <ContextMenuItem onClick={openRename}>
+            <Pencil className="mr-2 size-3.5" />
+            Rename
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => void openConfirm()}
           >
-            <Trash2 className="size-3.5 mr-2" />
+            <Trash2 className="mr-2 size-3.5" />
             Move to Trash
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
 
+      {/* Rename dialog */}
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename</DialogTitle>
+            <DialogDescription>Enter a new name for {filename}.</DialogDescription>
+          </DialogHeader>
+          <Input
+            ref={renameInputRef}
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleRename();
+              }
+            }}
+            className="font-mono text-xs"
+          />
+          {renameError ? <div className="text-xs text-destructive">{renameError}</div> : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleRename()} disabled={renameBusy}>
+              {renameBusy ? (
+                <>
+                  <DotmSquare1 size={16} dotSize={2} animated className="mr-1.5" />
+                  Renaming…
+                </>
+              ) : (
+                "Rename"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
@@ -86,7 +174,7 @@ export function FileContextMenu(props: FileContextMenuProps) {
               This will move the file to the OS trash. You can restore it from the trash later.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded border bg-muted/30 p-2 text-xs font-mono space-y-0.5">
+          <div className="space-y-0.5 rounded border bg-muted/30 p-2 font-mono text-xs">
             <div className="truncate">{filename}</div>
             {preview?.has_sidecar ? (
               <div className="text-muted-foreground">+ .meta sidecar</div>

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -166,7 +166,10 @@ export function TreeView(props: {
         return;
       }
       try {
-        await fsRename(edit.path, newName);
+        const result = await fsRename(edit.path, newName);
+        window.dispatchEvent(
+          new CustomEvent("progest:renamed", { detail: { from: edit.path, to: result.to } }),
+        );
         toast.success(`Renamed to ${newName}`);
         bumpRefresh();
       } catch (e) {

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -26,6 +26,7 @@ import {
   fsCreateFile,
   fsRename,
   fileDeleteApply,
+  dirDeleteApply,
   IpcError,
   type DirEntry,
   type FileEntry,
@@ -323,7 +324,7 @@ function DirNode(
   const handleDelete = React.useCallback(async () => {
     if (!path) return;
     try {
-      await fileDeleteApply(path);
+      await dirDeleteApply(path);
       toast.success("Moved to Trash");
       bumpRefresh();
     } catch (e) {

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -182,17 +182,16 @@ export function TreeView(props: {
     return dirPathAtPoint(dragState.position);
   }, [dragState.active, dragState.position]);
 
-  // F2 keybinding for rename
+  // Listen for palette "New file / New folder" commands
   React.useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "F2" && !edit) {
-        // Rename the currently selected dir or last clicked item
-        // For now, F2 is handled per-node via context menu
-      }
+    function onCreateEvent(e: Event) {
+      const detail = (e as CustomEvent<{ kind: "file" | "dir" }>).detail;
+      const dir = props.selectedDir ?? "";
+      startCreate(dir, detail.kind);
     }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [edit]);
+    window.addEventListener("progest:create", onCreateEvent);
+    return () => window.removeEventListener("progest:create", onCreateEvent);
+  }, [props.selectedDir, startCreate]);
 
   return (
     <nav className="h-full overflow-auto p-1 text-xs">

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -1,11 +1,36 @@
 import * as React from "react";
-import { ChevronRight, ChevronDown, Folder, FolderOpen, FileIcon } from "lucide-react";
+import {
+  ChevronRight,
+  ChevronDown,
+  Folder,
+  FolderOpen,
+  FileIcon,
+  FilePlus,
+  FolderPlus,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
 
 import { useDragActive } from "@/components/drag-drop-overlay";
-import { FileContextMenu } from "@/components/file-context-menu";
-import { filesListDir, IpcError, type DirEntry, type FileEntry } from "@/lib/ipc";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  filesListDir,
+  fsCreateDir,
+  fsCreateFile,
+  fsRename,
+  fileDeleteApply,
+  IpcError,
+  type DirEntry,
+  type FileEntry,
+} from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
-
 import { ViolationDots } from "@/components/violation-badges";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +41,11 @@ type DirState = {
   children: DirEntry[];
   error?: string;
 };
+
+type EditState =
+  | { mode: "rename"; path: string; name: string }
+  | { mode: "create"; parentDir: string; kind: "file" | "dir" }
+  | null;
 
 /**
  * Given a CSS-pixel position, find the closest `[data-dir-path]`
@@ -34,9 +64,10 @@ export function TreeView(props: {
   selectedDir?: string;
   onSelectDir?: (path: string) => void;
 }) {
-  const { project, refreshTick } = useProject();
+  const { project, refreshTick, bumpRefresh } = useProject();
   const [cache, setCache] = React.useState<Record<string, DirState>>({});
   const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set([""]));
+  const [edit, setEdit] = React.useState<EditState>(null);
 
   const fetchDir = React.useCallback(async (path: string) => {
     setCache((c) => ({
@@ -58,6 +89,7 @@ export function TreeView(props: {
   React.useEffect(() => {
     setCache({});
     setExpanded(new Set([""]));
+    setEdit(null);
     void fetchDir("");
   }, [project?.root, fetchDir]);
 
@@ -87,11 +119,80 @@ export function TreeView(props: {
     [expanded, cache, fetchDir],
   );
 
+  const startCreate = React.useCallback(
+    (parentDir: string, kind: "file" | "dir") => {
+      setExpanded((prev) => new Set([...prev, parentDir]));
+      if (!cache[parentDir] || cache[parentDir].state !== "loaded") {
+        void fetchDir(parentDir);
+      }
+      setEdit({ mode: "create", parentDir, kind });
+    },
+    [cache, fetchDir],
+  );
+
+  const startRename = React.useCallback((path: string, name: string) => {
+    setEdit({ mode: "rename", path, name });
+  }, []);
+
+  const cancelEdit = React.useCallback(() => setEdit(null), []);
+
+  const commitCreate = React.useCallback(
+    async (name: string) => {
+      if (!edit || edit.mode !== "create") return;
+      const fullPath = edit.parentDir ? `${edit.parentDir}/${name}` : name;
+      try {
+        if (edit.kind === "dir") {
+          await fsCreateDir(fullPath);
+          toast.success(`Created folder: ${name}`);
+        } else {
+          await fsCreateFile(fullPath);
+          toast.success(`Created file: ${name}`);
+        }
+        bumpRefresh();
+      } catch (e) {
+        toast.error(String(e));
+      }
+      setEdit(null);
+    },
+    [edit, bumpRefresh],
+  );
+
+  const commitRename = React.useCallback(
+    async (newName: string) => {
+      if (!edit || edit.mode !== "rename") return;
+      if (newName === edit.name || !newName.trim()) {
+        setEdit(null);
+        return;
+      }
+      try {
+        await fsRename(edit.path, newName);
+        toast.success(`Renamed to ${newName}`);
+        bumpRefresh();
+      } catch (e) {
+        toast.error(String(e));
+      }
+      setEdit(null);
+    },
+    [edit, bumpRefresh],
+  );
+
   const dragState = useDragActive();
   const dragOverPath = React.useMemo(() => {
     if (!dragState.active || !dragState.position) return null;
     return dirPathAtPoint(dragState.position);
   }, [dragState.active, dragState.position]);
+
+  // F2 keybinding for rename
+  React.useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "F2" && !edit) {
+        // Rename the currently selected dir or last clicked item
+        // For now, F2 is handled per-node via context menu
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [edit]);
 
   return (
     <nav className="h-full overflow-auto p-1 text-xs">
@@ -106,23 +207,93 @@ export function TreeView(props: {
         selectedDir={props.selectedDir}
         onSelectDir={props.onSelectDir}
         dragOverPath={dragOverPath}
+        edit={edit}
+        onStartCreate={startCreate}
+        onStartRename={startRename}
+        onCancelEdit={cancelEdit}
+        onCommitCreate={commitCreate}
+        onCommitRename={commitRename}
       />
     </nav>
   );
 }
 
-function DirNode(props: {
-  path: string;
-  name: string;
-  depth: number;
-  expanded: Set<string>;
-  cache: Record<string, DirState>;
-  toggle: (path: string) => Promise<void>;
-  onPickFile: ((entry: DirEntry) => void) | undefined;
-  selectedDir: string | undefined;
-  onSelectDir: ((path: string) => void) | undefined;
-  dragOverPath: string | null;
+// ── Inline input ────────────────────────────────────────────────────
+
+function InlineInput(props: {
+  defaultValue: string;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+  selectStem?: boolean;
 }) {
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    const input = ref.current;
+    if (!input) return;
+    input.focus();
+    if (props.selectStem) {
+      const dot = props.defaultValue.lastIndexOf(".");
+      input.setSelectionRange(0, dot > 0 ? dot : props.defaultValue.length);
+    } else {
+      input.select();
+    }
+  }, [props.defaultValue, props.selectStem]);
+
+  return (
+    <input
+      ref={ref}
+      type="text"
+      defaultValue={props.defaultValue}
+      className="h-5 w-full min-w-0 rounded border bg-background px-1 text-xs outline-none focus:ring-1 focus:ring-ring"
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          props.onCommit((e.target as HTMLInputElement).value.trim());
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          props.onCancel();
+        }
+        e.stopPropagation();
+      }}
+      onBlur={(e) => {
+        const value = e.target.value.trim();
+        if (value && value !== props.defaultValue) {
+          props.onCommit(value);
+        } else {
+          props.onCancel();
+        }
+      }}
+      onClick={(e) => e.stopPropagation()}
+    />
+  );
+}
+
+// ── DirNode ─────────────────────────────────────────────────────────
+
+type TreeEditProps = {
+  edit: EditState;
+  onStartCreate: (parentDir: string, kind: "file" | "dir") => void;
+  onStartRename: (path: string, name: string) => void;
+  onCancelEdit: () => void;
+  onCommitCreate: (name: string) => void;
+  onCommitRename: (newName: string) => void;
+};
+
+function DirNode(
+  props: {
+    path: string;
+    name: string;
+    depth: number;
+    expanded: Set<string>;
+    cache: Record<string, DirState>;
+    toggle: (path: string) => Promise<void>;
+    onPickFile: ((entry: DirEntry) => void) | undefined;
+    selectedDir: string | undefined;
+    onSelectDir: ((path: string) => void) | undefined;
+    dragOverPath: string | null;
+  } & TreeEditProps,
+) {
   const {
     path,
     name,
@@ -134,44 +305,110 @@ function DirNode(props: {
     selectedDir,
     onSelectDir,
     dragOverPath,
+    edit,
+    onStartCreate,
+    onStartRename,
+    onCancelEdit,
+    onCommitCreate,
+    onCommitRename,
   } = props;
+  const { bumpRefresh } = useProject();
   const isOpen = expanded.has(path);
   const isSelected = selectedDir === path;
   const entry = cache[path];
   const indent = depth * 12;
-
   const isDragOver = dragOverPath === path;
+  const isRenaming = edit?.mode === "rename" && edit.path === path;
+  const isCreatingHere = edit?.mode === "create" && edit.parentDir === path;
+
+  const handleDelete = React.useCallback(async () => {
+    if (!path) return;
+    try {
+      await fileDeleteApply(path);
+      toast.success("Moved to Trash");
+      bumpRefresh();
+    } catch (e) {
+      toast.error(String(e));
+    }
+  }, [path, bumpRefresh]);
 
   return (
     <div>
-      <button
-        type="button"
-        data-dir-path={path}
-        className={cn(
-          "flex w-full items-center gap-1 rounded px-1 py-0.5 hover:bg-accent",
-          isSelected && "bg-accent text-accent-foreground",
-          isDragOver && "bg-primary/20 ring-1 ring-primary/50",
-        )}
-        style={{ paddingLeft: indent + 4 }}
-        onClick={() => {
-          onSelectDir?.(path);
-          void toggle(path);
-        }}
-      >
-        {isOpen ? (
-          <ChevronDown className="size-3 opacity-60" />
-        ) : (
-          <ChevronRight className="size-3 opacity-60" />
-        )}
-        {isOpen ? (
-          <FolderOpen className="size-3.5 opacity-70" />
-        ) : (
-          <Folder className="size-3.5 opacity-70" />
-        )}
-        <span className="truncate">{name}</span>
-      </button>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <button
+            type="button"
+            data-dir-path={path}
+            className={cn(
+              "flex w-full items-center gap-1 rounded px-1 py-0.5 hover:bg-accent",
+              isSelected && "bg-accent text-accent-foreground",
+              isDragOver && "bg-primary/20 ring-1 ring-primary/50",
+            )}
+            style={{ paddingLeft: indent + 4 }}
+            onClick={() => {
+              onSelectDir?.(path);
+              void toggle(path);
+            }}
+          >
+            {isOpen ? (
+              <ChevronDown className="size-3 shrink-0 opacity-60" />
+            ) : (
+              <ChevronRight className="size-3 shrink-0 opacity-60" />
+            )}
+            {isOpen ? (
+              <FolderOpen className="size-3.5 shrink-0 opacity-70" />
+            ) : (
+              <Folder className="size-3.5 shrink-0 opacity-70" />
+            )}
+            {isRenaming ? (
+              <InlineInput defaultValue={name} onCommit={onCommitRename} onCancel={onCancelEdit} />
+            ) : (
+              <span className="truncate">{name}</span>
+            )}
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={() => onStartCreate(path, "file")}>
+            <FilePlus className="mr-2 size-3.5" />
+            New File
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => onStartCreate(path, "dir")}>
+            <FolderPlus className="mr-2 size-3.5" />
+            New Folder
+          </ContextMenuItem>
+          {path !== "" && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem onClick={() => onStartRename(path, name)}>
+                <Pencil className="mr-2 size-3.5" />
+                Rename
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => void handleDelete()}
+              >
+                <Trash2 className="mr-2 size-3.5" />
+                Move to Trash
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
       {isOpen ? (
         <div>
+          {isCreatingHere && edit.mode === "create" && (
+            <div
+              className="flex items-center gap-1 rounded px-1 py-0.5"
+              style={{ paddingLeft: (depth + 1) * 12 + (edit.kind === "dir" ? 4 : 16) }}
+            >
+              {edit.kind === "dir" ? (
+                <Folder className="size-3.5 shrink-0 opacity-70" />
+              ) : (
+                <FileIcon className="size-3.5 shrink-0 opacity-60" />
+              )}
+              <InlineInput defaultValue="" onCommit={onCommitCreate} onCancel={onCancelEdit} />
+            </div>
+          )}
           {entry?.state === "loading" && (
             <div className="px-1 py-0.5 text-muted-foreground" style={{ paddingLeft: indent + 24 }}>
               loading…
@@ -201,9 +438,24 @@ function DirNode(props: {
                   selectedDir={selectedDir}
                   onSelectDir={onSelectDir}
                   dragOverPath={dragOverPath}
+                  edit={edit}
+                  onStartCreate={onStartCreate}
+                  onStartRename={onStartRename}
+                  onCancelEdit={onCancelEdit}
+                  onCommitCreate={onCommitCreate}
+                  onCommitRename={onCommitRename}
                 />
               ) : (
-                <FileNode key={child.path} entry={child} depth={depth + 1} onPick={onPickFile} />
+                <FileNode
+                  key={child.path}
+                  entry={child}
+                  depth={depth + 1}
+                  onPick={onPickFile}
+                  edit={edit}
+                  onStartRename={onStartRename}
+                  onCancelEdit={onCancelEdit}
+                  onCommitRename={onCommitRename}
+                />
               ),
             )}
         </div>
@@ -212,32 +464,75 @@ function DirNode(props: {
   );
 }
 
+// ── FileNode ────────────────────────────────────────────────────────
+
 function FileNode(props: {
   entry: DirEntry;
   depth: number;
   onPick: ((entry: DirEntry) => void) | undefined;
+  edit: EditState;
+  onStartRename: (path: string, name: string) => void;
+  onCancelEdit: () => void;
+  onCommitRename: (newName: string) => void;
 }) {
-  const { entry, depth, onPick } = props;
+  const { entry, depth, onPick, edit, onStartRename, onCancelEdit, onCommitRename } = props;
   const { bumpRefresh } = useProject();
   const file: FileEntry | undefined = entry.file;
   const indent = depth * 12;
+  const isRenaming = edit?.mode === "rename" && edit.path === entry.path;
+
+  const handleDelete = React.useCallback(async () => {
+    try {
+      await fileDeleteApply(entry.path);
+      toast.success("Moved to Trash", { description: entry.name });
+      bumpRefresh();
+    } catch (e) {
+      toast.error(String(e));
+    }
+  }, [entry.path, entry.name, bumpRefresh]);
+
   return (
-    <FileContextMenu path={entry.path} onDeleted={bumpRefresh}>
-      <button
-        type="button"
-        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-accent"
-        style={{ paddingLeft: indent + 16 }}
-        onClick={() => onPick?.(entry)}
-      >
-        <FileIcon className="size-3.5 opacity-60" />
-        <span className="truncate">{entry.name}</span>
-        {file ? <ViolationDots counts={file.violations} /> : null}
-        {file && file.tags.length > 0 ? (
-          <span className="ml-auto text-[0.625rem] text-muted-foreground">
-            {file.tags.map((t) => `#${t}`).join(" ")}
-          </span>
-        ) : null}
-      </button>
-    </FileContextMenu>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-accent"
+          style={{ paddingLeft: indent + 16 }}
+          onClick={() => onPick?.(entry)}
+        >
+          <FileIcon className="size-3.5 shrink-0 opacity-60" />
+          {isRenaming ? (
+            <InlineInput
+              defaultValue={entry.name}
+              onCommit={onCommitRename}
+              onCancel={onCancelEdit}
+              selectStem
+            />
+          ) : (
+            <span className="truncate">{entry.name}</span>
+          )}
+          {!isRenaming && file ? <ViolationDots counts={file.violations} /> : null}
+          {!isRenaming && file && file.tags.length > 0 ? (
+            <span className="ml-auto text-[0.625rem] text-muted-foreground">
+              {file.tags.map((t) => `#${t}`).join(" ")}
+            </span>
+          ) : null}
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onStartRename(entry.path, entry.name)}>
+          <Pencil className="mr-2 size-3.5" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={() => void handleDelete()}
+        >
+          <Trash2 className="mr-2 size-3.5" />
+          Move to Trash
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -547,6 +547,14 @@ export async function fileDeleteApply(path: string): Promise<DeleteOutcome> {
   }
 }
 
+export async function dirDeleteApply(path: string): Promise<DeleteOutcome> {
+  try {
+    return await invoke<DeleteOutcome>("dir_delete_apply", { path });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- CRUD (create / rename / move) ----------------------------------------
 
 export type CreateOutcome = { path: string; kind: string };

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -547,6 +547,44 @@ export async function fileDeleteApply(path: string): Promise<DeleteOutcome> {
   }
 }
 
+// --- CRUD (create / rename / move) ----------------------------------------
+
+export type CreateOutcome = { path: string; kind: string };
+export type RenameOutcome = { from: string; to: string };
+export type MoveOutcome = { from: string; to: string };
+
+export async function fsCreateDir(path: string): Promise<CreateOutcome> {
+  try {
+    return await invoke<CreateOutcome>("fs_create_dir", { path });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function fsCreateFile(path: string): Promise<CreateOutcome> {
+  try {
+    return await invoke<CreateOutcome>("fs_create_file", { path });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function fsRename(from: string, newName: string): Promise<RenameOutcome> {
+  try {
+    return await invoke<RenameOutcome>("fs_rename", { from, newName });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function fsMove(path: string, destDir: string): Promise<MoveOutcome> {
+  try {
+    return await invoke<MoveOutcome>("fs_move", { path, destDir });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- lint refresh ----------------------------------------------------------
 
 export type LintRunResponse = {

--- a/app/src/lib/palette-commands/file-commands.ts
+++ b/app/src/lib/palette-commands/file-commands.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { useProject } from "@/lib/project-context";
+import type { PaletteCommand } from "./types";
+
+export function useFileCommands(): PaletteCommand[] {
+  const { project } = useProject();
+
+  return React.useMemo<PaletteCommand[]>(() => {
+    if (!project) return [];
+    return [
+      {
+        id: "file.new-file",
+        title: "New file…",
+        group: "File",
+        keywords: ["create", "touch"],
+        run: () => {
+          window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "file" } }));
+        },
+      },
+      {
+        id: "file.new-folder",
+        title: "New folder…",
+        group: "File",
+        keywords: ["create", "directory", "mkdir"],
+        run: () => {
+          window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "dir" } }));
+        },
+      },
+    ];
+  }, [project]);
+}

--- a/app/src/lib/palette-commands/index.ts
+++ b/app/src/lib/palette-commands/index.ts
@@ -18,6 +18,7 @@
 import * as React from "react";
 
 import { useAiCommands } from "./ai-commands";
+import { useFileCommands } from "./file-commands";
 import { useProjectCommands } from "./project-commands";
 import { useThemeCommands } from "./theme-commands";
 import type { PaletteCommand } from "./types";
@@ -27,9 +28,10 @@ export { fuzzyMatch } from "./types";
 
 export function usePaletteCommands(): PaletteCommand[] {
   const project = useProjectCommands();
+  const file = useFileCommands();
   const theme = useThemeCommands();
   const ai = useAiCommands();
-  return React.useMemo(() => [...project, ...theme, ...ai], [project, theme, ai]);
+  return React.useMemo(() => [...project, ...file, ...theme, ...ai], [project, file, theme, ai]);
 }
 
 /**

--- a/crates/progest-core/src/create.rs
+++ b/crates/progest-core/src/create.rs
@@ -1,0 +1,111 @@
+//! Create new files and directories inside a project.
+//!
+//! Thin wrappers around [`FileSystem`] that handle parent directory
+//! creation and existence checks. The reconciler picks up new entries
+//! on the next scan, generating `.meta` sidecars and index rows.
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::fs::{FileSystem, ProjectPath};
+
+#[derive(Debug, Error)]
+pub enum CreateError {
+    #[error("already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("filesystem error: {0}")]
+    Fs(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateOutcome {
+    pub path: ProjectPath,
+    pub kind: &'static str,
+}
+
+/// Create an empty directory at `path` (relative to project root).
+pub fn create_dir(fs: &dyn FileSystem, path: &ProjectPath) -> Result<CreateOutcome, CreateError> {
+    if fs.exists(path) {
+        return Err(CreateError::AlreadyExists(path.to_string()));
+    }
+    fs.create_dir_all(path)
+        .map_err(|e| CreateError::Fs(e.to_string()))?;
+    Ok(CreateOutcome {
+        path: path.clone(),
+        kind: "directory",
+    })
+}
+
+/// Create an empty file at `path` (relative to project root).
+/// Parent directories are created automatically.
+/// The reconciler will generate the `.meta` sidecar and index entry.
+pub fn create_file(fs: &dyn FileSystem, path: &ProjectPath) -> Result<CreateOutcome, CreateError> {
+    if fs.exists(path) {
+        return Err(CreateError::AlreadyExists(path.to_string()));
+    }
+
+    if let Some(parent) = path.parent()
+        && !parent.is_root()
+    {
+        let _ = fs.create_dir_all(&parent);
+    }
+
+    fs.write_atomic(path, &[])
+        .map_err(|e| CreateError::Fs(e.to_string()))?;
+
+    Ok(CreateOutcome {
+        path: path.clone(),
+        kind: "file",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::MemFileSystem;
+
+    #[test]
+    fn create_dir_succeeds() {
+        let fs = MemFileSystem::new();
+        let path = ProjectPath::new("new_dir").unwrap();
+        let outcome = create_dir(&fs, &path).unwrap();
+        assert_eq!(outcome.kind, "directory");
+        assert!(fs.exists(&path));
+    }
+
+    #[test]
+    fn create_dir_rejects_existing() {
+        let fs = MemFileSystem::new();
+        let path = ProjectPath::new("existing").unwrap();
+        fs.create_dir_all(&path).unwrap();
+        let err = create_dir(&fs, &path).unwrap_err();
+        assert!(matches!(err, CreateError::AlreadyExists(_)));
+    }
+
+    #[test]
+    fn create_file_succeeds() {
+        let fs = MemFileSystem::new();
+        let path = ProjectPath::new("test.txt").unwrap();
+        let outcome = create_file(&fs, &path).unwrap();
+        assert_eq!(outcome.kind, "file");
+        assert!(fs.exists(&path));
+    }
+
+    #[test]
+    fn create_file_creates_parents() {
+        let fs = MemFileSystem::new();
+        let path = ProjectPath::new("deep/nested/file.txt").unwrap();
+        create_file(&fs, &path).unwrap();
+        assert!(fs.exists(&path));
+    }
+
+    #[test]
+    fn create_file_rejects_existing() {
+        let fs = MemFileSystem::new();
+        let path = ProjectPath::new("exists.txt").unwrap();
+        fs.write_atomic(&path, b"content").unwrap();
+        let err = create_file(&fs, &path).unwrap_err();
+        assert!(matches!(err, CreateError::AlreadyExists(_)));
+    }
+}

--- a/crates/progest-core/src/delete.rs
+++ b/crates/progest-core/src/delete.rs
@@ -68,6 +68,44 @@ pub struct DeletePreview {
     pub has_sidecar: bool,
 }
 
+/// Move a directory to the OS trash, removing index entries for any
+/// files that were inside it.
+pub fn apply_delete_dir(
+    index: &dyn Index,
+    project_root: &Path,
+    path: &ProjectPath,
+) -> Result<DeleteOutcome, DeleteError> {
+    let abs = project_root.join(path.as_str());
+    if !abs.is_dir() {
+        return Err(DeleteError::NotIndexed { path: path.clone() });
+    }
+
+    let prefix = format!("{}/", path.as_str());
+    let indexed_files = index
+        .list_files()
+        .map_err(|e| DeleteError::Index(e.to_string()))?;
+    let mut first_id = None;
+    for row in &indexed_files {
+        if row.path.as_str().starts_with(&prefix) {
+            if first_id.is_none() {
+                first_id = Some(row.file_id);
+            }
+            let _ = index.delete_file(&row.file_id);
+        }
+    }
+
+    trash::delete(&abs).map_err(|e| DeleteError::Trash {
+        path: path.as_str().to_owned(),
+        message: e.to_string(),
+    })?;
+
+    Ok(DeleteOutcome {
+        path: path.clone(),
+        file_id: first_id.unwrap_or_else(FileId::new_v7),
+        sidecar_trashed: false,
+    })
+}
+
 /// Move the file (and its `.meta` sidecar if present) to the OS trash,
 /// then remove the index entry.
 pub fn apply_delete(

--- a/crates/progest-core/src/lib.rs
+++ b/crates/progest-core/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod accepts;
 pub mod ai;
+pub mod create;
 pub mod delete;
 pub mod fs;
 pub mod history;

--- a/crates/progest-tauri/src/crud_commands.rs
+++ b/crates/progest-tauri/src/crud_commands.rs
@@ -1,0 +1,193 @@
+//! IPC commands for file/directory CRUD (create, rename, move).
+
+use progest_core::create::{create_dir, create_file};
+use progest_core::fs::{FileSystem, ProjectPath};
+use progest_core::index::Index;
+use progest_core::naming::FillMode;
+use progest_core::naming::types::{NameCandidate, Segment};
+use progest_core::rename;
+use progest_core::rename::apply::Rename;
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use crate::commands::no_project_error;
+use crate::state::AppState;
+
+// ── Create ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateOutcomeWire {
+    pub path: String,
+    pub kind: String,
+}
+
+#[tauri::command]
+pub async fn fs_create_dir(path: String, app: AppHandle) -> Result<CreateOutcomeWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let project_path =
+            ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
+        let outcome = create_dir(&ctx.fs, &project_path).map_err(|e| format!("{e}"))?;
+
+        Ok(CreateOutcomeWire {
+            path: outcome.path.as_str().to_owned(),
+            kind: outcome.kind.to_owned(),
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
+pub async fn fs_create_file(path: String, app: AppHandle) -> Result<CreateOutcomeWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let project_path =
+            ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
+        let outcome = create_file(&ctx.fs, &project_path).map_err(|e| format!("{e}"))?;
+
+        Ok(CreateOutcomeWire {
+            path: outcome.path.as_str().to_owned(),
+            kind: outcome.kind.to_owned(),
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+// ── Rename ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RenameOutcomeWire {
+    pub from: String,
+    pub to: String,
+}
+
+fn name_candidate_from_basename(basename: &str) -> NameCandidate {
+    let (stem, ext) = match basename.rsplit_once('.') {
+        Some((s, e)) => (s.to_string(), Some(e.to_string())),
+        None => (basename.to_string(), None),
+    };
+    NameCandidate {
+        segments: vec![Segment::Literal(stem)],
+        ext,
+    }
+}
+
+/// Rename a single file or directory.
+#[tauri::command]
+pub async fn fs_rename(
+    from: String,
+    new_name: String,
+    app: AppHandle,
+) -> Result<RenameOutcomeWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let from_path =
+            ProjectPath::new(&from).map_err(|e| format!("invalid path `{from}`: {e}"))?;
+
+        let candidate = name_candidate_from_basename(&new_name);
+        let request = rename::RenameRequest::new(from_path.clone(), candidate);
+
+        let preview = rename::build_preview(&[request], &FillMode::Skip, &ctx.fs)
+            .map_err(|e| format!("preview: {e}"))?;
+
+        if !preview.is_clean() {
+            let msgs: Vec<String> = preview
+                .conflicting_ops()
+                .flat_map(|op| op.conflicts.iter().map(|c| c.message.clone()))
+                .collect();
+            return Err(format!("conflicts: {}", msgs.join("; ")));
+        }
+
+        let driver = Rename::new_without_history(&ctx.fs, &ctx.index);
+        let outcome = driver.apply(&preview).map_err(|e| format!("apply: {e}"))?;
+
+        let to_path = outcome
+            .applied
+            .first()
+            .map(|op| op.to.as_str().to_owned())
+            .unwrap_or_default();
+
+        Ok(RenameOutcomeWire {
+            from: from_path.as_str().to_owned(),
+            to: to_path,
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+// ── Move ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MoveOutcomeWire {
+    pub from: String,
+    pub to: String,
+}
+
+/// Move a file or directory to a different parent directory.
+#[tauri::command]
+pub async fn fs_move(
+    path: String,
+    dest_dir: String,
+    app: AppHandle,
+) -> Result<MoveOutcomeWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let from_path =
+            ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
+        let basename = from_path
+            .file_name()
+            .ok_or_else(|| "cannot move project root".to_string())?;
+
+        let new_path_str = if dest_dir.is_empty() {
+            basename.to_string()
+        } else {
+            format!("{dest_dir}/{basename}")
+        };
+
+        if from_path.as_str() == new_path_str {
+            return Err("source and destination are the same".into());
+        }
+
+        let to_path =
+            ProjectPath::new(&new_path_str).map_err(|e| format!("invalid destination: {e}"))?;
+        ctx.fs
+            .rename(&from_path, &to_path)
+            .map_err(|e| format!("move failed: {e}"))?;
+
+        // Move the .meta sidecar if it exists.
+        if let (Ok(from_meta), Ok(to_meta)) = (
+            progest_core::meta::sidecar_path(&from_path),
+            progest_core::meta::sidecar_path(&to_path),
+        ) && ctx.fs.exists(&from_meta)
+        {
+            let _ = ctx.fs.rename(&from_meta, &to_meta);
+        }
+
+        // Update index: delete old path, reconcile will pick up new path.
+        if let Ok(Some(row)) = ctx.index.get_file_by_path(&from_path) {
+            let _ = ctx.index.delete_file(&row.file_id);
+        }
+
+        Ok(MoveOutcomeWire {
+            from: from_path.as_str().to_owned(),
+            to: to_path.as_str().to_owned(),
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}

--- a/crates/progest-tauri/src/crud_commands.rs
+++ b/crates/progest-tauri/src/crud_commands.rs
@@ -2,7 +2,7 @@
 
 use progest_core::create::{create_dir, create_file};
 use progest_core::fs::{FileSystem, ProjectPath};
-use progest_core::index::Index;
+use progest_core::index::{Index, SearchProjection};
 use progest_core::meta::StdMetaStore;
 use progest_core::naming::FillMode;
 use progest_core::naming::types::{NameCandidate, Segment};
@@ -125,6 +125,25 @@ pub async fn fs_rename(
             .first()
             .map(|op| op.to.as_str().to_owned())
             .unwrap_or_default();
+
+        // Update the index name/ext columns so FlatView shows the new
+        // name immediately (Rename::apply updates path but not name).
+        if let Some(op) = outcome.applied.first()
+            && let Ok(Some(row)) = ctx.index.get_file_by_path(&op.to)
+        {
+            let name = op.to.file_name().map(str::to_string);
+            let ext = op.to.extension().map(str::to_ascii_lowercase);
+            let _ = ctx.index.set_search_projection(
+                &row.file_id,
+                &SearchProjection {
+                    name,
+                    ext,
+                    notes: None,
+                    updated_at: None,
+                    is_orphan: false,
+                },
+            );
+        }
 
         Ok(RenameOutcomeWire {
             from: from_path.as_str().to_owned(),

--- a/crates/progest-tauri/src/crud_commands.rs
+++ b/crates/progest-tauri/src/crud_commands.rs
@@ -3,8 +3,10 @@
 use progest_core::create::{create_dir, create_file};
 use progest_core::fs::{FileSystem, ProjectPath};
 use progest_core::index::Index;
+use progest_core::meta::StdMetaStore;
 use progest_core::naming::FillMode;
 use progest_core::naming::types::{NameCandidate, Segment};
+use progest_core::reconcile::Reconciler;
 use progest_core::rename;
 use progest_core::rename::apply::Rename;
 use serde::Serialize;
@@ -51,6 +53,12 @@ pub async fn fs_create_file(path: String, app: AppHandle) -> Result<CreateOutcom
         let project_path =
             ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
         let outcome = create_file(&ctx.fs, &project_path).map_err(|e| format!("{e}"))?;
+
+        // Run a quick reconcile so the new file gets a .meta sidecar
+        // and an index entry immediately.
+        let meta_store = StdMetaStore::new(ctx.fs.clone());
+        let reconciler = Reconciler::new(&ctx.fs, &meta_store, &ctx.index);
+        let _ = reconciler.full_scan();
 
         Ok(CreateOutcomeWire {
             path: outcome.path.as_str().to_owned(),

--- a/crates/progest-tauri/src/delete_commands.rs
+++ b/crates/progest-tauri/src/delete_commands.rs
@@ -1,6 +1,6 @@
 //! IPC commands for file deletion (OS trash).
 
-use progest_core::delete::{apply_delete, preview_delete};
+use progest_core::delete::{apply_delete, apply_delete_dir, preview_delete};
 use progest_core::fs::ProjectPath;
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
@@ -58,6 +58,28 @@ pub async fn file_delete_apply(path: String, app: AppHandle) -> Result<DeleteOut
             ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
         let outcome =
             apply_delete(&ctx.index, ctx.root.root(), &project_path).map_err(|e| format!("{e}"))?;
+
+        Ok(DeleteOutcomeWire {
+            path: outcome.path.as_str().to_owned(),
+            file_id: outcome.file_id.to_string(),
+            sidecar_trashed: outcome.sidecar_trashed,
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
+pub async fn dir_delete_apply(path: String, app: AppHandle) -> Result<DeleteOutcomeWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let project_path =
+            ProjectPath::new(&path).map_err(|e| format!("invalid path `{path}`: {e}"))?;
+        let outcome = apply_delete_dir(&ctx.index, ctx.root.root(), &project_path)
+            .map_err(|e| format!("{e}"))?;
 
         Ok(DeleteOutcomeWire {
             path: outcome.path.as_str().to_owned(),

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -7,6 +7,7 @@
 mod accepts_commands;
 mod ai_commands;
 mod commands;
+mod crud_commands;
 mod delete_commands;
 mod file_inspector_commands;
 mod import_commands;
@@ -86,6 +87,10 @@ pub fn run() {
             import_commands::import_preview,
             import_commands::import_apply,
             thumbnail_commands::thumbnail_paths,
+            crud_commands::fs_create_dir,
+            crud_commands::fs_create_file,
+            crud_commands::fs_rename,
+            crud_commands::fs_move,
             delete_commands::file_delete_preview,
             delete_commands::file_delete_apply,
             ai_commands::ai_suggest,

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             crud_commands::fs_move,
             delete_commands::file_delete_preview,
             delete_commands::file_delete_apply,
+            delete_commands::dir_delete_apply,
             ai_commands::ai_suggest,
             ai_commands::ai_apply_rename,
             ai_commands::ai_set_key,


### PR DESCRIPTION
## Summary

ファイル・ディレクトリの Create / Rename 操作と、TreeView のコンテキストメニュー拡充。

### Core 層
- `core::create` モジュール — `create_file()` / `create_dir()` (存在チェック + 親ディレクトリ自動作成 + 5 unit test)

### Tauri IPC
- `fs_create_dir` / `fs_create_file` — async + spawn_blocking
- `fs_rename` — core::rename の preview/apply パイプライン経由（atomic rename + .meta sidecar 同期）
- `fs_move` — 直接 fs::rename + sidecar 移動 + index 更新

### TreeView コンテキストメニュー
- **ディレクトリ**: New File / New Folder / Rename / Move to Trash
- **ファイル**: Rename / Move to Trash
- ルートディレクトリは Rename/Delete 不可

### インライン編集
- `InlineInput` コンポーネント（Enter 確定 / Esc キャンセル / blur でコミット）
- Rename: ファイル名が入力フィールドに切り替わり、stem のみ選択状態
- Create: 対象ディレクトリの先頭に空の入力行が挿入される

### コマンドパレット
- `>New file…` / `>New folder…` コマンド追加（File グループ）
- `progest:create` カスタムイベント経由で TreeView の現在選択ディレクトリに作成

### 含まれないもの（後続 PR）
- TreeView 内 DnD 移動（別 Issue に分離）
- FlatView からのリネーム
- 命名規則チェック付きリネーム（警告ダイアログ）

## Test plan

- [x] core::create 5 unit test pass
- [x] mise run check green (Rust + TS)
- [ ] TreeView でフォルダ右クリック → New File → 名前入力 → Enter で作成確認
- [ ] TreeView でファイル右クリック → Rename → 名前変更 → Enter で確認
- [ ] コマンドパレット `>New file` / `>New folder` で作成確認
- [ ] Esc でキャンセルされることを確認
- [ ] 既存名で作成 → エラー toast 確認

Closes #93 (Create + Rename 部分。DnD Move は別 Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)