### PR TITLE
fix: prevent text overflow in palette, TreeView, GridView, and delete dialog

### DIFF
--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -399,10 +399,10 @@ function SearchBody(props: {
     <CommandGroup heading={`${response.hits.length} hit${response.hits.length === 1 ? "" : "s"}`}>
       {response.hits.map((hit) => (
         <CommandItem key={hit.file_id} value={hit.file_id} onSelect={() => onPick(hit)}>
-          <span className="truncate font-mono">{hit.path}</span>
-          <ViolationBadges counts={hit.violations} />
+          <span className="min-w-0 flex-1 truncate font-mono">{hit.path}</span>
+          <ViolationBadges counts={hit.violations} className="shrink-0" />
           {hit.tags.length > 0 ? (
-            <CommandShortcut>
+            <CommandShortcut className="shrink-0">
               <span className="opacity-70">{hit.tags.map((t) => `#${t}`).join(" ")}</span>
             </CommandShortcut>
           ) : null}

--- a/app/src/components/file-context-menu.tsx
+++ b/app/src/components/file-context-menu.tsx
@@ -165,7 +165,9 @@ export function FileContextMenu(props: FileContextMenuProps) {
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Rename</DialogTitle>
-            <DialogDescription>Enter a new name for {filename}.</DialogDescription>
+            <DialogDescription className="truncate">
+              Enter a new name for {filename}.
+            </DialogDescription>
           </DialogHeader>
           <Input
             ref={renameInputRef}
@@ -207,7 +209,7 @@ export function FileContextMenu(props: FileContextMenuProps) {
               This will move the file to the OS trash. You can restore it from the trash later.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-0.5 rounded border bg-muted/30 p-2 font-mono text-xs">
+          <div className="space-y-0.5 overflow-hidden rounded border bg-muted/30 p-2 font-mono text-xs">
             <div className="truncate">{filename}</div>
             {preview?.has_sidecar ? (
               <div className="text-muted-foreground">+ .meta sidecar</div>

--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -575,7 +575,7 @@ function HitGrid(props: {
           <FileContextMenu key={hit.file_id} path={hit.path}>
             <button
               type="button"
-              className="flex flex-col gap-1 rounded-md border p-2 text-left hover:bg-accent"
+              className="flex min-w-0 flex-col gap-1 overflow-hidden rounded-md border p-2 text-left hover:bg-accent"
               onClick={() => props.onPick?.(hit)}
             >
               <div className="flex w-full h-full aspect-square items-center justify-center rounded bg-muted/40 overflow-hidden">
@@ -591,10 +591,10 @@ function HitGrid(props: {
                   <FileIcon className="size-8 opacity-50" />
                 )}
               </div>
-              <div className="truncate text-xs font-mono" title={hit.path}>
+              <div className="w-full min-w-0 truncate text-xs font-mono" title={hit.path}>
                 {hit.name ?? hit.path.split("/").pop()}
               </div>
-              <div className="flex items-center justify-between text-[0.625rem] text-muted-foreground">
+              <div className="flex w-full min-w-0 items-center justify-between text-[0.625rem] text-muted-foreground">
                 <span>{hit.kind}</span>
                 <ViolationBadges counts={hit.violations} />
               </div>

--- a/app/src/components/tree-view.tsx
+++ b/app/src/components/tree-view.tsx
@@ -538,11 +538,11 @@ function FileNode(props: {
               selectStem
             />
           ) : (
-            <span className="truncate">{entry.name}</span>
+            <span className="min-w-0 truncate">{entry.name}</span>
           )}
           {!isRenaming && file ? <ViolationDots counts={file.violations} /> : null}
           {!isRenaming && file && file.tags.length > 0 ? (
-            <span className="ml-auto text-[0.625rem] text-muted-foreground">
+            <span className="ml-auto min-w-0 shrink truncate text-[0.625rem] text-muted-foreground">
               {file.tags.map((t) => `#${t}`).join(" ")}
             </span>
           ) : null}


### PR DESCRIPTION
## Summary
- **#81** コマンドパレットのバッジ行ふぞろい — path に `min-w-0 flex-1`、badges/tags に `shrink-0` を追加し位置を統一
- **#82** TreeView で Tag 多数時に名前・アイコンが潰れる — name に `min-w-0`、tags に `truncate shrink` を追加
- **GridView** 長い名前がカード幅を超えてはみ出す — card の button と子要素に `w-full min-w-0` を追加し truncate を正しく機能させる
- **MoveToTrash / Rename ダイアログ** 長い名前で UI 要素がはみ出す — filename コンテナに `overflow-hidden`、Rename description に `truncate` を追加

Closes #81
Closes #82

## Test plan
- [ ] コマンドパレットで violation バッジ付きの検索結果を表示し、バッジ位置が行ごとに揃っていることを確認
- [ ] TreeView でタグが多数付いたファイルを表示し、名前とアイコンが潰れずタグ側が省略されることを確認
- [ ] GridView で長い名前のファイルを表示し、サムネ幅で `...` 付き truncate されることを確認
- [ ] 長い名前のファイルを右クリック → Move to Trash で、ダイアログが崩れないことを確認
- [ ] 長い名前のファイルを右クリック → Rename で、ダイアログが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)