### PR TITLE
feat: auto-hide .meta sidecar files with Settings toggle (#111)

### DIFF
--- a/app/src/components/settings-dialog.tsx
+++ b/app/src/components/settings-dialog.tsx
@@ -6,6 +6,8 @@ import {
   IpcError,
   aiDeleteKey,
   aiGetConfig,
+  metaGetHidden,
+  metaSetHidden,
   aiSetConfig,
   aiSetKey,
   historyGetConfig,
@@ -288,7 +290,45 @@ function GeneralTab() {
       <ThemeSettings />
       <SearchDebounceSettings />
       <HistoryRetentionSettings />
+      <MetaHiddenToggle />
       {isMac ? <MenubarToggle /> : null}
+    </div>
+  );
+}
+
+function MetaHiddenToggle() {
+  const [hidden, setHidden] = React.useState(true);
+  const [loaded, setLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    void metaGetHidden()
+      .then((c) => {
+        setHidden(c.hidden);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  if (!loaded) return null;
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="grid gap-0.5">
+        <Label htmlFor="meta-hidden">Hide .meta files</Label>
+        <span className="text-[0.625rem] text-muted-foreground">
+          Set OS hidden attribute on sidecar files so they don&apos;t appear in Finder / Explorer
+        </span>
+      </div>
+      <Switch
+        id="meta-hidden"
+        checked={hidden}
+        onCheckedChange={(checked) => {
+          setHidden(checked);
+          void metaSetHidden(checked).catch((e) => {
+            toast.error(`Failed: ${e instanceof IpcError ? e.raw : String(e)}`);
+          });
+        }}
+      />
     </div>
   );
 }

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -717,6 +717,28 @@ export async function historySetConfig(config: { retention: number }): Promise<v
   }
 }
 
+// --- meta hidden -----------------------------------------------------------
+
+export type MetaHiddenConfig = {
+  hidden: boolean;
+};
+
+export async function metaGetHidden(): Promise<MetaHiddenConfig> {
+  try {
+    return await invoke<MetaHiddenConfig>("meta_get_hidden");
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
+export async function metaSetHidden(value: boolean): Promise<void> {
+  try {
+    await invoke<void>("meta_set_hidden", { value });
+  } catch (e) {
+    throw toIpcError(e);
+  }
+}
+
 // --- rescan ----------------------------------------------------------------
 
 export type RescanResponse = {

--- a/crates/progest-core/src/fs/hidden.rs
+++ b/crates/progest-core/src/fs/hidden.rs
@@ -1,0 +1,68 @@
+//! Set the OS "hidden" attribute on a file. Best-effort — failures are
+//! silently ignored since hiding is a cosmetic preference.
+
+use std::path::Path;
+
+pub fn set_hidden(path: &Path) {
+    let _ = set_hidden_impl(path);
+}
+
+pub fn set_visible(path: &Path) {
+    let _ = set_visible_impl(path);
+}
+
+#[cfg(target_os = "macos")]
+fn set_hidden_impl(path: &Path) -> std::io::Result<()> {
+    use std::process::Command;
+    let status = Command::new("chflags").arg("hidden").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("chflags failed"))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn set_hidden_impl(path: &Path) -> std::io::Result<()> {
+    use std::process::Command;
+    let status = Command::new("attrib").arg("+h").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("attrib +h failed"))
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn set_hidden_impl(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn set_visible_impl(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn set_visible_impl(path: &Path) -> std::io::Result<()> {
+    use std::process::Command;
+    let status = Command::new("chflags").arg("nohidden").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("chflags nohidden failed"))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn set_visible_impl(path: &Path) -> std::io::Result<()> {
+    use std::process::Command;
+    let status = Command::new("attrib").arg("-h").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("attrib -h failed"))
+    }
+}

--- a/crates/progest-core/src/fs/mod.rs
+++ b/crates/progest-core/src/fs/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod fault;
 pub mod filesystem;
+pub mod hidden;
 pub mod ignore;
 pub mod mem;
 pub mod path;

--- a/crates/progest-core/src/project/document.rs
+++ b/crates/progest-core/src/project/document.rs
@@ -79,6 +79,29 @@ const fn default_retention() -> usize {
     50
 }
 
+/// Per-project meta sidecar configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetaConfig {
+    #[serde(default = "default_true")]
+    pub hidden: bool,
+}
+
+impl Default for MetaConfig {
+    fn default() -> Self {
+        Self {
+            hidden: default_true(),
+        }
+    }
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn is_default_meta(m: &MetaConfig) -> bool {
+    m.hidden == default_true()
+}
+
 /// Parsed representation of `.progest/project.toml`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectDocument {
@@ -94,6 +117,9 @@ pub struct ProjectDocument {
 
     #[serde(default, skip_serializing_if = "is_default_history")]
     pub history: HistoryConfig,
+
+    #[serde(default, skip_serializing_if = "is_default_meta")]
+    pub meta: MetaConfig,
 
     /// Unknown top-level keys preserved verbatim so that a newer Progest
     /// release can add fields without an older installation stripping them.
@@ -114,6 +140,7 @@ impl ProjectDocument {
             name,
             progest_version: crate::VERSION.to_string(),
             history: HistoryConfig::default(),
+            meta: MetaConfig::default(),
             extra: Table::new(),
         }
     }

--- a/crates/progest-core/src/project/mod.rs
+++ b/crates/progest-core/src/project/mod.rs
@@ -22,7 +22,7 @@ pub mod layout;
 pub mod preview;
 pub mod root;
 
-pub use document::{HistoryConfig, ProjectDocument, ProjectError, ProjectId};
+pub use document::{HistoryConfig, MetaConfig, ProjectDocument, ProjectError, ProjectId};
 pub use layout::{
     DOT_DIR, GITIGNORE_ENTRIES, HISTORY_DB_FILENAME, IGNORE_TEMPLATE, INDEX_DB_FILENAME, LOCAL_DIR,
     PROJECT_TOML_FILENAME, RULES_TOML_FILENAME, SCHEMA_TOML_FILENAME, SEARCH_HISTORY_FILENAME,

--- a/crates/progest-core/src/reconcile/reconciler.rs
+++ b/crates/progest-core/src/reconcile/reconciler.rs
@@ -11,7 +11,10 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::fs::{EntryKind, FileSystem, IgnoreRules, Metadata, ProjectPath, ScanEntry, Scanner};
+use crate::fs::{
+    EntryKind, FileSystem, IgnoreRules, Metadata, ProjectPath, ScanEntry, Scanner,
+    hidden::set_hidden,
+};
 use crate::identity::{FileId, Fingerprint, compute_fingerprint};
 use crate::index::{FileRow, Index, SearchProjection};
 use crate::meta::{Kind, MetaDocument, MetaStore, SIDECAR_SUFFIX, Status, sidecar_path};
@@ -28,6 +31,7 @@ pub struct Reconciler<'a> {
     fs: &'a dyn FileSystem,
     meta: &'a dyn MetaStore,
     index: &'a dyn Index,
+    hide_meta: bool,
 }
 
 impl<'a> Reconciler<'a> {
@@ -36,7 +40,24 @@ impl<'a> Reconciler<'a> {
     /// callers can reuse existing trait objects without cloning.
     #[must_use]
     pub fn new(fs: &'a dyn FileSystem, meta: &'a dyn MetaStore, index: &'a dyn Index) -> Self {
-        Self { fs, meta, index }
+        Self {
+            fs,
+            meta,
+            index,
+            hide_meta: true,
+        }
+    }
+
+    #[must_use]
+    pub fn with_hide_meta(mut self, hide: bool) -> Self {
+        self.hide_meta = hide;
+        self
+    }
+
+    fn hide_sidecar(&self, sidecar: &ProjectPath) {
+        if self.hide_meta {
+            set_hidden(&self.fs.root().join(sidecar.as_str()));
+        }
     }
 
     /// Walk the project from the root, reconciling every non-ignored file
@@ -253,12 +274,14 @@ impl<'a> Reconciler<'a> {
                 let mut updated = existing_doc.clone();
                 updated.content_fingerprint = fingerprint;
                 self.meta.save(&sidecar, &updated)?;
+                self.hide_sidecar(&sidecar);
             }
             existing_doc.file_id
         } else {
             let fresh = FileId::new_v7();
             let doc = MetaDocument::new(fresh, fingerprint);
             self.meta.save(&sidecar, &doc)?;
+            self.hide_sidecar(&sidecar);
             fresh
         };
 
@@ -354,18 +377,17 @@ impl<'a> Reconciler<'a> {
             // reconciles treat this file as anchored.
             let doc = MetaDocument::new(file_id, fingerprint);
             self.meta.save(&sidecar, &doc)?;
+            self.hide_sidecar(&sidecar);
             return Ok(());
         }
         let mut doc = self.meta.load(&sidecar)?;
         if doc.file_id != file_id {
-            // Sidecar drifted to a different identity — trust the index for
-            // now (it owns the live row) and correct the sidecar. A future
-            // PR can surface this as an IdentityConflict via doctor.
             doc.file_id = file_id;
         }
         if doc.content_fingerprint != fingerprint {
             doc.content_fingerprint = fingerprint;
             self.meta.save(&sidecar, &doc)?;
+            self.hide_sidecar(&sidecar);
         }
         Ok(())
     }

--- a/crates/progest-tauri/src/history_commands.rs
+++ b/crates/progest-tauri/src/history_commands.rs
@@ -1,6 +1,7 @@
 //! IPC commands for history undo/redo.
 
 use progest_core::delete::apply_delete;
+use progest_core::fs::hidden;
 use progest_core::history::{Entry, Operation, Store as _};
 use progest_core::index::Index;
 use progest_core::meta::{MetaStore, StdMetaStore, sidecar_path};
@@ -292,4 +293,69 @@ fn summarize(op: &Operation) -> String {
             }
         }
     }
+}
+
+// ── Meta hidden config ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MetaHiddenConfigWire {
+    pub hidden: bool,
+}
+
+#[tauri::command]
+pub async fn meta_get_hidden(app: AppHandle) -> Result<MetaHiddenConfigWire, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+        let text = std::fs::read_to_string(ctx.root.project_toml())
+            .map_err(|e| format!("reading project.toml: {e}"))?;
+        let doc = ProjectDocument::from_toml_str(&text)
+            .map_err(|e| format!("parsing project.toml: {e}"))?;
+        Ok(MetaHiddenConfigWire {
+            hidden: doc.meta.hidden,
+        })
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+}
+
+#[tauri::command]
+pub async fn meta_set_hidden(value: bool, app: AppHandle) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let guard = state.project.lock().expect("project mutex poisoned");
+        let ctx = guard.as_ref().ok_or_else(no_project_error)?;
+
+        let toml_path = ctx.root.project_toml();
+        let text = std::fs::read_to_string(&toml_path)
+            .map_err(|e| format!("reading project.toml: {e}"))?;
+        let mut doc = ProjectDocument::from_toml_str(&text)
+            .map_err(|e| format!("parsing project.toml: {e}"))?;
+        doc.meta.hidden = value;
+        let rendered = doc
+            .to_toml_string()
+            .map_err(|e| format!("serializing project.toml: {e}"))?;
+        std::fs::write(&toml_path, rendered).map_err(|e| format!("writing project.toml: {e}"))?;
+
+        let rows = ctx
+            .index
+            .list_files()
+            .map_err(|e| format!("list files: {e}"))?;
+        for row in &rows {
+            if let Ok(sc) = sidecar_path(&row.path) {
+                let abs = ctx.root.root().join(sc.as_str());
+                if abs.exists() {
+                    if value {
+                        hidden::set_hidden(&abs);
+                    } else {
+                        hidden::set_visible(&abs);
+                    }
+                }
+            }
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
 }

