### PR TITLE
feat: complete trace contract with NotApplicable + golden verification

### DIFF
--- a/crates/progest-core/src/lint/orchestrator.rs
+++ b/crates/progest-core/src/lint/orchestrator.rs
@@ -15,7 +15,8 @@ use crate::identity::FileId;
 use crate::meta::{DIRMETA_FILENAME, MetaDocument, MetaStore, MetaStoreError, sidecar_path};
 use crate::naming::{CleanupConfig, fill_suggested_names};
 use crate::rules::{
-    Category, CompiledRuleSet, Decision, RuleId, RuleKind, Severity, Violation, evaluate,
+    Category, CompiledRuleSet, Decision, EvaluationOptions, RuleId, RuleKind, Severity, Violation,
+    evaluate_with_options,
 };
 use crate::sequence::{DriftReason, DriftViolation, detect_drift, detect_sequences};
 
@@ -113,7 +114,16 @@ pub fn lint_paths_with_progress<F: FileSystem, M: MetaStore>(
             &mut effective_cache,
         )?;
 
-        let outcome = evaluate(p, meta.as_ref(), opts.ruleset, opts.compound_exts);
+        let eval_opts = EvaluationOptions {
+            include_not_applicable: opts.explain,
+        };
+        let outcome = evaluate_with_options(
+            p,
+            meta.as_ref(),
+            opts.ruleset,
+            opts.compound_exts,
+            &eval_opts,
+        );
         let mut naming_hits = outcome.violations;
         if !opts.explain {
             // DSL §9.3: without --explain, keep only the Winner trace

--- a/crates/progest-core/src/rules/eval.rs
+++ b/crates/progest-core/src/rules/eval.rs
@@ -45,6 +45,16 @@ pub struct EvaluationOutcome {
     pub trace: Vec<RuleHit>,
 }
 
+/// Controls optional behaviour of [`evaluate`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EvaluationOptions {
+    /// When `true`, emit [`Decision::NotApplicable`] trace entries for
+    /// every rule whose `applies_to` did not match the file. Defaults
+    /// to `false` so the hot path stays cheap; CLI `lint --explain`
+    /// flips it on (§9.1).
+    pub include_not_applicable: bool,
+}
+
 /// Evaluate `path` (with optional `meta`) against `ruleset`.
 ///
 /// `compound_exts` is passed through to the constraint evaluator for
@@ -61,11 +71,32 @@ pub fn evaluate(
     ruleset: &CompiledRuleSet,
     compound_exts: &[&str],
 ) -> EvaluationOutcome {
+    evaluate_with_options(
+        path,
+        meta,
+        ruleset,
+        compound_exts,
+        &EvaluationOptions::default(),
+    )
+}
+
+/// Like [`evaluate`], but accepts [`EvaluationOptions`] to control
+/// optional behaviour such as `NotApplicable` trace emission.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn evaluate_with_options(
+    path: &ProjectPath,
+    meta: Option<&MetaDocument>,
+    ruleset: &CompiledRuleSet,
+    compound_exts: &[&str],
+    opts: &EvaluationOptions,
+) -> EvaluationOutcome {
     let basename = path.file_name().unwrap_or("");
     let file_id = meta.map(|m| m.file_id);
 
     // 1. Collect candidates + best specificity per rule.
     let mut candidates: Vec<Candidate> = Vec::new();
+    let mut not_applicable: Vec<usize> = Vec::new();
     for (idx, rule) in ruleset.rules.iter().enumerate() {
         if rule.mode == Mode::Off {
             continue;
@@ -76,6 +107,8 @@ pub fn evaluate(
                 kind: rule.kind(),
                 specificity: best.specificity(),
             });
+        } else if opts.include_not_applicable {
+            not_applicable.push(idx);
         }
     }
 
@@ -171,6 +204,19 @@ pub fn evaluate(
                 });
             }
         }
+    }
+
+    // 4. NotApplicable entries for rules that didn't match (§9.2).
+    for idx in not_applicable {
+        let rule = &ruleset.rules[idx];
+        trace.push(RuleHit {
+            rule_id: rule.id.clone(),
+            kind: rule.kind(),
+            source: rule.provenance.source,
+            decision: Decision::NotApplicable,
+            specificity_score: SpecificityScore::zero(),
+            explanation: "applies_to did not match this file".to_owned(),
+        });
     }
 
     // Attach the full trace only to violations (§9.3 default view).
