### PR TITLE
feat: application menu (macOS native + shadcn menubar)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FolderOpen, FolderPlus, Sparkles } from "lucide-react";
 
+import { AppMenubar } from "@/components/app-menubar";
 import { CommandPalette } from "@/components/command-palette";
 import { DirectoryInspector } from "@/components/directory-inspector";
 import { DragDropProvider, DropOverlay, useDropZone } from "@/components/drag-drop-overlay";
@@ -37,6 +38,8 @@ import { SettingsProvider, useSettings } from "@/lib/settings-context";
 import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
 import { Toaster } from "@/components/ui/sonner";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
+import { useMenuEvents } from "@/lib/use-menu-events";
 
 import "./App.css";
 
@@ -91,7 +94,7 @@ export function App() {
 }
 
 function Shell() {
-  const { project } = useProject();
+  const { project, openPicker, bumpRefresh, openInitDialog } = useProject();
   const [selection, setSelection] = React.useState<Selection>(null);
   const [pendingConfirm, setPendingConfirm] = React.useState<{
     next: Selection;
@@ -180,6 +183,32 @@ function Shell() {
 
   const selectedDir = selection?.kind === "dir" ? selection.path : "";
 
+  useMenuEvents({
+    "menu:new-project": () => openInitDialog("new"),
+    "menu:open-project": () => void openPicker(),
+    "menu:new-file": () =>
+      window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "file" } })),
+    "menu:new-folder": () =>
+      window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "dir" } })),
+    "menu:settings": () => settings.openSettings(),
+    "menu:settings-app": () => settings.openSettings(),
+    "menu:toggle-tree": () => togglePanel("tree"),
+    "menu:toggle-flat": () => togglePanel("flat"),
+    "menu:toggle-inspector": () => togglePanel("inspector"),
+    "menu:palette": () => window.dispatchEvent(new CustomEvent("progest:toggle-palette")),
+    "menu:rescan": () => bumpRefresh(),
+    "menu:import": () => void pickAndImport(),
+  });
+
+  const pickAndImport = React.useCallback(async () => {
+    const picked = await openFileDialog({ multiple: true });
+    if (!picked || (Array.isArray(picked) && picked.length === 0)) return;
+    const paths = Array.isArray(picked) ? picked : [picked];
+    setImportSources(paths);
+    setImportDest(undefined);
+    setImportOpen(true);
+  }, []);
+
   // --- import via drag & drop -----------------------------------------------
   const [importSources, setImportSources] = React.useState<string[]>([]);
   const [importDest, setImportDest] = React.useState<string | undefined>();
@@ -203,10 +232,30 @@ function Shell() {
     [project],
   );
 