--- a/crates/progest-tauri/src/lib.rs
+++ b/crates/progest-tauri/src/lib.rs
@@ -110,6 +110,8 @@ pub fn run() {
             history_commands::history_redo,
             history_commands::history_get_config,
             history_commands::history_set_config,
+            history_commands::meta_get_hidden,
+            history_commands::meta_set_hidden,
             rescan_commands::rescan_project,
             ai_commands::ai_suggest,
             ai_commands::ai_apply_rename,

--- a/crates/progest-tauri/src/rescan_commands.rs
+++ b/crates/progest-tauri/src/rescan_commands.rs
@@ -55,7 +55,8 @@ pub async fn rescan_project(
             total: 0,
             message: "Scanning files\u{2026}".to_string(),
         });
-        let reconciler = Reconciler::new(&ctx.fs, &meta, &ctx.index);
+        let hide_meta = load_meta_hidden(ctx);
+        let reconciler = Reconciler::new(&ctx.fs, &meta, &ctx.index).with_hide_meta(hide_meta);
         let report = reconciler
             .full_scan_with_progress(&|current, total, msg| {
                 let _ = on_progress.send(ProgressEvent {
@@ -177,4 +178,14 @@ fn load_cleanup(ctx: &ProjectContext) -> Result<CleanupConfig, String> {
     let (cfg, _warns) =
         extract_cleanup_config(&doc.extra).map_err(|e| format!("read [cleanup]: {e}"))?;
     Ok(cfg)
+}
+
+fn load_meta_hidden(ctx: &ProjectContext) -> bool {
+    let Ok(text) = std::fs::read_to_string(ctx.root.project_toml()) else {
+        return true;
+    };
+    let Ok(doc) = ProjectDocument::from_toml_str(&text) else {
+        return true;
+    };
+    doc.meta.hidden
 }


### PR DESCRIPTION
## Summary

- New `fs::hidden` module with `set_hidden` / `set_visible`: macOS uses `chflags hidden/nohidden`, Windows uses `attrib +h/-h`. Best-effort (failures silently ignored)
- Reconciler applies hidden attribute after every `.meta` save, controlled by `with_hide_meta(bool)` builder method (default `true`)
- New `[meta]` section in `project.toml` with `hidden = true` default (skipped from serialization when default)
- Tauri IPC: `meta_get_hidden` / `meta_set_hidden` — reads/writes `project.toml` and bulk applies hidden/visible to all indexed `.meta` files on toggle
- Settings → General → "Hide .meta files" Switch toggle
- Rescan command reads `meta.hidden` config to pass to the reconciler

## Test plan

- [ ] New project → `.meta` files are hidden in Finder
- [ ] Settings → General → toggle "Hide .meta files" off → `.meta` files become visible in Finder
- [ ] Toggle back on → hidden again
- [ ] Rescan respects the setting
- [ ] Windows: `attrib` path works (CI covers compilation)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)