### PR TITLE
feat: ListView column resize support

### DIFF
--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import type { SortingState, VisibilityState } from "@tanstack/react-table";
+import type { ColumnSizingState, SortingState, VisibilityState } from "@tanstack/react-table";
 
 import {
   IpcError,
@@ -55,6 +55,7 @@ import {
 
 const DEBOUNCE_MS = 200;
 const COLUMN_VISIBILITY_KEY = "progest:flatview-columns";
+const COLUMN_SIZING_KEY = "progest:flatview-column-sizing";
 const SORTING_KEY = "progest:flatview-sorting";
 
 const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
@@ -87,6 +88,16 @@ function loadSorting(): SortingState {
   }
 }
 
+function loadColumnSizing(): ColumnSizingState {
+  try {
+    const raw = localStorage.getItem(COLUMN_SIZING_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as ColumnSizingState;
+  } catch {
+    return {};
+  }
+}
+
 export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   const { project, refreshTick, flatViewSubmission } = useProject();
   const reportSummary = useReportFlatView();
@@ -106,12 +117,18 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>(() =>
     loadColumnVisibility(),
   );
+  const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>(() =>
+    loadColumnSizing(),
+  );
   React.useEffect(() => {
     localStorage.setItem(SORTING_KEY, JSON.stringify(sorting));
   }, [sorting]);
   React.useEffect(() => {
     localStorage.setItem(COLUMN_VISIBILITY_KEY, JSON.stringify(columnVisibility));
   }, [columnVisibility]);
+  React.useEffect(() => {
+    localStorage.setItem(COLUMN_SIZING_KEY, JSON.stringify(columnSizing));
+  }, [columnSizing]);
 
   // Apply the sort to the hit list once. Both render paths (DataTable
   // and grid) consume `sortedHits`; the DataTable still receives
@@ -382,6 +399,8 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
               onSortingChange={setSorting}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
+              columnSizing={columnSizing}
+              onColumnSizingChange={setColumnSizing}
             />
           ) : (
             <HitGrid hits={sortedHits} onPick={props.onPickHit} thumbUrls={thumbUrls} />

--- a/app/src/components/hits-data-table.tsx
+++ b/app/src/components/hits-data-table.tsx
@@ -5,6 +5,7 @@ import {
   getSortedRowModel,
   useReactTable,
   type ColumnDef,
+  type ColumnSizingState,
   type SortingState,
   type VisibilityState,
 } from "@tanstack/react-table";
@@ -55,6 +56,8 @@ export function HitsDataTable(props: {
   onSortingChange: (next: SortingState) => void;
   columnVisibility: VisibilityState;
   onColumnVisibilityChange: (next: VisibilityState) => void;
+  columnSizing: ColumnSizingState;
+  onColumnSizingChange: (next: ColumnSizingState) => void;
 }) {
   const columns = React.useMemo<ColumnDef<RichSearchHit>[]>(
     () => [
@@ -69,6 +72,8 @@ export function HitsDataTable(props: {
           </div>
         ),
         sortingFn: (a, b) => basename(a.original).localeCompare(basename(b.original)),
+        size: 240,
+        minSize: 100,
       },
       {
         id: "path",
@@ -76,11 +81,11 @@ export function HitsDataTable(props: {
         header: ({ column }) => <SortHeader column={column}>Path</SortHeader>,
         cell: ({ row }) => <span className="truncate font-mono">{row.original.path}</span>,
         sortingFn: (a, b) => a.original.path.localeCompare(b.original.path),
+        size: 300,
+        minSize: 100,
       },
       {
         id: "tags",
-        // Sort by joined-tag string so users get a deterministic A-Z
-        // grouping when the tag column is the active sort.
         accessorFn: (h) => h.tags.join(" "),
         header: ({ column }) => <SortHeader column={column}>Tags</SortHeader>,
         cell: ({ row }) =>
@@ -92,10 +97,11 @@ export function HitsDataTable(props: {
             <span className="text-muted-foreground">—</span>
           ),
         sortingFn: (a, b) => a.original.tags.join(" ").localeCompare(b.original.tags.join(" ")),
+        size: 160,
+        minSize: 60,
       },
       {
         id: "violations",
-        // Sort by total violation count (naming + placement + sequence).
         accessorFn: (h) => h.violations.naming + h.violations.placement + h.violations.sequence,
         header: ({ column }) => <SortHeader column={column}>Violations</SortHeader>,
         cell: ({ row }) => {
@@ -105,12 +111,16 @@ export function HitsDataTable(props: {
           }
           return <ViolationBadges counts={v} className="" />;
         },
+        size: 120,
+        minSize: 60,
       },
       {
         id: "kind",
         accessorKey: "kind",
         header: ({ column }) => <SortHeader column={column}>Kind</SortHeader>,
         cell: ({ row }) => <span className="text-muted-foreground">{row.original.kind}</span>,
+        size: 80,
+        minSize: 50,
       },
       {
         id: "ext",
@@ -120,6 +130,8 @@ export function HitsDataTable(props: {
           <span className="font-mono text-muted-foreground">{row.original.ext ?? ""}</span>
         ),
         sortingFn: (a, b) => (a.original.ext ?? "").localeCompare(b.original.ext ?? ""),
+        size: 70,
+        minSize: 40,
       },
     ],
     [],
@@ -131,7 +143,10 @@ export function HitsDataTable(props: {
     state: {
       sorting: props.sorting,
       columnVisibility: props.columnVisibility,
+      columnSizing: props.columnSizing,
     },
+    columnResizeMode: "onChange",
+    enableColumnResizing: true,
     onSortingChange: (updater) => {
       const next = typeof updater === "function" ? updater(props.sorting) : updater;
       props.onSortingChange(next);
@@ -140,20 +155,40 @@ export function HitsDataTable(props: {
       const next = typeof updater === "function" ? updater(props.columnVisibility) : updater;
       props.onColumnVisibilityChange(next);
     },
+    onColumnSizingChange: (updater) => {
+      const next = typeof updater === "function" ? updater(props.columnSizing) : updater;
+      props.onColumnSizingChange(next);
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
 
   return (
-    <Table>
+    <Table style={{ width: table.getTotalSize(), tableLayout: "fixed" }}>
       <TableHeader>
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
-              <TableHead key={header.id} className="text-[0.625rem] uppercase tracking-wide">
+              <TableHead
+                key={header.id}
+                className="relative text-[0.625rem] uppercase tracking-wide"
+                style={{ width: header.getSize() }}
+              >
                 {header.isPlaceholder
                   ? null
                   : flexRender(header.column.columnDef.header, header.getContext())}
+                {header.column.getCanResize() ? (
+                  <div
+                    onMouseDown={header.getResizeHandler()}
+                    onTouchStart={header.getResizeHandler()}
+                    className={cn(
+                      "absolute right-0 top-0 h-full w-1 cursor-col-resize select-none touch-none",
+                      header.column.getIsResizing()
+                        ? "bg-primary"
+                        : "bg-transparent hover:bg-border",
+                    )}
+                  />
+                ) : null}
               </TableHead>
             ))}
           </TableRow>
@@ -177,7 +212,11 @@ export function HitsDataTable(props: {
             >
               <TableRow className="cursor-pointer" onClick={() => props.onPick?.(row.original)}>
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} className="text-xs">
+                  <TableCell
+                    key={cell.id}
+                    className="overflow-hidden text-xs"
+                    style={{ width: cell.column.getSize() }}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}


### PR DESCRIPTION
## Summary
- TanStack Table の `columnResizeMode: "onChange"` を有効化
- 各列ヘッダー右端にドラッグ可能なリサイズハンドルを追加
- 列サイズを localStorage に永続化
- `table-layout: fixed` で列幅を厳密に制御

Closes #129

## Test plan
- [ ] ListView のヘッダー右端にマウスを合わせるとリサイズカーソルが表示されること
- [ ] ドラッグで列幅を変更できること
- [ ] リサイズした列幅がページリロード後も保持されること
- [ ] 全列を表示した状態でもリサイズが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)