+  const isMac = navigator.platform.includes("Mac");
+  const showShadcnMenu = !isMac || localStorage.getItem("progest:show-menubar") === "true";
+
+  const menuActions = {
+    onNewProject: () => openInitDialog("new"),
+    onOpenProject: () => void openPicker(),
+    onNewFile: () =>
+      window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "file" } })),
+    onNewFolder: () =>
+      window.dispatchEvent(new CustomEvent("progest:create", { detail: { kind: "dir" } })),
+    onImport: () => void pickAndImport(),
+    onSettings: () => settings.openSettings(),
+    onToggleTree: () => togglePanel("tree"),
+    onToggleFlat: () => togglePanel("flat"),
+    onToggleInspector: () => togglePanel("inspector"),
+    onPalette: () => window.dispatchEvent(new CustomEvent("progest:toggle-palette")),
+    onRescan: () => bumpRefresh(),
+  };
+
   return (
     <DragDropProvider onDrop={handleDrop}>
       <div className="grid h-screen grid-rows-[auto_1fr_auto] bg-background">
         <TitleBar panels={panels} onTogglePanel={togglePanel} />
+        {showShadcnMenu ? <AppMenubar {...menuActions} /> : null}
         {project ? (
           <MainShell
             onPickHit={onPickFlatHit}

--- a/app/src/components/app-menubar.tsx
+++ b/app/src/components/app-menubar.tsx
@@ -1,0 +1,70 @@
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarTrigger,
+} from "@/components/ui/menubar";
+
+type MenuAction = () => void;
+
+export function AppMenubar(props: {
+  onNewProject: MenuAction;
+  onOpenProject: MenuAction;
+  onNewFile: MenuAction;
+  onNewFolder: MenuAction;
+  onImport: MenuAction;
+  onSettings: MenuAction;
+  onToggleTree: MenuAction;
+  onToggleFlat: MenuAction;
+  onToggleInspector: MenuAction;
+  onPalette: MenuAction;
+  onRescan: MenuAction;
+}) {
+  const mod = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
+  return (
+    <Menubar className="h-7 rounded-none border-x-0 border-t-0 px-1">
+      <MenubarMenu>
+        <MenubarTrigger className="px-2 py-0.5 text-xs">File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem onClick={props.onNewProject}>New Project…</MenubarItem>
+          <MenubarItem onClick={props.onOpenProject}>
+            Open Project… <MenubarShortcut>{mod}O</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={props.onNewFile}>
+            New File <MenubarShortcut>{mod}N</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={props.onNewFolder}>
+            New Folder <MenubarShortcut>{mod}⇧N</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={props.onImport}>
+            Import… <MenubarShortcut>{mod}I</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={props.onSettings}>
+            Settings… <MenubarShortcut>{mod},</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger className="px-2 py-0.5 text-xs">View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem onClick={props.onToggleTree}>Toggle Tree Panel</MenubarItem>
+          <MenubarItem onClick={props.onToggleFlat}>Toggle Flat Panel</MenubarItem>
+          <MenubarItem onClick={props.onToggleInspector}>Toggle Inspector</MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={props.onPalette}>
+            Command Palette… <MenubarShortcut>{mod}K</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={props.onRescan}>
+            Rescan Project <MenubarShortcut>{mod}⇧R</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  );
+}

--- a/app/src/components/settings-dialog.tsx
+++ b/app/src/components/settings-dialog.tsx
@@ -280,10 +280,36 @@ const DEBOUNCE_MAX = 1500;
 const DEBOUNCE_STEP = 50;
 
 function GeneralTab() {
+  const isMac = navigator.platform.includes("Mac");
   return (
     <div className="grid gap-4">
       <ThemeSettings />
       <SearchDebounceSettings />
+      {isMac ? <MenubarToggle /> : null}
+    </div>
+  );
+}
+
+function MenubarToggle() {
+  const [enabled, setEnabled] = React.useState(
+    () => localStorage.getItem("progest:show-menubar") === "true",
+  );
+  return (
+    <div className="flex items-center justify-between">
+      <div className="grid gap-0.5">
+        <Label htmlFor="show-menubar">Show menubar</Label>
+        <span className="text-[0.625rem] text-muted-foreground">
+          Display a shadcn menubar below the title bar (reload required)
+        </span>
+      </div>
+      <Switch
+        id="show-menubar"
+        checked={enabled}
+        onCheckedChange={(checked) => {
+          setEnabled(checked);
+          localStorage.setItem("progest:show-menubar", checked ? "true" : "false");
+        }}
+      />
     </div>
   );
 }

--- a/app/src/components/ui/menubar.tsx
+++ b/app/src/components/ui/menubar.tsx
@@ -1,0 +1,275 @@
+import * as React from "react"
+import { Menubar as MenubarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function Menubar({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Root>) {
+  return (
+    <MenubarPrimitive.Root
+      data-slot="menubar"
+      className={cn("flex h-9 items-center rounded-lg border p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function MenubarMenu({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
+  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />
+}
+
+function MenubarGroup({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Group>) {
+  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />
+}
+
+function MenubarPortal({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
+  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />
+}
+
+function MenubarRadioGroup({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
+  return (
+    <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
+  )
+}
+
+function MenubarTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
+  return (
+    <MenubarPrimitive.Trigger
+      data-slot="menubar-trigger"
+      className={cn(
+        "flex items-center rounded-[calc(var(--radius-md)-2px)] px-2 py-[calc(--spacing(0.85))] text-xs/relaxed font-medium outline-hidden select-none hover:bg-muted aria-expanded:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MenubarContent({
+  className,
+  align = "start",
+  alignOffset = -4,
+  sideOffset = 8,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Content>) {
+  return (
+    <MenubarPortal>
+      <MenubarPrimitive.Content
+        data-slot="menubar-content"
+        align={align}
+        alignOffset={alignOffset}
+        sideOffset={sideOffset}
+        className={cn("z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95", className )}
+        {...props}
+      />
+    </MenubarPortal>
+  )
+}
+
+function MenubarItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenubarPrimitive.Item
+      data-slot="menubar-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/menubar-item relative flex min-h-7 cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MenubarCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <MenubarPrimitive.CheckboxItem
+      data-slot="menubar-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex min-h-7 cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-7.5 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7.5 data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className
+      )}
+      {...(checked !== undefined ? { checked } : {})}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-4 items-center justify-center [&_svg:not([class*='size-'])]:size-4">
+        <MenubarPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.CheckboxItem>
+  )
+}
+
+function MenubarRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <MenubarPrimitive.RadioItem
+      data-slot="menubar-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex min-h-7 cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-7.5 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-4 items-center justify-center [&_svg:not([class*='size-'])]:size-4">
+        <MenubarPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.RadioItem>
+  )
+}
+
+function MenubarLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <MenubarPrimitive.Label
+      data-slot="menubar-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-xs text-muted-foreground data-inset:pl-7.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MenubarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Separator>) {
+  return (
+    <MenubarPrimitive.Separator
+      data-slot="menubar-separator"
+      className={cn("-mx-1 my-1 h-px bg-border/50", className)}
+      {...props}
+    />
+  )
+}
+
+function MenubarShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="menubar-shortcut"
+      className={cn(
+        "ml-auto text-[0.625rem] tracking-widest text-muted-foreground group-focus/menubar-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MenubarSub({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
+  return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />
+}
+
+function MenubarSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <MenubarPrimitive.SubTrigger
+      data-slot="menubar-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex min-h-7 cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs outline-none select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7.5 data-open:bg-accent data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </MenubarPrimitive.SubTrigger>
+  )
+}
+
+function MenubarSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
+  return (
+    <MenubarPrimitive.SubContent
+      data-slot="menubar-sub-content"
+      className={cn("z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Menubar,
+  MenubarPortal,
+  MenubarMenu,
+  MenubarTrigger,
+  MenubarContent,
+  MenubarGroup,
+  MenubarSeparator,
+  MenubarLabel,
+  MenubarItem,
+  MenubarShortcut,
+  MenubarCheckboxItem,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+}

--- a/app/src/lib/use-menu-events.ts
+++ b/app/src/lib/use-menu-events.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { listen } from "@tauri-apps/api/event";
+
+export function useMenuEvents(handlers: Record<string, () => void>) {
+  const handlersRef = React.useRef(handlers);
+  handlersRef.current = handlers;
+
+  React.useEffect(() => {
+    const unlisten = listen<string>("menu-action", (event) => {
+      const handler = handlersRef.current[event.payload];
+      if (handler) handler();
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, []);
+}

--- a/crates/progest-tauri/capabilities/default.json
+++ b/crates/progest-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-toggle-maximize",
     "dialog:default",
     "drag:default",
-    "core:event:default"
+    "core:event:default",
+    "core:menu:default"
   ]
 }

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod delete_commands;
 mod file_inspector_commands;
 mod import_commands;
 mod lint_commands;
+mod menu;
 mod progress;
 mod project_init_commands;
 mod recent;
@@ -106,7 +107,12 @@ pub fn run() {
             ai_commands::ai_set_config,
             ai_commands::ai_delete_key,
         ])
+        .on_menu_event(|app, event| {
+            menu::handle_menu_event(app, event.id().as_ref());
+        })
         .setup(|app| {
+            let menu = menu::build_menu(app.handle())?;
+            app.set_menu(menu)?;
             // We build the main window programmatically rather than via
             // tauri.conf.json so we can call `traffic_light_position`
             // on the builder. As of Tauri 2.10.x the JSON-config path

--- a/crates/progest-tauri/src/menu.rs
+++ b/crates/progest-tauri/src/menu.rs
@@ -1,0 +1,103 @@
+use tauri::menu::{Menu, MenuItemBuilder, SubmenuBuilder};
+use tauri::{AppHandle, Emitter, Wry};
+
+pub fn build_menu(app: &AppHandle<Wry>) -> tauri::Result<Menu<Wry>> {
+    let file_menu = SubmenuBuilder::new(app, "File")
+        .item(&MenuItemBuilder::with_id("menu:new-project", "New Project…").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("menu:open-project", "Open Project…")
+                .accelerator("CmdOrCtrl+O")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("menu:new-file", "New File")
+                .accelerator("CmdOrCtrl+N")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("menu:new-folder", "New Folder")
+                .accelerator("CmdOrCtrl+Shift+N")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id("menu:import", "Import…")
+                .accelerator("CmdOrCtrl+I")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id("menu:settings", "Settings…")
+                .accelerator("CmdOrCtrl+,")
+                .build(app)?,
+        )
+        .separator()
+        .close_window()
+        .build()?;
+
+    let edit_menu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    let view_menu = SubmenuBuilder::new(app, "View")
+        .item(&MenuItemBuilder::with_id("menu:toggle-tree", "Toggle Tree Panel").build(app)?)
+        .item(&MenuItemBuilder::with_id("menu:toggle-flat", "Toggle Flat Panel").build(app)?)
+        .item(&MenuItemBuilder::with_id("menu:toggle-inspector", "Toggle Inspector").build(app)?)
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id("menu:palette", "Command Palette…")
+                .accelerator("CmdOrCtrl+K")
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id("menu:rescan", "Rescan Project")
+                .accelerator("CmdOrCtrl+Shift+R")
+                .build(app)?,
+        )
+        .build()?;
+
+    let help_menu = SubmenuBuilder::new(app, "Help")
+        .item(&MenuItemBuilder::with_id("menu:about", "About Progest").build(app)?)
+        .build()?;
+
+    #[cfg(target_os = "macos")]
+    let menu = {
+        let app_menu = SubmenuBuilder::new(app, "Progest")
+            .about(None)
+            .separator()
+            .item(
+                &MenuItemBuilder::with_id("menu:settings-app", "Settings…")
+                    .accelerator("CmdOrCtrl+,")
+                    .build(app)?,
+            )
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?;
+        Menu::with_items(
+            app,
+            &[&app_menu, &file_menu, &edit_menu, &view_menu, &help_menu],
+        )?
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let menu = Menu::with_items(app, &[&file_menu, &edit_menu, &view_menu, &help_menu])?;
+
+    Ok(menu)
+}
+
+pub fn handle_menu_event(app: &AppHandle<Wry>, id: &str) {
+    let _ = app.emit("menu-action", id);
+}


### PR DESCRIPTION
## Summary
- **macOS**: Tauri Menu API でネイティブメニューバー（Progest/File/Edit/View/Help）
- **全プラットフォーム**: shadcn Menubar コンポーネント（macOS は設定で有効化、Windows/Linux は常時表示）
- **Settings > General**: 「Show menubar」トグル（macOS のみ）
- **メニュー項目**: New/Open Project、New File/Folder、Import（ファイルピッカー付き）、Settings、パネル切替、Command Palette、Rescan、標準 Edit 操作
- メニューイベントは Tauri emit → `useMenuEvents` フックでブリッジ

Closes #107

## Test plan
- [ ] macOS でネイティブメニューバーが表示されること
- [ ] File > New Project / Open Project / Import が動作すること
- [ ] Import でファイルピッカーが開き、選択後に ImportModal が表示されること
- [ ] View > Toggle panels / Command Palette / Rescan が動作すること
- [ ] Edit メニューの Undo/Redo/Cut/Copy/Paste が動作すること
- [ ] Settings > General > Show menubar でメニューバーの表示/非表示が切り替わること（macOS）
- [ ] Windows/Linux で shadcn メニューバーが常時表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)