### PR TITLE
feat: F1 key opens command palette in command mode (#112)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -320,8 +320,10 @@ function Shell() {
   return (
     <DragDropProvider onDrop={handleDrop}>
       <div className="grid h-screen grid-rows-[auto_1fr_auto] bg-background">
-        <TitleBar panels={panels} onTogglePanel={togglePanel} />
-        {showShadcnMenu ? <AppMenubar {...menuActions} /> : null}
+        <div>
+          <TitleBar panels={panels} onTogglePanel={togglePanel} />
+          {showShadcnMenu ? <AppMenubar {...menuActions} /> : null}
+        </div>
         {project ? (
           <MainShell
             onPickHit={onPickFlatHit}
@@ -476,7 +478,7 @@ function InspectorPane(props: {
 function Welcome() {
   const { recent, openPicker, pickRecent, openInitDialog, error } = useProject();
   return (
-    <div className="flex flex-col items-center justify-center gap-6 overflow-auto p-6">
+    <div className="flex h-full flex-col items-center justify-center gap-6 overflow-auto p-6">
       <div className="text-center">
         <h1 className="text-2xl font-semibold tracking-tight">Progest</h1>
         <p className="text-xs text-muted-foreground">

--- a/app/src/components/app-menubar.tsx
+++ b/app/src/components/app-menubar.tsx
@@ -70,7 +70,7 @@ export function AppMenubar(props: {
           <MenubarItem onClick={props.onToggleInspector}>Toggle Inspector</MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={props.onPalette}>
-            Command Palette… <MenubarShortcut>{mod}K</MenubarShortcut>
+            Command Palette… <MenubarShortcut>{mod}K / F1</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={props.onRescan}>

--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -85,6 +85,13 @@ export function CommandPalette(props: { onPickHit?: (hit: RichSearchHit) => void
         e.preventDefault();
         setOpen((v) => !v);
       }
+      if (e.key === "F1") {
+        e.preventDefault();
+        setOpen((prev) => {
+          if (!prev) setQuery(">");
+          return !prev;
+        });
+      }
     };
     const onToggle = () => setOpen((v) => !v);
     window.addEventListener("keydown", onKey);


### PR DESCRIPTION
## Summary

- Add F1 as an alternative keyboard shortcut to toggle the command palette
- F1 opens with `>` pre-filled so it starts in command mode (showing available commands)
- Cmd+K / Ctrl+K continues to open in search mode as before
- Update menubar shortcut label to show both bindings

## Test plan

- [ ] F1 opens command palette with `>` prefix (command mode)
- [ ] Cmd+K opens command palette in search mode (no prefix)
- [ ] F1 again closes the palette when already open

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)