@@ -588,5 +634,105 @@ template = "{prefix}_{seq:03d}_{desc:snake}.{ext}"
         // Both normalize to the same glob `assets/shots/**/*.psd`, so
         // specificity ties and the Own layer should take it.
         assert_eq!(winner.rule_id.as_str(), "own-shot");
+    }
+
+    // --- NotApplicable trace ------------------------------------------------
+
+    #[test]
+    fn not_applicable_hidden_by_default() {
+        let rs = ruleset(
+            r#"
+schema_version = 1
+
+[[rules]]
+id = "shots-only"
+kind = "template"
+applies_to = "./assets/shots/**/*.psd"
+template = "{prefix}_{seq:03d}.{ext}"
+"#,
+        );
+        let out = evaluate(&path("docs/readme.md"), None, &rs, &[]);
+        assert!(out.trace.is_empty());
+    }
+
+    #[test]
+    fn not_applicable_emitted_when_enabled() {
+        let rs = ruleset(
+            r#"
+schema_version = 1
+
+[[rules]]
+id = "shots-only"
+kind = "template"
+applies_to = "./assets/shots/**/*.psd"
+template = "{prefix}_{seq:03d}.{ext}"
+"#,
+        );
+        let opts = EvaluationOptions {
+            include_not_applicable: true,
+        };
+        let out = evaluate_with_options(&path("docs/readme.md"), None, &rs, &[], &opts);
+        assert_eq!(out.trace.len(), 1);
+        assert!(matches!(out.trace[0].decision, Decision::NotApplicable));
+        assert_eq!(out.trace[0].rule_id.as_str(), "shots-only");
+    }
+
+    #[test]
+    fn not_applicable_coexists_with_winner_and_shadowed() {
+        let rs = ruleset(
+            r#"
+schema_version = 1
+
+[[rules]]
+id = "general"
+kind = "template"
+applies_to = "./assets/**"
+template = "{desc:snake}_v{version:02d}.{ext}"
+
+[[rules]]
+id = "shots-specific"
+kind = "template"
+applies_to = "./assets/shots/**/*.psd"
+template = "{prefix}_{seq:03d}_{desc:snake}_v{version:02d}.{ext}"
+
+[[rules]]
+id = "docs-only"
+kind = "constraint"
+applies_to = "./docs/**"
+charset = "ascii"
+"#,
+        );
+        let opts = EvaluationOptions {
+            include_not_applicable: true,
+        };
+        let out = evaluate_with_options(
+            &path("assets/shots/ch010/ch010_001_bg_v03.psd"),
+            None,
+            &rs,
+            &[],
+            &opts,
+        );
+
+        let decisions: Vec<_> = out
+            .trace
+            .iter()
+            .map(|h| (h.rule_id.as_str(), &h.decision))
+            .collect();
+
+        assert!(
+            decisions
+                .iter()
+                .any(|(id, d)| *id == "shots-specific" && matches!(d, Decision::Winner))
+        );
+        assert!(
+            decisions
+                .iter()
+                .any(|(id, d)| *id == "general" && matches!(d, Decision::Shadowed))
+        );
+        assert!(
+            decisions
+                .iter()
+                .any(|(id, d)| *id == "docs-only" && matches!(d, Decision::NotApplicable))
+        );
     }
 }

--- a/crates/progest-core/src/rules/mod.rs
+++ b/crates/progest-core/src/rules/mod.rs
@@ -25,7 +25,7 @@ pub use constraint::{
     BUILTIN_COMPOUND_EXTS, CompiledConstraint, ConstraintCompileError, ConstraintFailure,
     compile_constraint, evaluate_constraint, split_basename,
 };
