### PR TITLE
feat: tag autocomplete with existing project tags

### DIFF
--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -11,6 +11,7 @@ import {
   notesRead,
   notesWrite,
   tagAdd,
+  tagListAll,
   tagRemove,
   type AiConfigResponse,
   type AiSuggestionWire,
@@ -462,6 +463,25 @@ function TagsSection(props: {
   const [error, setError] = React.useState<string | null>(null);
   const [busy, setBusy] = React.useState(false);
   const pendingAdd = React.useRef<string | null>(null);
+  const [allTags, setAllTags] = React.useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = React.useState(false);
+  const [selectedIdx, setSelectedIdx] = React.useState(-1);
+
+  React.useEffect(() => {
+    tagListAll()
+      .then(setAllTags)
+      .catch(() => {});
+  }, [hit.file_id]);
+
+  const suggestions = React.useMemo(() => {
+    if (draft.trim().length === 0) return [];
+    const lower = draft.toLowerCase();
+    return allTags.filter((t) => t.toLowerCase().includes(lower) && !tags.includes(t)).slice(0, 8);
+  }, [draft, allTags, tags]);
+
+  React.useEffect(() => {
+    setSelectedIdx(-1);
+  }, [suggestions]);
 
   React.useEffect(() => {
     setTags(hit.tags);
@@ -470,14 +490,15 @@ function TagsSection(props: {
     pendingAdd.current = null;
   }, [hit.file_id, hit.path, hit.tags]);
 
-  const submitDraft = async () => {
-    const tag = draft.trim();
+  const submitTag = async (value: string) => {
+    const tag = value.trim();
     if (tag.length === 0 || tags.includes(tag) || pendingAdd.current === tag || disabled) {
       if (tag.length === 0 || tags.includes(tag)) setDraft("");
       return;
     }
     pendingAdd.current = tag;
     setDraft("");
+    setShowSuggestions(false);
     setBusy(true);
     setError(null);
     try {
@@ -488,6 +509,7 @@ function TagsSection(props: {
         next.sort((a, b) => a.localeCompare(b));
         return next;
       });
+      if (!allTags.includes(tag)) setAllTags((prev) => [...prev, tag].sort());
       bumpRefresh();
     } catch (e) {
       setError(e instanceof IpcError ? e.raw : String(e));
@@ -496,6 +518,8 @@ function TagsSection(props: {
       setBusy(false);
     }
   };
+
+  const submitDraft = () => submitTag(draft);
 
   const removeTag = async (tag: string) => {
     if (disabled) return;
@@ -513,9 +537,24 @@ function TagsSection(props: {
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "ArrowDown" && suggestions.length > 0) {
       e.preventDefault();
-      void submitDraft();
+      setSelectedIdx((i) => (i + 1) % suggestions.length);
+      setShowSuggestions(true);
+    } else if (e.key === "ArrowUp" && suggestions.length > 0) {
+      e.preventDefault();
+      setSelectedIdx((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+      setShowSuggestions(true);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (selectedIdx >= 0 && selectedIdx < suggestions.length) {
+        void submitTag(suggestions[selectedIdx]!);
+      } else {
+        void submitDraft();
+      }
+    } else if (e.key === "Escape" && showSuggestions) {
+      e.preventDefault();
+      setShowSuggestions(false);
     } else if (e.key === "Backspace" && draft.length === 0 && tags.length > 0) {
       e.preventDefault();
       void removeTag(tags[tags.length - 1]!);
@@ -555,15 +594,45 @@ function TagsSection(props: {
             </button>
           </span>
         ))}
-        <Input
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={onKeyDown}
-          onBlur={() => void submitDraft()}
-          disabled={disabled || busy}
-          placeholder={tags.length === 0 ? "add tag…" : ""}
-          className="h-6 min-w-24 flex-1 border-0 bg-transparent px-1 shadow-none focus-visible:ring-0 dark:bg-transparent"
-        />
+        <div className="relative min-w-24 flex-1">
+          <Input
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setShowSuggestions(true);
+            }}
+            onKeyDown={onKeyDown}
+            onFocus={() => setShowSuggestions(true)}
+            onBlur={() => {
+              setTimeout(() => setShowSuggestions(false), 150);
+              void submitDraft();
+            }}
+            disabled={disabled || busy}
+            placeholder={tags.length === 0 ? "add tag…" : ""}
+            className="h-6 w-full border-0 bg-transparent px-1 shadow-none focus-visible:ring-0 dark:bg-transparent"
+          />
+          {showSuggestions && suggestions.length > 0 ? (
+            <ul className="absolute left-0 top-full z-50 mt-1 max-h-40 w-48 overflow-auto rounded-md border bg-popover py-1 shadow-md">
+              {suggestions.map((s, i) => (
+                <li key={s}>
+                  <button
+                    type="button"
+                    className={cn(
+                      "w-full px-2 py-1 text-left font-mono text-xs hover:bg-accent",
+                      i === selectedIdx && "bg-accent",
+                    )}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      void submitTag(s);
+                    }}
+                  >
+                    #{s}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
         <Button
           type="button"
           variant="ghost"

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -392,6 +392,14 @@ export async function tagRemove(file_id: string, tag: string): Promise<void> {
   }
 }
 
+export async function tagListAll(): Promise<string[]> {
+  try {
+    return await invoke<string[]>("tag_list_all");
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 export async function notesRead(path: string): Promise<NotesReadResponse> {
   try {
     return await invoke<NotesReadResponse>("notes_read", { path });

--- a/crates/progest-tauri/src/file_inspector_commands.rs
+++ b/crates/progest-tauri/src/file_inspector_commands.rs
@@ -61,6 +61,18 @@ pub fn tag_remove(file_id: String, tag: String, state: State<'_, AppState>) -> R
     Ok(())
 }
 
+/// Return every distinct tag in the project, sorted alphabetically.
+/// Used by the inspector's tag autocomplete to suggest existing tags.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub fn tag_list_all(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    let guard = state.project.lock().expect("project mutex poisoned");
+    let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+    ctx.index
+        .list_all_tags()
+        .map_err(|e| format!("list tags: {e}"))
+}
+
 /// Read the `[notes].body` for the file at `path` (project-relative).
 /// Returns an empty body for files that don't have a sidecar yet —
 /// the inspector's textarea starts blank in that case rather than

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -78,6 +78,7 @@ pub fn run() {
             project_init_commands::project_init_existing,
             file_inspector_commands::tag_add,
             file_inspector_commands::tag_remove,
+            file_inspector_commands::tag_list_all,
             file_inspector_commands::notes_read,
             file_inspector_commands::notes_write,
             template_commands::template_export,


### PR DESCRIPTION
## Summary
- `tag_list_all` Tauri コマンド追加（`core::index::list_all_tags()` で全タグ取得）
- タグ入力時にプロジェクト内の既存タグをドロップダウンでサジェスト
- 部分一致フィルタリング、上下キーナビゲーション、Enter/クリックで選択
- 新規追加したタグもローカルのサジェストプールに即反映

Closes #110

## Test plan
- [ ] タグ入力開始でプロジェクト内の既存タグがドロップダウン表示されること
- [ ] 部分一致でフィルタされること（例: "w" → "wip"）
- [ ] 上下キーで選択、Enter で適用されること
- [ ] クリックでも適用されること
- [ ] 既に付いているタグはサジェストから除外されること
- [ ] 新規タグ追加後、次回入力時にサジェストに含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)