### PR TITLE
test: expand golden coverage for §4.3/§4.4/§4.8/§5.6/§5.7/§7.2/§7.4

### DIFF
--- a/crates/progest-core/tests/rules_golden.rs
+++ b/crates/progest-core/tests/rules_golden.rs
@@ -44,6 +44,10 @@ struct CaseDocument {
     created_at: Option<String>,
     #[serde(default)]
     dirmeta_layers: Vec<DirmetaLayer>,
+    /// Extra compound extensions registered by the project (in addition
+    /// to `BUILTIN_COMPOUND_EXTS`).
+    #[serde(default)]
+    compound_exts: Vec<String>,
     expected: ExpectedOutcome,
 }
 
@@ -59,6 +63,11 @@ struct ExpectedOutcome {
     violations: Vec<ExpectedViolation>,
     #[serde(default)]
     winner_rule_id: Option<String>,
+    /// When set, the scenario's `rules.toml` + dirmeta layers are
+    /// expected to fail at `load_document` or `compile_ruleset` time
+    /// with a message containing this substring. No evaluation runs.
+    #[serde(default)]
+    compile_error_contains: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -119,14 +128,53 @@ fn run_all_golden_fixtures() {
 fn run_case(rules_toml: &Path, case_path: &Path) -> Result<(), String> {
     let rules_src = fs::read_to_string(rules_toml)
         .map_err(|e| format!("read {}: {e}", rules_toml.display()))?;
-    let project_doc =
-        load_document(&rules_src).map_err(|e| format!("load project rules.toml: {e}"))?;
 
     let case_src = fs::read_to_string(case_path).map_err(|e| format!("read case: {e}"))?;
     let case: CaseDocument =
         serde_yaml::from_str(&case_src).map_err(|e| format!("parse case YAML: {e}"))?;
 
-    // Layers: own dirmeta first (nearest wins per spec §7.1), project last.
+    // Try to load + compile. If the case expects a compile error, verify
+    // the error message and return early.
+    let ruleset = match try_build_ruleset(&rules_src, &case) {
+        Ok(rs) => rs,
+        Err(err_msg) => {
+            if let Some(needle) = &case.expected.compile_error_contains {
+                if err_msg.contains(needle) {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "expected compile error containing `{needle}`, got: {err_msg}"
+                ));
+            }
+            return Err(err_msg);
+        }
+    };
+
+    if case.expected.compile_error_contains.is_some() {
+        return Err("expected a compile error but load+compile succeeded".into());
+    }
+
+    let path = ProjectPath::new(&case.path)
+        .map_err(|e| format!("invalid case path `{}`: {e}", case.path))?;
+    let meta = build_meta(&case).map_err(|e| format!("build meta: {e}"))?;
+
+    let mut exts: Vec<&str> = BUILTIN_COMPOUND_EXTS.to_vec();
+    for e in &case.compound_exts {
+        exts.push(e.as_str());
+    }
+
+    let outcome = evaluate(&path, meta.as_ref(), &ruleset, &exts);
+
+    compare_outcome(&outcome, &case.expected)
+}
+
+fn try_build_ruleset(
+    rules_src: &str,
+    case: &CaseDocument,
+) -> Result<progest_core::rules::CompiledRuleSet, String> {
+    let project_doc =
+        load_document(rules_src).map_err(|e| format!("load project rules.toml: {e}"))?;
+
     let mut layers = Vec::new();
     for dirmeta in &case.dirmeta_layers {
         let doc = load_document(&dirmeta.rules_toml)
@@ -144,15 +192,7 @@ fn run_case(rules_toml: &Path, case_path: &Path) -> Result<(), String> {
         rules: project_doc.rules,
     });
 
-    let ruleset = compile_ruleset(layers).map_err(|e| format!("compile_ruleset: {e}"))?;
-
-    let path = ProjectPath::new(&case.path)
-        .map_err(|e| format!("invalid case path `{}`: {e}", case.path))?;
-    let meta = build_meta(&case).map_err(|e| format!("build meta: {e}"))?;
-
-    let outcome = evaluate(&path, meta.as_ref(), &ruleset, BUILTIN_COMPOUND_EXTS);
-
-    compare_outcome(&outcome, &case.expected)
+    compile_ruleset(layers).map_err(|e| format!("compile_ruleset: {e}"))
 }
 
 // --- Helpers ---------------------------------------------------------------

--- a/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/cases/case_a_literal_brace_match.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/cases/case_a_literal_brace_match.yaml
@@ -1,0 +1,5 @@
+name: "§4.3 — literal brace {{ in template matches literal { in filename"
+path: "assets/{project}_forest_night.psd"
+expected:
+  winner_rule_id: "braces-template"
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/cases/case_b_literal_brace_mismatch.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/cases/case_b_literal_brace_mismatch.yaml
@@ -1,0 +1,8 @@
+name: "§4.3 — filename without literal { does not match"
+path: "assets/project_forest_night.psd"
+expected:
+  violations:
+    - rule_id: "braces-template"
+      kind: "template"
+      severity: "warn"
+      reason_contains: "does not satisfy template"

--- a/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_3_literal_braces/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "braces-template"
+kind = "template"
+applies_to = "./**"
+template = "{{project}}_{desc:snake}.{ext}"

--- a/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_a_string_value_for_numeric_spec.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_a_string_value_for_numeric_spec.yaml
@@ -1,0 +1,10 @@
+name: "§4.4 — string value on numeric :03d spec is evaluation_error"
+path: "assets/sc020_forest-night.tif"
+custom:
+  scene: "twenty"
+expected:
+  violations:
+    - rule_id: "scene-template"
+      kind: "template"
+      severity: "evaluation_error"
+      reason_contains: "expected integer"

--- a/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_b_missing_field.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_b_missing_field.yaml
@@ -1,0 +1,9 @@
+name: "§4.4 — missing custom field is evaluation_error"
+path: "assets/sc020_forest-night.tif"
+custom: {}
+expected:
+  violations:
+    - rule_id: "scene-template"
+      kind: "template"
+      severity: "evaluation_error"
+      reason_contains: "custom.scene is missing"

--- a/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_c_numeric_overflow.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/cases/case_c_numeric_overflow.yaml
@@ -1,0 +1,10 @@
+name: "§4.4 — numeric value exceeds :03d width is evaluation_error"
+path: "assets/sc9999_forest-night.tif"
+custom:
+  scene: 9999
+expected:
+  violations:
+    - rule_id: "scene-template"
+      kind: "template"
+      severity: "evaluation_error"
+      reason_contains: "does not fit"

--- a/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_4_field_type_mismatch/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "scene-template"
+kind = "template"
+applies_to = "./**"
+template = "sc{field:scene:03d}_{desc:slug}.{ext}"

--- a/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/cases/case_a_project_compound_ext.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/cases/case_a_project_compound_ext.yaml
@@ -1,0 +1,7 @@
+name: "§4.8 — project-registered compound ext psd.bak is peeled correctly"
+path: "assets/forest_night.psd.bak"
+compound_exts:
+  - "psd.bak"
+expected:
+  winner_rule_id: "compound-template"
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/cases/case_b_unknown_compound_falls_back.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/cases/case_b_unknown_compound_falls_back.yaml
@@ -1,0 +1,8 @@
+name: "§4.8 — unknown compound ext without registration causes mismatch"
+path: "assets/forest_night.psd.bak"
+expected:
+  violations:
+    - rule_id: "compound-template"
+      kind: "template"
+      severity: "warn"
+      reason_contains: "does not satisfy template"

--- a/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_4_8_project_compound/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "compound-template"
+kind = "template"
+applies_to = "./**"
+template = "{desc:snake}.{ext}"

--- a/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_a_middle_token.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_a_middle_token.yaml
@@ -1,0 +1,8 @@
+name: "§5.6 — reserved word as middle token triggers violation"
+path: "assets/scene_tmp_export.psd"
+expected:
+  violations:
+    - rule_id: "reserved-words"
+      kind: "constraint"
+      severity: "warn"
+      reason_contains: "tmp"

--- a/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_b_whole_stem.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_b_whole_stem.yaml
@@ -1,0 +1,8 @@
+name: "§5.6 — whole stem equals reserved word"
+path: "assets/test.psd"
+expected:
+  violations:
+    - rule_id: "reserved-words"
+      kind: "constraint"
+      severity: "warn"
+      reason_contains: "test"

--- a/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_c_case_insensitive.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_c_case_insensitive.yaml
@@ -1,0 +1,8 @@
+name: "§5.6 — case-insensitive match on reserved word"
+path: "assets/scene_TMP_export.psd"
+expected:
+  violations:
+    - rule_id: "reserved-words"
+      kind: "constraint"
+      severity: "warn"
+      reason_contains: "TMP"

--- a/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_d_no_reserved_word.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/cases/case_d_no_reserved_word.yaml
@@ -1,0 +1,4 @@
+name: "§5.6 — no reserved word in filename passes"
+path: "assets/scene_forest_export.psd"
+expected:
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_6_reserved_words/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "reserved-words"
+kind = "constraint"
+applies_to = "./**"
+reserved_words = ["tmp", "test", "backup"]

--- a/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/cases/case_a_nfc_within_limit.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/cases/case_a_nfc_within_limit.yaml
@@ -1,0 +1,5 @@
+name: "§5.7 — NFC-normalized grapheme count is within max_length"
+# がぎぐげご in NFC = 5 graphemes, plus .psd ext → stem is 5 ≤ 10
+path: "assets/がぎぐげご.psd"
+expected:
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/cases/case_b_exceeds_max_length.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/cases/case_b_exceeds_max_length.yaml
@@ -1,0 +1,9 @@
+name: "§5.7 — stem exceeding max_length in NFC graphemes triggers violation"
+# 12345678901 = 11 graphemes > 10
+path: "assets/12345678901.psd"
+expected:
+  violations:
+    - rule_id: "length-cap"
+      kind: "constraint"
+      severity: "warn"
+      reason_contains: "graphemes"

--- a/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_5_7_nfc_normalization/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "length-cap"
+kind = "constraint"
+applies_to = "./**"
+max_length = 10

--- a/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/cases/case_a_kind_change_without_override.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/cases/case_a_kind_change_without_override.yaml
@@ -1,0 +1,13 @@
+name: "§7.2 — kind change without override = true is a compile error"
+path: "assets/shots/forest.psd"
+dirmeta_layers:
+  - base_dir: "assets/shots"
+    rules_toml: |
+      schema_version = 1
+      [[rules]]
+      id = "my-rule"
+      kind = "constraint"
+      applies_to = "./**"
+      charset = "ascii"
+expected:
+  compile_error_contains: "changes kind"

--- a/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/cases/case_b_kind_change_with_override.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/cases/case_b_kind_change_with_override.yaml
@@ -1,0 +1,14 @@
+name: "§7.2 — kind change with override = true succeeds"
+path: "assets/shots/forest.psd"
+dirmeta_layers:
+  - base_dir: "assets/shots"
+    rules_toml: |
+      schema_version = 1
+      [[rules]]
+      id = "my-rule"
+      kind = "constraint"
+      applies_to = "./**"
+      override = true
+      charset = "ascii"
+expected:
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_2_kind_change/rules.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[[rules]]
+id = "my-rule"
+kind = "template"
+applies_to = "./**"
+template = "{desc:snake}.{ext}"

--- a/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/cases/case_a_lexicographic_tiebreak.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/cases/case_a_lexicographic_tiebreak.yaml
@@ -1,0 +1,7 @@
+name: "§7.4 — when specificity and source tie, lexicographic rule_id wins"
+path: "assets/forest_night.psd"
+expected:
+  # Both rules have same applies_to (./**) and same source (project_wide).
+  # alpha-template < beta-template lexicographically → alpha wins.
+  winner_rule_id: "alpha-template"
+  violations: []

--- a/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/cases/case_b_own_beats_project_wide.yaml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/cases/case_b_own_beats_project_wide.yaml
@@ -1,0 +1,15 @@
+name: "§7.4 — own-dir layer wins over project-wide at same specificity"
+path: "assets/shots/forest_night.psd"
+dirmeta_layers:
+  - base_dir: "assets/shots"
+    rules_toml: |
+      schema_version = 1
+      [[rules]]
+      id = "own-template"
+      kind = "template"
+      applies_to = "./**"
+      template = "{prefix}_{desc:snake}.{ext}"
+expected:
+  # own-template (Own source) beats alpha-template and beta-template
+  # (ProjectWide) even though specificity of ./** ties with ./**
+  winner_rule_id: "own-template"

--- a/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/rules.toml
+++ b/crates/progest-core/tests/rules_golden/coverage_7_4_source_hierarchy/rules.toml
@@ -1,0 +1,13 @@
+schema_version = 1
+
+[[rules]]
+id = "alpha-template"
+kind = "template"
+applies_to = "./**"
+template = "{desc:snake}.{ext}"
+
+[[rules]]
+id = "beta-template"
+kind = "template"
+applies_to = "./**"
+template = "{prefix}_{desc:snake}.{ext}"


### PR DESCRIPTION
## Summary

- Add 7 new golden scenarios with 15 cases covering DSL clauses flagged by Codex review
- Extend golden harness with `expected.compile_error_contains` for load/compile error cases and `compound_exts` for project-registered extension testing

| Scenario | Cases | Coverage |
|---|---|---|
| `coverage_4_3_literal_braces` | 2 | `{{` escape match + mismatch |
| `coverage_4_4_field_type_mismatch` | 3 | string-for-numeric, missing field, overflow |
| `coverage_4_8_project_compound` | 2 | project-registered compound ext + fallback |
| `coverage_5_6_reserved_words` | 4 | middle token, whole stem, case-insensitive, passing |
| `coverage_5_7_nfc_normalization` | 2 | NFC grapheme count within/exceeding limit |
| `coverage_7_2_kind_change` | 2 | kind change without/with override |
| `coverage_7_4_source_hierarchy` | 2 | lexicographic tiebreak + own-beats-project-wide |

## Test plan

- [x] All 38 golden cases pass (15 new + 23 existing)
- [x] `mise run check` green (fmt + clippy + tsc)
- [x] pre-push hook green (check + full workspace test)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)