-pub use eval::{EvaluationOutcome, evaluate};
+pub use eval::{EvaluationOptions, EvaluationOutcome, evaluate, evaluate_with_options};
 pub use inheritance::{
     CompiledRule, CompiledRuleBody, CompiledRuleSet, InheritanceError, RuleProvenance,
     RuleSetLayer, compile_ruleset,

--- a/crates/progest-core/tests/rules_golden.rs
+++ b/crates/progest-core/tests/rules_golden.rs
@@ -27,8 +27,8 @@ use progest_core::fs::ProjectPath;
 use progest_core::identity::FileId;
 use progest_core::meta::MetaDocument;
 use progest_core::rules::{
-    BUILTIN_COMPOUND_EXTS, Decision, RuleKind, RuleSetLayer, RuleSource, Severity, compile_ruleset,
-    evaluate, load_document,
+    BUILTIN_COMPOUND_EXTS, Decision, EvaluationOptions, RuleKind, RuleSetLayer, RuleSource,
+    Severity, compile_ruleset, evaluate_with_options, load_document,
 };
 
 // --- Fixture types ---------------------------------------------------------
@@ -59,6 +59,8 @@ struct ExpectedOutcome {
     violations: Vec<ExpectedViolation>,
     #[serde(default)]
     winner_rule_id: Option<String>,
+    #[serde(default)]
+    trace: Vec<ExpectedTraceEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,6 +70,15 @@ struct ExpectedViolation {
     severity: String, // "strict" | "warn" | "hint" | "evaluation_error"
     #[serde(default)]
     reason_contains: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedTraceEntry {
+    rule_id: String,
+    kind: String,     // "template" | "constraint"
+    decision: String, // "winner" | "shadowed" | "not_applicable"
+    #[serde(default)]
+    source: Option<String>, // "own" | "inherited" | "project_wide"
 }
 
 // --- Test entry point ------------------------------------------------------
@@ -150,7 +161,11 @@ fn run_case(rules_toml: &Path, case_path: &Path) -> Result<(), String> {
         .map_err(|e| format!("invalid case path `{}`: {e}", case.path))?;
     let meta = build_meta(&case).map_err(|e| format!("build meta: {e}"))?;
 
-    let outcome = evaluate(&path, meta.as_ref(), &ruleset, BUILTIN_COMPOUND_EXTS);
+    let opts = EvaluationOptions {
+        include_not_applicable: !case.expected.trace.is_empty(),
+    };
+    let outcome =
+        evaluate_with_options(&path, meta.as_ref(), &ruleset, BUILTIN_COMPOUND_EXTS, &opts);
 
     compare_outcome(&outcome, &case.expected)
 }
@@ -214,6 +229,7 @@ fn yaml_to_toml(value: serde_yaml::Value) -> Result<toml::Value, String> {
     })
 }
 
+#[allow(clippy::too_many_lines)]
 fn compare_outcome(
     outcome: &progest_core::rules::EvaluationOutcome,
     expected: &ExpectedOutcome,
@@ -296,6 +312,67 @@ fn compare_outcome(
         }
     }
 
+    // Optional trace verification (order-insensitive).
+    if !expected.trace.is_empty() {
+        let mut remaining: Vec<usize> = (0..outcome.trace.len()).collect();
+        for exp in &expected.trace {
+            let pos = remaining
+                .iter()
+                .position(|&i| {
+                    let h = &outcome.trace[i];
+                    h.rule_id.as_str() == exp.rule_id
+                        && kind_str(h.kind) == exp.kind
+                        && decision_str(h.decision) == exp.decision
+                        && exp
+                            .source
+                            .as_deref()
+                            .is_none_or(|s| source_str(h.source) == s)
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "no trace entry matches rule_id={} kind={} decision={} source={:?}; actual = [{}]",
+                        exp.rule_id,
+                        exp.kind,
+                        exp.decision,
+                        exp.source,
+                        outcome
+                            .trace
+                            .iter()
+                            .map(|h| format!(
+                                "{}:{}:{}:{}",
+                                h.rule_id,
+                                kind_str(h.kind),
+                                decision_str(h.decision),
+                                source_str(h.source),
+                            ))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })?;
+            remaining.remove(pos);
+        }
+
+        if !remaining.is_empty() {
+            let extra: Vec<_> = remaining
+                .iter()
+                .map(|&i| {
+                    let h = &outcome.trace[i];
+                    format!(
+                        "{}:{}:{}",
+                        h.rule_id,
+                        kind_str(h.kind),
+                        decision_str(h.decision)
+                    )
+                })
+                .collect();
+            return Err(format!(
+                "trace has {} unexpected entries: [{}]",
+                extra.len(),
+                extra.join(", ")
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -312,6 +389,22 @@ fn severity_str(s: Severity) -> &'static str {
         Severity::Warn => "warn",
         Severity::Hint => "hint",
         Severity::EvaluationError => "evaluation_error",
+    }
+}
+
+fn decision_str(d: Decision) -> &'static str {
+    match d {
+        Decision::Winner => "winner",
+        Decision::Shadowed => "shadowed",
+        Decision::NotApplicable => "not_applicable",
+    }
+}
+
+fn source_str(s: RuleSource) -> &'static str {
+    match s {
+        RuleSource::Own => "own",
+        RuleSource::Inherited { .. } => "inherited",
+        RuleSource::ProjectWide => "project_wide",
     }
 }
 

--- a/crates/progest-core/tests/rules_golden/trace_not_applicable/cases/case_a_winner_shadowed_not_applicable.yaml
+++ b/crates/progest-core/tests/rules_golden/trace_not_applicable/cases/case_a_winner_shadowed_not_applicable.yaml
@@ -1,0 +1,18 @@
+name: "Case A — winner + shadowed + not_applicable in one trace"
+path: "assets/shots/ch010/ch010_001_bg_v03.psd"
+expected:
+  winner_rule_id: "shot-template"
+  violations: []
+  trace:
+    - rule_id: "shot-template"
+      kind: "template"
+      decision: "winner"
+      source: "project_wide"
+    - rule_id: "general-template"
+      kind: "template"
+      decision: "shadowed"
+      source: "project_wide"
+    - rule_id: "ascii-constraint"
+      kind: "constraint"
+      decision: "not_applicable"
+      source: "project_wide"

--- a/crates/progest-core/tests/rules_golden/trace_not_applicable/cases/case_b_all_not_applicable.yaml
+++ b/crates/progest-core/tests/rules_golden/trace_not_applicable/cases/case_b_all_not_applicable.yaml
@@ -1,0 +1,14 @@
+name: "Case B — file matches no rules, all are not_applicable"
+path: "misc/todo.txt"
+expected:
+  violations: []
+  trace:
+    - rule_id: "shot-template"
+      kind: "template"
+      decision: "not_applicable"
+    - rule_id: "general-template"
+      kind: "template"
+      decision: "not_applicable"
+    - rule_id: "ascii-constraint"
+      kind: "constraint"
+      decision: "not_applicable"

--- a/crates/progest-core/tests/rules_golden/trace_not_applicable/rules.toml
+++ b/crates/progest-core/tests/rules_golden/trace_not_applicable/rules.toml
@@ -1,0 +1,19 @@
+schema_version = 1
+
+[[rules]]
+id = "shot-template"
+kind = "template"
+applies_to = "./assets/shots/**/*.psd"
+template = "{prefix}_{seq:03d}_{desc:snake}_v{version:02d}.{ext}"
+
+[[rules]]
+id = "general-template"
+kind = "template"
+applies_to = "./assets/**"
+template = "{desc:snake}_v{version:02d}.{ext}"
+
+[[rules]]
+id = "ascii-constraint"
+kind = "constraint"
+applies_to = "./docs/**"
+charset = "ascii"


### PR DESCRIPTION
## Summary

- Add `EvaluationOptions` with `include_not_applicable` flag — rules whose `applies_to` didn't match now emit `Decision::NotApplicable` trace entries (§9.2)
- Default `false` keeps the hot path cheap; lint orchestrator wires `opts.explain` through to enable it
- Extend golden test harness with optional `expected.trace` verification (order-insensitive matching on rule_id, kind, decision, source)
- New golden scenario `trace_not_applicable` with 2 cases (winner+shadowed+not_applicable coexistence, all-not_applicable)
- 3 new unit tests in `eval.rs`

## Test plan

- [x] 11 eval unit tests pass (3 new: default-hidden, enabled, coexistence)
- [x] Golden fixtures: 12 cases pass including 2 new trace cases
- [x] Full progest-core suite: 761 tests, 0 failures
- [x] `mise run check` green (fmt + clippy + tsc)
- [x] pre-push hook green

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)