### PR TITLE
feat: SequenceView sidebar + multi-file drag-out for sequences

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FolderOpen, FolderPlus, Sparkles } from "lucide-react";
+import { FolderOpen, FolderPlus, FolderTree, Layers, Sparkles } from "lucide-react";
 
 import { AppMenubar } from "@/components/app-menubar";
 import { CommandPalette } from "@/components/command-palette";
@@ -13,6 +13,7 @@ import { ImportModal } from "@/components/import-modal";
 import { InitProjectDialog } from "@/components/init-project-dialog";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { StatusBar } from "@/components/status-bar";
+import { SequenceView } from "@/components/sequence-view";
 import { TreeView } from "@/components/tree-view";
 import {
   ALL_PANELS_VISIBLE,
@@ -38,6 +39,7 @@ import { SettingsProvider, useSettings } from "@/lib/settings-context";
 import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
 import { Toaster } from "@/components/ui/sonner";
+import { cn } from "@/lib/utils";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useMenuEvents } from "@/lib/use-menu-events";
 
@@ -322,13 +324,13 @@ function MainShell(props: {
       key: "tree",
       node: (
         <ResizablePanel id="tree" key="tree" defaultSize={22} minSize={12}>
-          <aside ref={props.treeRef} className="h-full overflow-hidden">
-            <TreeView
-              onPickFile={props.onPickTreeFile}
-              selectedDir={props.selectedDir}
-              onSelectDir={props.onSelectDir}
-            />
-          </aside>
+          <SidePanel
+            treeRef={props.treeRef}
+            onPickTreeFile={props.onPickTreeFile}
+            selectedDir={props.selectedDir}
+            onSelectDir={props.onSelectDir}
+            onPickHit={props.onPickHit}
+          />
         </ResizablePanel>
       ),
     });
@@ -456,6 +458,57 @@ function Welcome() {
       ) : null}
       {error ? <div className="text-xs text-destructive">{error}</div> : null}
     </div>
+  );
+}
+
+function SidePanel(props: {
+  treeRef: React.RefObject<HTMLElement | null>;
+  onPickTreeFile: (entry: DirEntry) => void;
+  selectedDir: string;
+  onSelectDir: (path: string) => void;
+  onPickHit: (hit: RichSearchHit) => void;
+}) {
+  const [tab, setTab] = React.useState<"tree" | "sequences">("tree");
+  return (
+    <aside ref={props.treeRef} className="grid h-full grid-rows-[auto_1fr] overflow-hidden">
+      <div className="flex border-b">
+        <button
+          type="button"
+          className={cn(
+            "flex flex-1 items-center justify-center gap-1 px-2 py-1 text-[0.625rem] uppercase tracking-wide",
+            tab === "tree"
+              ? "border-b-2 border-primary font-medium"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => setTab("tree")}
+        >
+          <FolderTree className="size-3" />
+          Tree
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "flex flex-1 items-center justify-center gap-1 px-2 py-1 text-[0.625rem] uppercase tracking-wide",
+            tab === "sequences"
+              ? "border-b-2 border-primary font-medium"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => setTab("sequences")}
+        >
+          <Layers className="size-3" />
+          Sequences
+        </button>
+      </div>
+      {tab === "tree" ? (
+        <TreeView
+          onPickFile={props.onPickTreeFile}
+          selectedDir={props.selectedDir}
+          onSelectDir={props.onSelectDir}
+        />
+      ) : (
+        <SequenceView onPickHit={props.onPickHit} />
+      )}
+    </aside>
   );
 }
 

--- a/app/src/components/hits-data-table.tsx
+++ b/app/src/components/hits-data-table.tsx
@@ -37,7 +37,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ViolationBadges } from "@/components/violation-badges";
 import type { RichSearchHit } from "@/lib/ipc";
-import { useDragOut } from "@/lib/use-drag-out";
+import { useDragOut, useDragOutMulti } from "@/lib/use-drag-out";
 import type { SequenceMap } from "@/lib/sequence-grouping";
 import { cn } from "@/lib/utils";
 
