### PR TITLE
feat: add under: filter to search DSL

### DIFF
--- a/crates/progest-core/src/search/plan.rs
+++ b/crates/progest-core/src/search/plan.rs
@@ -119,7 +119,7 @@ impl SqlBuilder {
                 self.push_text(glob);
                 "f.name GLOB ?".into()
             }
-            ReservedClause::Path(glob) => {
+            ReservedClause::Path(glob) | ReservedClause::Under(glob) => {
                 self.push_text(glob);
                 "f.path GLOB ?".into()
             }

--- a/crates/progest-core/src/search/validate.rs
+++ b/crates/progest-core/src/search/validate.rs
@@ -103,6 +103,7 @@ pub enum ReservedClause {
     Is(IsValue),
     Name(String),
     Path(String),
+    Under(String),
     Created(InstantRange),
     Updated(InstantRange),
 }
@@ -346,7 +347,7 @@ impl Ctx {
         let key = clause.key.as_str();
         let is_reserved = matches!(
             key,
-            "tag" | "type" | "kind" | "is" | "name" | "path" | "created" | "updated"
+            "tag" | "type" | "kind" | "is" | "name" | "path" | "under" | "created" | "updated"
         );
         let is_custom = !is_reserved && schema.get(key).is_some();
         if !is_reserved && !is_custom {
@@ -505,6 +506,24 @@ impl Ctx {
                     return Some(ValidAtom::AlwaysFalse(format!("invalid_glob:path={raw}")));
                 }
             },
+            "under" => {
+                let pattern = if raw.ends_with("/**") {
+                    raw.to_string()
+                } else {
+                    let trimmed = raw.trim_end_matches('/');
+                    format!("{trimmed}/**")
+                };
+                match validate_glob(&pattern) {
+                    Ok(_) => ReservedClause::Under(pattern),
+                    Err(_) => {
+                        self.warn(Warning::InvalidGlob {
+                            key: "under".into(),
+                            value: raw.into(),
+                        });
+                        return Some(ValidAtom::AlwaysFalse(format!("invalid_glob:under={raw}")));
+                    }
+                }
+            }
             "created" | "updated" => {
                 let count = self.instant_keys_seen.entry(key.to_string()).or_insert(0);
                 *count += 1;

--- a/crates/progest-core/tests/search_golden/10_9_under_filter.toml
+++ b/crates/progest-core/tests/search_golden/10_9_under_filter.toml
@@ -1,0 +1,9 @@
+name = "10.9 under: directory filter"
+query = 'under:assets/shots'
+
+[expected]
+sql_contains = [
+  "f.path GLOB ?",
+]
+text_params = ["assets/shots/**"]
+warning_count = 0


### PR DESCRIPTION
## Summary
- 検索 DSL に `under:` フィルターを追加 — `under:assets/shots` で特定ディレクトリ下のファイルに絞り込み
- バリデーターが `under:dir` → `dir/**` glob パターンに正規化
- プランナーは `f.path GLOB ?` で SQL 生成（`path:` と同じメカニズム）
- ゴールデンテスト追加

Closes #89

## Test plan
- [ ] `under:assets` で assets/ 以下のファイルのみ表示されること
- [ ] `under:assets/shots/` (末尾スラッシュ) でも同様に動作すること
- [ ] `-under:archive` で archive/ 以下を除外できること
- [ ] `under:assets under:shots` (AND) が期待通り動作すること
- [ ] 存在しないディレクトリを指定しても 0 件で正常終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)