### PR TITLE
feat: file media info in inspector — size, resolution, codec, FPS (#109)

### DIFF
--- a/app/src/components/file-inspector.tsx
+++ b/app/src/components/file-inspector.tsx
@@ -8,6 +8,7 @@ import {
   aiSuggest,
   fileDeleteApply,
   fileDeletePreview,
+  fileMediaInfo,
   notesRead,
   notesWrite,
   tagAdd,
@@ -16,6 +17,7 @@ import {
   type AiConfigResponse,
   type AiSuggestionWire,
   type DeletePreview,
+  type MediaInfo,
   type RichSearchHit,
 } from "@/lib/ipc";
 import { useProject } from "@/lib/project-context";
@@ -322,6 +324,7 @@ export const FileInspector = React.forwardRef<
           }
         />
         <StaticFields hit={localHit} />
+        <MediaInfoSection path={localHit.path} />
         <TagsSection
           hit={localHit}
           disabled={!isIndexed}
@@ -444,6 +447,61 @@ function Row(props: { label: string; value: string; mono?: boolean; className?: 
       </span>
     </div>
   );
+}
+
+// ── Media info section ─────────────────────────────────────────────
+
+function MediaInfoSection(props: { path: string }) {
+  const [info, setInfo] = React.useState<MediaInfo | null>(null);
+
+  React.useEffect(() => {
+    setInfo(null);
+    void fileMediaInfo(props.path)
+      .then(setInfo)
+      .catch(() => {});
+  }, [props.path]);
+
+  if (!info || info.size_bytes === 0) return null;
+
+  return (
+    <div className="grid gap-1.5">
+      <Row label="Size" value={formatBytes(info.size_bytes)} />
+      {info.width != null && info.height != null ? (
+        <Row label="Resolution" value={`${info.width} × ${info.height}`} />
+      ) : null}
+      {info.bit_depth != null ? <Row label="Bit depth" value={`${info.bit_depth}-bit`} /> : null}
+      {info.codec != null ? <Row label="Codec" value={info.codec} /> : null}
+      {info.fps != null ? <Row label="FPS" value={`${Math.round(info.fps * 100) / 100}`} /> : null}
+      {info.duration_secs != null ? (
+        <Row label="Duration" value={formatDuration(info.duration_secs)} />
+      ) : null}
+      {info.audio_codec != null ? <Row label="Audio" value={info.audio_codec} /> : null}
+      {info.sample_rate != null ? (
+        <Row label="Sample rate" value={`${info.sample_rate} Hz`} />
+      ) : null}
+      {info.channels != null ? (
+        <Row
+          label="Channels"
+          value={info.channels === 1 ? "Mono" : info.channels === 2 ? "Stereo" : `${info.channels}`}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDuration(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = Math.floor(secs % 60);
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 // ── Tags section ───────────────────────────────────────────────────

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -744,6 +744,29 @@ export async function rescanProject(
   }
 }
 
+// --- media info ------------------------------------------------------------
+
+export type MediaInfo = {
+  size_bytes: number;
+  width?: number;
+  height?: number;
+  duration_secs?: number;
+  codec?: string;
+  fps?: number;
+  audio_codec?: string;
+  sample_rate?: number;
+  channels?: number;
+  bit_depth?: number;
+};
+
+export async function fileMediaInfo(path: string): Promise<MediaInfo> {
+  try {
+    return await invoke<MediaInfo>("file_media_info", { path });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- AI suggestions -------------------------------------------------------
 
 export type AiSuggestionWire = {

--- a/crates/progest-core/src/lib.rs
+++ b/crates/progest-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod identity;
 pub mod import;
 pub mod index;
 pub mod lint;
+pub mod media;
 pub mod meta;
 pub mod naming;
 pub mod project;

--- a/crates/progest-core/src/media.rs
+++ b/crates/progest-core/src/media.rs
@@ -1,0 +1,198 @@
+//! Lightweight media metadata extraction (dimensions, duration, codec).
+//!
+//! Reads only file headers where possible — no full decode. Used by the
+//! inspector IPC to show file properties on demand.
+
+use std::path::Path;
+use std::process::Command;
+
+use image::ImageReader;
+use serde::Serialize;
+
+use crate::thumbnail::ffmpeg::find_ffmpeg;
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MediaInfo {
+    pub size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codec: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_codec: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_rate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channels: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bit_depth: Option<u32>,
+}
+
+pub fn probe(abs_path: &Path) -> MediaInfo {
+    let mut info = MediaInfo::default();
+
+    if let Ok(meta) = std::fs::metadata(abs_path) {
+        info.size_bytes = meta.len();
+    }
+
+    let ext = abs_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match ext.as_str() {
+        "png" | "jpg" | "jpeg" | "webp" | "gif" | "bmp" | "tiff" | "tif" | "ico" | "avif"
+        | "exr" | "hdr" => {
+            probe_image(abs_path, &mut info);
+        }
+        "psd" => {
+            probe_psd(abs_path, &mut info);
+        }
+        "heic" | "heif" | "mp4" | "mov" | "avi" | "mkv" | "webm" | "m4v" | "flv" | "wmv"
+        | "mp3" | "wav" | "flac" | "aac" | "ogg" | "m4a" | "wma" | "aiff" | "opus" => {
+            probe_ffprobe(abs_path, &mut info);
+        }
+        _ => {}
+    }
+
+    info
+}
+
+fn probe_image(path: &Path, info: &mut MediaInfo) {
+    if let Ok(reader) = ImageReader::open(path)
+        && let Ok((w, h)) = reader.into_dimensions()
+    {
+        info.width = Some(w);
+        info.height = Some(h);
+    }
+}
+
+fn probe_psd(path: &Path, info: &mut MediaInfo) {
+    if let Ok(bytes) = std::fs::read(path)
+        && let Ok(psd) = psd::Psd::from_bytes(&bytes)
+    {
+        info.width = Some(psd.width());
+        info.height = Some(psd.height());
+    }
+}
+
+fn probe_ffprobe(path: &Path, info: &mut MediaInfo) {
+    let ffmpeg_path = find_ffmpeg();
+    let ffprobe_path = ffmpeg_path.as_deref().and_then(|p| {
+        let probe = p.parent()?.join("ffprobe");
+        probe.exists().then_some(probe)
+    });
+
+    let ffprobe = match ffprobe_path {
+        Some(p) => p,
+        None => {
+            if which::which("ffprobe").is_ok() {
+                std::path::PathBuf::from("ffprobe")
+            } else {
+                return;
+            }
+        }
+    };
+
+    let output = Command::new(&ffprobe)
+        .args([
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+        ])
+        .arg(path)
+        .output();
+
+    let Ok(output) = output else { return };
+    if !output.status.success() {
+        return;
+    }
+
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) else {
+        return;
+    };
+
+    if let Some(duration_str) = json
+        .pointer("/format/duration")
+        .and_then(serde_json::Value::as_str)
+    {
+        info.duration_secs = duration_str.parse::<f64>().ok();
+    }
+
+    if let Some(streams) = json.get("streams").and_then(|v| v.as_array()) {
+        for stream in streams {
+            let codec_type = stream.get("codec_type").and_then(serde_json::Value::as_str);
+            match codec_type {
+                Some("video") if info.codec.is_none() => {
+                    info.codec = stream
+                        .get("codec_name")
+                        .and_then(serde_json::Value::as_str)
+                        .map(String::from);
+                    info.width = stream
+                        .get("width")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|v| v.try_into().ok());
+                    info.height = stream
+                        .get("height")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|v| v.try_into().ok());
+                    if let Some(fps_str) = stream
+                        .get("r_frame_rate")
+                        .and_then(serde_json::Value::as_str)
+                    {
+                        info.fps = parse_fps(fps_str);
+                    }
+                    info.bit_depth = stream
+                        .get("bits_per_raw_sample")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|s| s.parse::<u32>().ok());
+                }
+                Some("audio") if info.audio_codec.is_none() => {
+                    info.audio_codec = stream
+                        .get("codec_name")
+                        .and_then(serde_json::Value::as_str)
+                        .map(String::from);
+                    info.sample_rate = stream
+                        .get("sample_rate")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|s| s.parse::<u32>().ok());
+                    info.channels = stream
+                        .get("channels")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|v| v.try_into().ok());
+                    if info.codec.is_none()
+                        && let Some(dur) = stream
+                            .pointer("/duration")
+                            .or_else(|| json.pointer("/format/duration"))
+                            .and_then(serde_json::Value::as_str)
+                    {
+                        info.duration_secs = dur.parse::<f64>().ok();
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn parse_fps(s: &str) -> Option<f64> {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() == 2 {
+        let num = parts[0].parse::<f64>().ok()?;
+        let den = parts[1].parse::<f64>().ok()?;
+        if den > 0.0 {
+            return Some(num / den);
+        }
+    }
+    s.parse::<f64>().ok()
+}

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod file_inspector_commands;
 mod history_commands;
 mod import_commands;
 mod lint_commands;
+mod media_commands;
 mod menu;
 mod progress;
 mod project_init_commands;
@@ -111,6 +112,7 @@ pub fn run() {
             history_commands::history_get_config,
             history_commands::history_set_config,
             rescan_commands::rescan_project,
+            media_commands::file_media_info,
             ai_commands::ai_suggest,
             ai_commands::ai_apply_rename,
             ai_commands::ai_set_key,

--- a/crates/progest-tauri/src/media_commands.rs
+++ b/crates/progest-tauri/src/media_commands.rs
@@ -1,0 +1,20 @@
+//! IPC command for file media info (dimensions, duration, codec).
+
+use progest_core::media;
+use tauri::{AppHandle, Manager};
+
+use crate::commands::no_project_error;
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn file_media_info(path: String, app: AppHandle) -> Result<media::MediaInfo, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+        let abs = ctx.root.root().join(&path);
+        Ok(media::probe(&abs))
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}


### PR DESCRIPTION
## Summary

- New `core::media` module with `probe()` that extracts file metadata on demand:
  - **Image** (image crate): dimensions via header-only read (PNG, JPG, WebP, GIF, BMP, TIFF, EXR, HDR, AVIF)
  - **PSD** (psd crate): width/height
  - **Video/Audio** (ffprobe JSON): resolution, FPS, duration, codec, sample rate, channels, bit depth. Graceful degradation when ffprobe is not installed
  - **All files**: size via `std::fs::metadata`
- New Tauri IPC `file_media_info(path)` — called on demand when inspector selects a file
- `<MediaInfoSection>` in FileInspector shows size, resolution, bit depth, codec, FPS, duration, audio codec, sample rate, channels — only fields that exist for the file type

## Test plan

- [ ] Select a PNG/JPG → inspector shows Size + Resolution
- [ ] Select a PSD → inspector shows Size + Resolution
- [ ] Select a video (mp4/mov) with ffprobe installed → shows Resolution, FPS, Duration, Codec
- [ ] Select any file → shows Size
- [ ] Without ffprobe → video files show only Size (graceful degradation)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)