@@ -308,27 +308,18 @@ function SequenceAwareRows(props: {
     seenSeqs.add(seqKey);
     const seq = sequenceMap.sequences.get(seqKey)!;
     const isCollapsed = collapsed.has(seqKey);
+    const memberPaths = rows
+      .filter((r) => sequenceMap.hitToSeq.get(r.original.file_id || r.original.path) === seqKey)
+      .map((r) => r.original.path);
     rendered.push(
-      <TableRow
+      <SeqHeaderRow
         key={`seq-${seqKey}`}
-        className="cursor-pointer bg-muted/30 hover:bg-muted/50"
-        onClick={() => toggle(seqKey)}
-      >
-        <TableCell colSpan={colCount} className="text-xs">
-          <div className="flex items-center gap-2">
-            {isCollapsed ? (
-              <ChevronRight className="size-3.5 shrink-0" />
-            ) : (
-              <ChevronDown className="size-3.5 shrink-0" />
-            )}
-            <Layers className="size-3.5 shrink-0 opacity-60" />
-            <span className="font-mono">
-              {seq.stemPrefix}[{seq.rangeStart}–{seq.rangeEnd}].{seq.extension}
-            </span>
-            <span className="text-muted-foreground">({seq.count} files)</span>
-          </div>
-        </TableCell>
-      </TableRow>,
+        seq={seq}
+        collapsed={isCollapsed}
+        onToggle={() => toggle(seqKey)}
+        colCount={colCount}
+        memberPaths={memberPaths}
+      />,
     );
     if (!isCollapsed) {
       rendered.push(<HitRow key={hitId} row={row} onPick={onPick} inSequence />);
@@ -336,6 +327,39 @@ function SequenceAwareRows(props: {
   }
 
   return rendered;
+}
+
+function SeqHeaderRow(props: {
+  seq: import("@/lib/sequence-grouping").SequenceInfo;
+  collapsed: boolean;
+  onToggle: () => void;
+  colCount: number;
+  memberPaths: string[];
+}) {
+  const { seq, collapsed, onToggle, colCount, memberPaths } = props;
+  const drag = useDragOutMulti(memberPaths);
+  return (
+    <TableRow
+      className="cursor-pointer bg-muted/30 hover:bg-muted/50"
+      onClick={onToggle}
+      onMouseDown={drag.onMouseDown}
+    >
+      <TableCell colSpan={colCount} className="text-xs">
+        <div className="flex items-center gap-2">
+          {collapsed ? (
+            <ChevronRight className="size-3.5 shrink-0" />
+          ) : (
+            <ChevronDown className="size-3.5 shrink-0" />
+          )}
+          <Layers className="size-3.5 shrink-0 opacity-60" />
+          <span className="font-mono">
+            {seq.stemPrefix}[{seq.rangeStart}–{seq.rangeEnd}].{seq.extension}
+          </span>
+          <span className="text-muted-foreground">({seq.count} files)</span>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
 }
 
 /**

--- a/app/src/components/sequence-view.tsx
+++ b/app/src/components/sequence-view.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import { ChevronDown, ChevronRight, Layers } from "lucide-react";
+
+import { filesListAll, type RichSearchHit } from "@/lib/ipc";
+import { useProject } from "@/lib/project-context";
+import { buildSequenceMap, type SequenceInfo } from "@/lib/sequence-grouping";
+import { useDragOutMulti } from "@/lib/use-drag-out";
+
+export function SequenceView(props: { onPickHit?: (hit: RichSearchHit) => void }) {
+  const { project, refreshTick } = useProject();
+  const [hits, setHits] = React.useState<RichSearchHit[]>([]);
+  const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set());
+
+  React.useEffect(() => {
+    filesListAll()
+      .then(setHits)
+      .catch(() => {});
+  }, [project?.root, refreshTick]);
+
+  const seqMap = React.useMemo(() => buildSequenceMap(hits), [hits]);
+  const sequences = React.useMemo(
+    () =>
+      [...seqMap.sequences.values()].toSorted((a, b) => a.stemPrefix.localeCompare(b.stemPrefix)),
+    [seqMap],
+  );
+
+  const membersBySeq = React.useMemo(() => {
+    const map = new Map<string, RichSearchHit[]>();
+    for (const hit of hits) {
+      const id = hit.file_id || hit.path;
+      const seqKey = seqMap.hitToSeq.get(id);
+      if (!seqKey) continue;
+      let list = map.get(seqKey);
+      if (!list) {
+        list = [];
+        map.set(seqKey, list);
+      }
+      list.push(hit);
+    }
+    return map;
+  }, [hits, seqMap]);
+
+  const toggle = React.useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  if (sequences.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+        No sequences detected
+      </div>
+    );
+  }
+
+  return (
+    <nav className="h-full overflow-auto p-1 text-xs">
+      {sequences.map((seq) => {
+        const isOpen = expanded.has(seq.key);
+        const members = membersBySeq.get(seq.key) ?? [];
+        return (
+          <SeqNode
+            key={seq.key}
+            seq={seq}
+            members={members}
+            isOpen={isOpen}
+            onToggle={() => toggle(seq.key)}
+            onPickHit={props.onPickHit}
+          />
+        );
+      })}
+    </nav>
+  );
+}
+
+function SeqNode(props: {
+  seq: SequenceInfo;
+  members: RichSearchHit[];
+  isOpen: boolean;
+  onToggle: () => void;
+  onPickHit?: ((hit: RichSearchHit) => void) | undefined;
+}) {
+  const { seq, members, isOpen, onToggle, onPickHit } = props;
+  const memberPaths = React.useMemo(() => members.map((m) => m.path), [members]);
+  const drag = useDragOutMulti(memberPaths);
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex w-full items-center gap-1 rounded px-1 py-0.5 hover:bg-accent"
+        onClick={onToggle}
+        onMouseDown={drag.onMouseDown}
+      >
+        {isOpen ? (
+          <ChevronDown className="size-3 shrink-0 opacity-60" />
+        ) : (
+          <ChevronRight className="size-3 shrink-0 opacity-60" />
+        )}
+        <Layers className="size-3 shrink-0 opacity-60" />
+        <span className="min-w-0 truncate font-mono">
+          {seq.stemPrefix}*.{seq.extension}
+        </span>
+        <span className="ml-auto shrink-0 text-[0.625rem] text-muted-foreground">{seq.count}</span>
+      </button>
+      {isOpen ? (
+        <div className="ml-4">
+          {members.map((hit) => (
+            <button
+              key={hit.file_id || hit.path}
+              type="button"
+              className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-accent"
+              onClick={() => onPickHit?.(hit)}
+            >
+              <span className="min-w-0 truncate font-mono text-muted-foreground">
+                {hit.name ?? hit.path.split("/").pop()}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/lib/use-drag-out.ts
+++ b/app/src/lib/use-drag-out.ts
@@ -19,54 +19,60 @@ async function getDragIcon(): Promise<string> {
 }
 
 export function useDragOut(path: string) {
+  return useDragOutMulti(React.useMemo(() => [path], [path]));
+}
+
+export function useDragOutMulti(paths: string[]) {
   const down = React.useRef<{ x: number; y: number } | null>(null);
   const dragging = React.useRef(false);
+  const pathsRef = React.useRef(paths);
+  pathsRef.current = paths;
 
-  const onMouseDown = React.useCallback(
-    (e: React.MouseEvent) => {
-      if (e.button !== 0) return;
-      down.current = { x: e.clientX, y: e.clientY };
-      dragging.current = false;
+  const onMouseDown = React.useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    down.current = { x: e.clientX, y: e.clientY };
+    dragging.current = false;
 
-      const onMove = async (me: MouseEvent) => {
-        if (dragging.current || !down.current) return;
-        const dx = me.clientX - down.current.x;
-        const dy = me.clientY - down.current.y;
-        if (dx * dx + dy * dy < DRAG_THRESHOLD * DRAG_THRESHOLD) return;
-        dragging.current = true;
-        cleanup();
-        try {
-          const [abs, icon] = await Promise.all([fsAbsPath(path), getDragIcon()]);
-          dragOutActive = true;
-          await startDrag({ item: [abs], icon });
-        } catch {
-          // drag cancelled or failed
-        } finally {
-          window.addEventListener(
-            "mousedown",
-            () => {
-              dragOutActive = false;
-            },
-            { once: true },
-          );
-        }
-      };
+    const onMove = async (me: MouseEvent) => {
+      if (dragging.current || !down.current) return;
+      const dx = me.clientX - down.current.x;
+      const dy = me.clientY - down.current.y;
+      if (dx * dx + dy * dy < DRAG_THRESHOLD * DRAG_THRESHOLD) return;
+      dragging.current = true;
+      cleanup();
+      try {
+        const [absPaths, icon] = await Promise.all([
+          Promise.all(pathsRef.current.map((p) => fsAbsPath(p))),
+          getDragIcon(),
+        ]);
+        dragOutActive = true;
+        await startDrag({ item: absPaths, icon });
+      } catch {
+        // drag cancelled or failed
+      } finally {
+        window.addEventListener(
+          "mousedown",
+          () => {
+            dragOutActive = false;
+          },
+          { once: true },
+        );
+      }
+    };
 
-      const onUp = () => {
-        cleanup();
-      };
+    const onUp = () => {
+      cleanup();
+    };
 
-      const cleanup = () => {
-        down.current = null;
-        window.removeEventListener("mousemove", onMove);
-        window.removeEventListener("mouseup", onUp);
-      };
+    const cleanup = () => {
+      down.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
 
-      window.addEventListener("mousemove", onMove);
-      window.addEventListener("mouseup", onUp);
-    },
-    [path],
-  );
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }, []);
 
   return { onMouseDown };
 }


### PR DESCRIPTION
## Summary
- **#138**: サイドパネルに Tree / Sequences タブ切替を追加
  - SequenceView: プロジェクト内の全 sequence を展開/折りたたみリストで表示
  - sequence メンバーをクリックでインスペクタ選択
  - タブに FolderTree / Layers アイコン
- **#139**: sequence まとめてドラッグアウト
  - `useDragOutMulti` フック: 複数パスを `startDrag` に渡す
  - DataTable の sequence ヘッダー行からまとめてドラッグ
  - SequenceView のノードからもまとめてドラッグ

Closes #138
Closes #139

## Test plan
- [ ] サイドパネルで Tree / Sequences タブが切り替わること
- [ ] Sequences タブで検出された sequence が表示されること
- [ ] sequence を展開してメンバーをクリックするとインスペクタに表示されること
- [ ] sequence ノードをドラッグして Finder に全メンバーがコピーされること
- [ ] DataTable の sequence ヘッダー行からもまとめてドラッグできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)