### PR TITLE
feat: Filename column + sort for ListView / GridView

### DIFF
--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -58,7 +58,8 @@ const COLUMN_VISIBILITY_KEY = "progest:flatview-columns";
 const SORTING_KEY = "progest:flatview-sorting";
 
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
-  path: true,
+  filename: true,
+  path: false,
   tags: true,
   violations: true,
   kind: false,
@@ -477,10 +478,16 @@ function sortHits(hits: RichSearchHit[], sorting: SortingState): RichSearchHit[]
   return desc ? sorted.toReversed() : sorted;
 }
 
+function hitBasename(h: RichSearchHit): string {
+  return h.name ?? h.path.split("/").pop() ?? h.path;
+}
+
 function compareHits(a: RichSearchHit, b: RichSearchHit, col: HitsColumnId): number {
   switch (col) {
     case "path":
       return a.path.localeCompare(b.path);
+    case "filename":
+      return hitBasename(a).localeCompare(hitBasename(b));
     case "tags":
       return a.tags.join(" ").localeCompare(b.tags.join(" "));
     case "violations": {
@@ -497,12 +504,13 @@ function compareHits(a: RichSearchHit, b: RichSearchHit, col: HitsColumnId): num
 
 const SORT_LABELS: Record<HitsColumnId, string> = {
   path: "Path",
+  filename: "Filename",
   tags: "Tags",
   violations: "Violations",
   kind: "Kind",
   ext: "Extension",
 };
-const SORT_KEYS: HitsColumnId[] = ["path", "tags", "violations", "kind", "ext"];
+const SORT_KEYS: HitsColumnId[] = ["path", "filename", "tags", "violations", "kind", "ext"];
 const UNSORTED = "__unsorted__";
 
 /** Toolbar control for grid mode — pairs a column Select with an

--- a/app/src/components/hits-data-table.tsx
+++ b/app/src/components/hits-data-table.tsx
@@ -30,8 +30,12 @@ import { ViolationBadges } from "@/components/violation-badges";
 import type { RichSearchHit } from "@/lib/ipc";
 import { cn } from "@/lib/utils";
 
+function basename(hit: RichSearchHit): string {
+  return hit.name ?? hit.path.split("/").pop() ?? hit.path;
+}
+
 /** Column ids exposed for sort persistence. Keep stable. */
-export type HitsColumnId = "path" | "tags" | "violations" | "kind" | "ext";
+export type HitsColumnId = "path" | "filename" | "tags" | "violations" | "kind" | "ext";
 
 /**
  * TanStack-table-backed list view for `RichSearchHit`s.
@@ -55,15 +59,22 @@ export function HitsDataTable(props: {
   const columns = React.useMemo<ColumnDef<RichSearchHit>[]>(
     () => [
       {
-        id: "path",
-        accessorKey: "path",
-        header: ({ column }) => <SortHeader column={column}>Path</SortHeader>,
+        id: "filename",
+        accessorFn: basename,
+        header: ({ column }) => <SortHeader column={column}>Filename</SortHeader>,
         cell: ({ row }) => (
           <div className="flex items-center gap-2 truncate">
             <FileIcon className="size-3.5 shrink-0 opacity-60" />
-            <span className="truncate font-mono">{row.original.path}</span>
+            <span className="truncate font-mono">{basename(row.original)}</span>
           </div>
         ),
+        sortingFn: (a, b) => basename(a.original).localeCompare(basename(b.original)),
+      },
+      {
+        id: "path",
+        accessorKey: "path",
+        header: ({ column }) => <SortHeader column={column}>Path</SortHeader>,
+        cell: ({ row }) => <span className="truncate font-mono">{row.original.path}</span>,
         sortingFn: (a, b) => a.original.path.localeCompare(b.original.path),
       },
       {
@@ -190,15 +201,13 @@ export function ColumnVisibilityMenu(props: {
 }) {
   const labels: Record<HitsColumnId, string> = {
     path: "Path",
+    filename: "Filename",
     tags: "Tags",
     violations: "Violations",
     kind: "Kind",
     ext: "Extension",
   };
-  const ids: HitsColumnId[] = ["path", "tags", "violations", "kind", "ext"];
-  // `path` always stays visible — there's nothing useful to show
-  // without it. Keep it in the menu but disabled so the user
-  // understands the column exists.
+  const ids: HitsColumnId[] = ["filename", "path", "tags", "violations", "kind", "ext"];
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -213,7 +222,7 @@ export function ColumnVisibilityMenu(props: {
             <DropdownMenuCheckboxItem
               key={id}
               checked={visible}
-              disabled={id === "path"}
+              disabled={id === "filename"}
               onCheckedChange={(next) => {
                 props.onColumnVisibilityChange({
                   ...props.columnVisibility,


### PR DESCRIPTION
## Summary
- **#91** ListView に Filename（ベースネーム）列を追加し、先頭列・デフォルト表示・常時表示に設定
- **#90** GridView の sort に Filename を追加、sortHits にも basename 比較を追加
- Path 列はデフォルト非表示に降格（Columns メニューで切替可能）

Closes #91
Closes #90

## Test plan
- [ ] ListView で Filename 列が先頭に表示され、ベースネームのみ表示されることを確認
- [ ] Columns メニューで Filename が常時表示（disabled）、Path がトグル可能なことを確認
- [ ] Filename 列ヘッダーをクリックしてソートが asc/desc で動作することを確認
- [ ] GridView の Sort ドロップダウンに Filename が表示され、ソートが効くことを確認
- [ ] Path 列を有効にして表示した場合、フルパスが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)