### PR TITLE
feat: compact sequence display with collapsible groups in ListView

### DIFF
--- a/app/src/components/flat-view.tsx
+++ b/app/src/components/flat-view.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useDragOut } from "@/lib/use-drag-out";
+import { buildSequenceMap } from "@/lib/sequence-grouping";
 import { ViolationBadges } from "@/components/violation-badges";
 import {
   ColumnVisibilityMenu,
@@ -151,6 +152,8 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
     () => sortHits(response?.hits ?? [], sorting),
     [response, sorting],
   );
+
+  const seqMap = React.useMemo(() => buildSequenceMap(sortedHits), [sortedHits]);
 
   const gridFileIds = React.useMemo(
     () => (display === "grid" ? sortedHits.map((h) => h.file_id).filter(Boolean) : []),
@@ -414,6 +417,7 @@ export function FlatView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
               onColumnVisibilityChange={setColumnVisibility}
               columnSizing={columnSizing}
               onColumnSizingChange={setColumnSizing}
+              sequenceMap={seqMap}
             />
           ) : (
             <HitGrid hits={sortedHits} onPick={props.onPickHit} thumbUrls={thumbUrls} />

--- a/app/src/components/hits-data-table.tsx
+++ b/app/src/components/hits-data-table.tsx
@@ -9,7 +9,15 @@ import {
   type SortingState,
   type VisibilityState,
 } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, FileIcon } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronDown,
