### PR TITLE
feat: Rescan command — full reconcile + lint + thumbnails (#96)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,13 +32,13 @@ import {
 } from "@/components/ui/dialog";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { BackgroundTaskProvider } from "@/lib/background-task-context";
+import { BackgroundTaskProvider, useBackgroundTasks } from "@/lib/background-task-context";
 import { FlatViewSummaryProvider } from "@/lib/flat-view-context";
 import { ProjectProvider, useProject } from "@/lib/project-context";
 import { SettingsProvider, useSettings } from "@/lib/settings-context";
 import { ThemeProvider } from "next-themes";
 import type { DirEntry, RichSearchHit } from "@/lib/ipc";
-import { historyUndo, historyRedo, IpcError } from "@/lib/ipc";
+import { historyUndo, historyRedo, rescanProject, IpcError } from "@/lib/ipc";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -99,6 +99,7 @@ export function App() {
 
 function Shell() {
   const { project, openPicker, bumpRefresh, openInitDialog } = useProject();
+  const { startTask, updateTask, finishTask } = useBackgroundTasks();
   const [selection, setSelection] = React.useState<Selection>(null);
   const [pendingConfirm, setPendingConfirm] = React.useState<{
     next: Selection;
@@ -245,6 +246,24 @@ function Shell() {
     return () => window.removeEventListener("keydown", onKey);
   }, [doUndo, doRedo]);
 
+  const doRescan = React.useCallback(async () => {
+    startTask("rescan", "Rescanning project");
+    try {
+      const result = await rescanProject((e) => {
+        updateTask("rescan", e.current, e.total, e.message);
+      });
+      toast.success(
+        `Rescan: ${result.added} added, ${result.updated} updated, ${result.removed} removed`,
+      );
+      bumpRefresh();
+    } catch (e) {
+      if (e instanceof IpcError && e.isNoProject) return;
+      toast.error(`Rescan failed: ${e instanceof IpcError ? e.raw : String(e)}`);
+    } finally {
+      finishTask("rescan");
+    }
+  }, [bumpRefresh, startTask, updateTask, finishTask]);
+
   useMenuEvents({
     "menu:new-project": () => openInitDialog("new"),
     "menu:open-project": () => void openPicker(),
@@ -258,7 +277,7 @@ function Shell() {
     "menu:toggle-flat": () => togglePanel("flat"),
     "menu:toggle-inspector": () => togglePanel("inspector"),
     "menu:palette": () => window.dispatchEvent(new CustomEvent("progest:toggle-palette")),
-    "menu:rescan": () => bumpRefresh(),
+    "menu:rescan": () => void doRescan(),
     "menu:import": () => void pickAndImport(),
     "menu:undo": () => void doUndo(),
     "menu:redo": () => void doRedo(),
@@ -314,7 +333,7 @@ function Shell() {
     onToggleFlat: () => togglePanel("flat"),
     onToggleInspector: () => togglePanel("inspector"),
     onPalette: () => window.dispatchEvent(new CustomEvent("progest:toggle-palette")),
-    onRescan: () => bumpRefresh(),
+    onRescan: () => void doRescan(),
   };
 
   return (

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -717,6 +717,33 @@ export async function historySetConfig(config: { retention: number }): Promise<v
   }
 }
 
+// --- rescan ----------------------------------------------------------------
+
+export type RescanResponse = {
+  added: number;
+  updated: number;
+  removed: number;
+  unchanged: number;
+  orphan_metas: number;
+  lint_naming: number;
+  lint_placement: number;
+  lint_sequence: number;
+  thumb_generated: number;
+  thumb_cached: number;
+};
+
+export async function rescanProject(
+  onProgress?: (e: ProgressEvent) => void,
+): Promise<RescanResponse> {
+  try {
+    return await invoke<RescanResponse>("rescan_project", {
+      onProgress: makeChannel(onProgress),
+    });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- AI suggestions -------------------------------------------------------
 
 export type AiSuggestionWire = {

--- a/app/src/lib/palette-commands/maintenance-commands.ts
+++ b/app/src/lib/palette-commands/maintenance-commands.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import { useBackgroundTasks } from "@/lib/background-task-context";
-import { lintRun, thumbnailGenerate } from "@/lib/ipc";
+import { lintRun, rescanProject, thumbnailGenerate } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
 import type { PaletteCommand } from "./types";
 
@@ -13,6 +13,28 @@ export function useMaintenanceCommands(): PaletteCommand[] {
   return React.useMemo<PaletteCommand[]>(() => {
     if (!project) return [];
     return [
+      {
+        id: "maintenance.rescan",
+        title: "Rescan project",
+        group: "Maintenance",
+        keywords: ["rescan", "scan", "reconcile", "refresh", "sync"],
+        run: async () => {
+          startTask("rescan", "Rescanning project");
+          try {
+            const result = await rescanProject((e) => {
+              updateTask("rescan", e.current, e.total, e.message);
+            });
+            toast.success(
+              `Rescan: ${result.added} added, ${result.updated} updated, ${result.removed} removed — lint: ${result.lint_naming + result.lint_placement + result.lint_sequence} violations — thumbnails: ${result.thumb_generated} generated`,
+            );
+            bumpRefresh();
+          } catch (e) {
+            toast.error(String(e));
+          } finally {
+            finishTask("rescan");
+          }
+        },
+      },
       {
         id: "maintenance.generate-thumbnails",
         title: "Generate thumbnails",

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod menu;
 mod progress;
 mod project_init_commands;
 mod recent;
+mod rescan_commands;
 mod state;
 mod template_commands;
 mod thumbnail_commands;
@@ -109,6 +110,7 @@ pub fn run() {
             history_commands::history_redo,
             history_commands::history_get_config,
             history_commands::history_set_config,
+            rescan_commands::rescan_project,
             ai_commands::ai_suggest,
             ai_commands::ai_apply_rename,
             ai_commands::ai_set_key,

--- a/crates/progest-tauri/src/rescan_commands.rs
+++ b/crates/progest-tauri/src/rescan_commands.rs
@@ -1,0 +1,180 @@
+//! IPC command for full project rescan (reconcile + lint + thumbnail).
+
+use progest_core::accepts::{AliasCatalog, SchemaLoad, load_alias_catalog};
+use progest_core::fs::ProjectPath;
+use progest_core::index::Index;
+use progest_core::lint::{LintOptions, lint_paths_with_progress, write_to_index};
+use progest_core::meta::StdMetaStore;
+use progest_core::naming::{CleanupConfig, extract_cleanup_config};
+use progest_core::project::ProjectDocument;
+use progest_core::reconcile::Reconciler;
+use progest_core::rules::{
+    BUILTIN_COMPOUND_EXTS, CompiledRuleSet, RuleSetLayer, RuleSource, compile_ruleset,
+    load_document,
+};
+use progest_core::thumbnail::{
+    DEFAULT_CACHE_MAX_BYTES, DEFAULT_MAX_DIM, ThumbnailCache, generate_batch_with_progress,
+    requests_from_index,
+};
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use crate::commands::no_project_error;
+use crate::progress::ProgressEvent;
+use crate::state::{AppState, ProjectContext};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RescanResponse {
+    pub added: usize,
+    pub updated: usize,
+    pub removed: usize,
+    pub unchanged: usize,
+    pub orphan_metas: usize,
+    pub lint_naming: usize,
+    pub lint_placement: usize,
+    pub lint_sequence: usize,
+    pub thumb_generated: usize,
+    pub thumb_cached: usize,
+}
+
+#[tauri::command]
+pub async fn rescan_project(
+    on_progress: tauri::ipc::Channel<ProgressEvent>,
+    app: AppHandle,
+) -> Result<RescanResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let meta = StdMetaStore::new(ctx.fs.clone());
+
+        // Phase 1: reconcile
+        let _ = on_progress.send(ProgressEvent {
+            current: 0,
+            total: 0,
+            message: "Scanning files\u{2026}".to_string(),
+        });
+        let reconciler = Reconciler::new(&ctx.fs, &meta, &ctx.index);
+        let report = reconciler
+            .full_scan_with_progress(&|current, total, msg| {
+                let _ = on_progress.send(ProgressEvent {
+                    current,
+                    total,
+                    message: msg.to_string(),
+                });
+            })
+            .map_err(|e| format!("reconcile: {e}"))?;
+
+        // Phase 2: lint
+        let _ = on_progress.send(ProgressEvent {
+            current: 0,
+            total: 0,
+            message: "Running lint\u{2026}".to_string(),
+        });
+        let rows = ctx
+            .index
+            .list_files()
+            .map_err(|e| format!("list indexed files: {e}"))?;
+        let paths: Vec<ProjectPath> = rows.iter().map(|r| r.path.clone()).collect();
+
+        let ruleset = load_ruleset(ctx)?;
+        let catalog = load_alias_catalog_for_ctx(ctx);
+        let cleanup = load_cleanup(ctx)?;
+        let opts = LintOptions {
+            ruleset: &ruleset,
+            alias_catalog: &catalog,
+            compound_exts: BUILTIN_COMPOUND_EXTS,
+            cleanup_cfg: &cleanup,
+            explain: false,
+        };
+        let lint_report = lint_paths_with_progress(
+            meta.filesystem(),
+            &meta,
+            &paths,
+            &opts,
+            &|current, total, msg| {
+                let _ = on_progress.send(ProgressEvent {
+                    current,
+                    total,
+                    message: msg.to_string(),
+                });
+            },
+        )
+        .map_err(|e| format!("lint: {e}"))?;
+
+        let visited: Vec<_> = rows.into_iter().map(|r| r.file_id).collect();
+        write_to_index(&ctx.index, &visited, &lint_report)
+            .map_err(|e| format!("write violations: {e}"))?;
+
+        // Phase 3: thumbnails
+        let _ = on_progress.send(ProgressEvent {
+            current: 0,
+            total: 0,
+            message: "Generating thumbnails\u{2026}".to_string(),
+        });
+        let cache = ThumbnailCache::new(ctx.root.thumbs_dir(), DEFAULT_CACHE_MAX_BYTES);
+        let reqs = requests_from_index(&ctx.index, ctx.root.root(), DEFAULT_MAX_DIM);
+        let thumb_report =
+            generate_batch_with_progress(&reqs, &cache, false, &|current, total, msg| {
+                let _ = on_progress.send(ProgressEvent {
+                    current,
+                    total,
+                    message: msg.to_string(),
+                });
+            });
+
+        Ok(RescanResponse {
+            added: report.added(),
+            updated: report.updated(),
+            removed: report.removed(),
+            unchanged: report.unchanged(),
+            orphan_metas: report.orphan_metas.len(),
+            lint_naming: lint_report.naming.len(),
+            lint_placement: lint_report.placement.len(),
+            lint_sequence: lint_report.sequence.len(),
+            thumb_generated: thumb_report.generated,
+            thumb_cached: thumb_report.cached,
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+fn load_ruleset(ctx: &ProjectContext) -> Result<CompiledRuleSet, String> {
+    let path = ctx.root.rules_toml();
+    if !path.exists() {
+        return compile_ruleset(vec![]).map_err(|e| format!("compile empty ruleset: {e}"));
+    }
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
+    let doc = load_document(&raw).map_err(|e| format!("parse rules.toml: {e}"))?;
+    let layer = RuleSetLayer {
+        source: RuleSource::ProjectWide,
+        base_dir: ProjectPath::root(),
+        rules: doc.rules,
+    };
+    compile_ruleset(vec![layer]).map_err(|e| format!("compile ruleset: {e}"))
+}
+
+fn load_alias_catalog_for_ctx(ctx: &ProjectContext) -> AliasCatalog {
+    let path = ctx.root.schema_toml();
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return AliasCatalog::builtin();
+    };
+    match load_alias_catalog(&text) {
+        Ok(SchemaLoad { catalog, .. }) => catalog,
+        Err(_) => AliasCatalog::builtin(),
+    }
+}
+
+fn load_cleanup(ctx: &ProjectContext) -> Result<CleanupConfig, String> {
+    let path = ctx.root.project_toml();
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
+    let doc =
+        ProjectDocument::from_toml_str(&raw).map_err(|e| format!("parse project.toml: {e}"))?;
+    let (cfg, _warns) =
+        extract_cleanup_config(&doc.extra).map_err(|e| format!("read [cleanup]: {e}"))?;
+    Ok(cfg)
+}


### PR DESCRIPTION
## Summary

- New Tauri IPC `rescan_project` with progress channel: runs full_scan → lint → thumbnail generate in sequence
- Palette command `>Rescan project` with background task progress indicator
- `menu:rescan` (Cmd+Shift+R) and menubar "Rescan Project" now call the backend reconcile instead of just refreshing the UI
- Toast summary shows added/updated/removed counts on completion

Previously, rescan only called `bumpRefresh()` which re-fetched UI data without actually reconciling the filesystem against the index.

## Test plan

- [ ] `>Rescan project` from palette triggers full scan with progress
- [ ] Cmd+Shift+R triggers the same flow
- [ ] Toast shows scan results on completion
- [ ] New/modified/deleted files are picked up after rescan

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)