+  ChevronRight,
+  FileIcon,
+  Layers,
+} from "lucide-react";
 
 import { FileContextMenu } from "@/components/file-context-menu";
 import {
@@ -30,6 +38,7 @@ import { Button } from "@/components/ui/button";
 import { ViolationBadges } from "@/components/violation-badges";
 import type { RichSearchHit } from "@/lib/ipc";
 import { useDragOut } from "@/lib/use-drag-out";
+import type { SequenceMap } from "@/lib/sequence-grouping";
 import { cn } from "@/lib/utils";
 
 function basename(hit: RichSearchHit): string {
@@ -59,6 +68,7 @@ export function HitsDataTable(props: {
   onColumnVisibilityChange: (next: VisibilityState) => void;
   columnSizing: ColumnSizingState;
   onColumnSizingChange: (next: ColumnSizingState) => void;
+  sequenceMap?: SequenceMap | undefined;
 }) {
   const columns = React.useMemo<ColumnDef<RichSearchHit>[]>(
     () => [
@@ -206,15 +216,12 @@ export function HitsDataTable(props: {
             </TableCell>
           </TableRow>
         ) : (
-          table
-            .getRowModel()
-            .rows.map((row) => (
-              <HitRow
-                key={row.original.file_id || row.original.path}
-                row={row}
-                onPick={props.onPick}
-              />
-            ))
+          <SequenceAwareRows
+            rows={table.getRowModel().rows}
+            onPick={props.onPick}
+            sequenceMap={props.sequenceMap}
+            colCount={table.getAllLeafColumns().length}
+          />
         )}
       </TableBody>
     </Table>
@@ -222,23 +229,27 @@ export function HitsDataTable(props: {
 }
 
 function HitRow(props: {
-  row: ReturnType<ReturnType<typeof useReactTable<RichSearchHit>>["getRowModel"]>["rows"][number];
+  row: RowType;
   onPick: ((hit: RichSearchHit) => void) | undefined;
+  inSequence?: boolean | undefined;
 }) {
   const { row } = props;
   const drag = useDragOut(row.original.path);
   return (
     <FileContextMenu path={row.original.path}>
       <TableRow
-        className="cursor-pointer"
+        className={cn("cursor-pointer", props.inSequence && "bg-muted/20")}
         onClick={() => props.onPick?.(row.original)}
         onMouseDown={drag.onMouseDown}
       >
-        {row.getVisibleCells().map((cell) => (
+        {row.getVisibleCells().map((cell, i) => (
           <TableCell
             key={cell.id}
             className="overflow-hidden text-xs"
-            style={{ width: cell.column.getSize() }}
+            style={{
+              width: cell.column.getSize(),
+              paddingLeft: props.inSequence && i === 0 ? 28 : undefined,
+            }}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </TableCell>
@@ -246,6 +257,85 @@ function HitRow(props: {
       </TableRow>
     </FileContextMenu>
   );
+}
+
+type RowType = ReturnType<
+  ReturnType<typeof useReactTable<RichSearchHit>>["getRowModel"]
+>["rows"][number];
+
+function SequenceAwareRows(props: {
+  rows: RowType[];
+  onPick: ((hit: RichSearchHit) => void) | undefined;
+  sequenceMap?: SequenceMap | undefined;
+  colCount: number;
+}) {
+  const { rows, onPick, sequenceMap, colCount } = props;
+  const [collapsed, setCollapsed] = React.useState<Set<string>>(() => new Set());
+
+  const toggle = React.useCallback((key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  if (!sequenceMap || sequenceMap.sequences.size === 0) {
+    return rows.map((row) => (
+      <HitRow key={row.original.file_id || row.original.path} row={row} onPick={onPick} />
+    ));
+  }
+
+  const rendered: React.ReactNode[] = [];
+  const seenSeqs = new Set<string>();
+
+  for (const row of rows) {
+    const hitId = row.original.file_id || row.original.path;
+    const seqKey = sequenceMap.hitToSeq.get(hitId);
+
+    if (!seqKey) {
+      rendered.push(<HitRow key={hitId} row={row} onPick={onPick} />);
+      continue;
+    }
+
+    if (seenSeqs.has(seqKey)) {
+      if (collapsed.has(seqKey)) continue;
+      rendered.push(<HitRow key={hitId} row={row} onPick={onPick} inSequence />);
+      continue;
+    }
+
+    seenSeqs.add(seqKey);
+    const seq = sequenceMap.sequences.get(seqKey)!;
+    const isCollapsed = collapsed.has(seqKey);
+    rendered.push(
+      <TableRow
+        key={`seq-${seqKey}`}
+        className="cursor-pointer bg-muted/30 hover:bg-muted/50"
+        onClick={() => toggle(seqKey)}
+      >
+        <TableCell colSpan={colCount} className="text-xs">
+          <div className="flex items-center gap-2">
+            {isCollapsed ? (
+              <ChevronRight className="size-3.5 shrink-0" />
+            ) : (
+              <ChevronDown className="size-3.5 shrink-0" />
+            )}
+            <Layers className="size-3.5 shrink-0 opacity-60" />
+            <span className="font-mono">
+              {seq.stemPrefix}[{seq.rangeStart}–{seq.rangeEnd}].{seq.extension}
+            </span>
+            <span className="text-muted-foreground">({seq.count} files)</span>
+          </div>
+        </TableCell>
+      </TableRow>,
+    );
+    if (!isCollapsed) {
+      rendered.push(<HitRow key={hitId} row={row} onPick={onPick} inSequence />);
+    }
+  }
+
+  return rendered;
 }
 
 /**

--- a/app/src/lib/sequence-grouping.ts
+++ b/app/src/lib/sequence-grouping.ts
@@ -1,0 +1,86 @@
+import type { RichSearchHit } from "@/lib/ipc";
+
+export type SequenceInfo = {
+  key: string;
+  stemPrefix: string;
+  extension: string;
+  parentDir: string;
+  rangeStart: number;
+  rangeEnd: number;
+  count: number;
+};
+
+export type SequenceMap = {
+  sequences: Map<string, SequenceInfo>;
+  hitToSeq: Map<string, string>;
+  seqFirstHit: Map<string, string>;
+};
+
+const SEQ_RE = /^(.+?)(\d+)$/;
+
+function parseSeqName(hit: RichSearchHit): {
+  stem: string;
+  number: number;
+  ext: string;
+  parentDir: string;
+} | null {
+  const name = hit.name ?? hit.path.split("/").pop() ?? "";
+  const dotIdx = name.lastIndexOf(".");
+  if (dotIdx <= 0) return null;
+  const base = name.slice(0, dotIdx);
+  const ext = name.slice(dotIdx + 1);
+  const m = SEQ_RE.exec(base);
+  if (!m) return null;
+  const lastSlash = hit.path.lastIndexOf("/");
+  const parentDir = lastSlash >= 0 ? hit.path.slice(0, lastSlash) : "";
+  return { stem: m[1]!, number: Number.parseInt(m[2]!, 10), ext, parentDir };
+}
+
+export function buildSequenceMap(hits: RichSearchHit[], minMembers = 2): SequenceMap {
+  const groups = new Map<
+    string,
+    { stem: string; ext: string; parentDir: string; numbers: number[]; hitIds: string[] }
+  >();
+
+  for (const hit of hits) {
+    const parsed = parseSeqName(hit);
+    if (!parsed) continue;
+    const key = `${parsed.parentDir}\0${parsed.stem}\0${parsed.ext}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        stem: parsed.stem,
+        ext: parsed.ext,
+        parentDir: parsed.parentDir,
+        numbers: [],
+        hitIds: [],
+      };
+      groups.set(key, group);
+    }
+    group.numbers.push(parsed.number);
+    group.hitIds.push(hit.file_id || hit.path);
+  }
+
+  const sequences = new Map<string, SequenceInfo>();
+  const hitToSeq = new Map<string, string>();
+  const seqFirstHit = new Map<string, string>();
+
+  for (const [key, group] of groups) {
+    if (group.hitIds.length < minMembers) continue;
+    sequences.set(key, {
+      key,
+      stemPrefix: group.stem,
+      extension: group.ext,
+      parentDir: group.parentDir,
+      rangeStart: Math.min(...group.numbers),
+      rangeEnd: Math.max(...group.numbers),
+      count: group.hitIds.length,
+    });
+    for (const id of group.hitIds) {
+      hitToSeq.set(id, key);
+    }
+    seqFirstHit.set(key, group.hitIds[0]!);
+  }
+
+  return { sequences, hitToSeq, seqFirstHit };
+}


### PR DESCRIPTION
## Summary
- DataTable 内で連番ファイルを sequence ヘッダー行でグルーピング
- ヘッダー行クリックで展開/折りたたみ切替
- 折りたたみ時はメンバー行を非表示、ヘッダーにファイル数と範囲を表示
- メンバー行は薄い背景色 + インデントで視覚的に区別
- フロントエンドのみの実装（Rust 変更なし）

Closes #108

## Test plan
- [x] 連番ファイル（frame_0001.exr 〜 frame_0010.exr 等）が sequence ヘッダー行でグルーピングされること
- [x] ヘッダー行クリックで展開/折りたたみが切り替わること
- [x] メンバー行がインデント + 薄い背景色で表示されること
- [ ] 連番でないファイルは通常の行として表示されること
- [x] sequence seed で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)